### PR TITLE
fix: bump README version badge to 2.0.0-alpha.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fMRIflow
 
-![Version](https://img.shields.io/badge/version-2.0.0--alpha.2-blue)
+![Version](https://img.shields.io/badge/version-2.0.0--alpha.3-blue)
 ![Python](https://img.shields.io/badge/python-≥3.10-green)
 ![License](https://img.shields.io/badge/license-MIT-brightgreen)
 


### PR DESCRIPTION
Missed in PR #49 — README's shields.io badge still pointed at `2.0.0-alpha.2`. Bumps it to match the released `2.0.0-alpha.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)