### PR TITLE
feat(preproc): YAML-driven configs + apptainer-backed fmriprep

### DIFF
--- a/fmriflow/preproc/backends/fmriprep.py
+++ b/fmriflow/preproc/backends/fmriprep.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -63,6 +64,15 @@ class FmriprepBackend:
 
     def run(self, config: PreprocConfig) -> PreprocManifest:
         params = _parse_params(config)
+
+        # Apptainer/Singularity refuse to bind-mount a source path that does
+        # not exist on the host. Ensure output_dir and work_dir exist before
+        # launching — fmriprep would create them anyway.
+        if config.output_dir:
+            Path(config.output_dir).mkdir(parents=True, exist_ok=True)
+        if config.work_dir:
+            Path(config.work_dir).mkdir(parents=True, exist_ok=True)
+
         cmd = self._build_command(config, params)
         logger.info("Running fmriprep: %s", " ".join(cmd))
 
@@ -186,6 +196,19 @@ class FmriprepBackend:
 
     # ── Private helpers ──────────────────────────────────────────
 
+    def _singularity_binary(self) -> str | None:
+        """Resolve the Singularity-compatible runtime binary.
+
+        Resolution order:
+        1. ``$FMRIFLOW_SINGULARITY_BIN`` env var (absolute path, if set).
+        2. ``apptainer`` on PATH (modern fork, handles current OCI images).
+        3. ``singularity`` on PATH (may be stuck on an old 2.x release).
+        """
+        override = os.environ.get("FMRIFLOW_SINGULARITY_BIN")
+        if override and Path(override).exists():
+            return override
+        return shutil.which("apptainer") or shutil.which("singularity")
+
     def _find_fmriprep(self, params: FmriprepParams) -> bool:
         """Check if fmriprep is available."""
         if params.container:
@@ -193,9 +216,11 @@ class FmriprepBackend:
                 # Docker image — either already pulled or will be pulled on run
                 return shutil.which("docker") is not None
             if params.container_type == "singularity":
+                if self._singularity_binary() is None:
+                    return False
                 # Could be a .sif path OR a docker://... URI
                 if params.container.startswith(("docker://", "library://", "shub://")):
-                    return shutil.which("singularity") is not None or shutil.which("apptainer") is not None
+                    return True
                 return Path(params.container).exists()
             # bare
             return True
@@ -232,8 +257,9 @@ class FmriprepBackend:
     ) -> list[str]:
         """Build the container invocation prefix."""
         if params.container_type == "singularity":
+            binary = self._singularity_binary() or "singularity"
             cmd = [
-                "singularity", "run", "--cleanenv",
+                binary, "run", "--cleanenv",
                 "-B", f"{config.bids_dir}:/data:ro",
                 "-B", f"{config.output_dir}:/out",
             ]

--- a/fmriflow/preproc/backends/fmriprep_params.py
+++ b/fmriflow/preproc/backends/fmriprep_params.py
@@ -37,6 +37,9 @@ class FmriprepParams:
     container: str | None = None
     container_type: str = "singularity"
 
+    # ── Validation ──────────────────────────────────────────────────
+    skip_bids_validation: bool = False
+
     # ── Anatomical ──────────────────────────────────────────────────
     skull_strip: str = "auto"
     skull_strip_template: str | None = None
@@ -312,6 +315,9 @@ class FmriprepParams:
             args += ["--fs-license-file", str(self.fs_license_file)]
 
         # Escape hatch
+        if self.skip_bids_validation:
+            args.append("--skip-bids-validation")
+
         args += self.extra_args
 
         return args

--- a/fmriflow/server/app.py
+++ b/fmriflow/server/app.py
@@ -14,6 +14,7 @@ from fmriflow.server.services.run_store import RunStore
 from fmriflow.server.services.run_manager import RunManager
 from fmriflow.server.services.module_loader import discover_user_modules
 from fmriflow.server.services.config_store import ConfigStore
+from fmriflow.server.services.preproc_config_store import PreprocConfigStore
 from fmriflow.server.services.preproc_manager import PreprocManager
 from fmriflow.server.services.convert_manager import ConvertManager
 from fmriflow.server.services.convert_config_store import ConvertConfigStore
@@ -26,6 +27,7 @@ def create_app(
     results_dir: str = './results',
     modules_dir: str | None = None,
     configs_dir: str = './experiments',
+    preproc_configs_dir: str = './experiments/preproc',
     derivatives_dir: str = './derivatives',
 ) -> FastAPI:
     """Create and configure the FastAPI application."""
@@ -57,6 +59,7 @@ def create_app(
     run_store = RunStore(Path(results_dir))
     run_manager = RunManager()
     config_store = ConfigStore(Path(configs_dir))
+    preproc_config_store = PreprocConfigStore(Path(preproc_configs_dir))
     preproc_manager = PreprocManager(Path(derivatives_dir))
     convert_manager = ConvertManager()
     convert_config_store = ConvertConfigStore()
@@ -66,6 +69,7 @@ def create_app(
     app.state.run_store = run_store
     app.state.run_manager = run_manager
     app.state.config_store = config_store
+    app.state.preproc_config_store = preproc_config_store
     app.state.preproc_manager = preproc_manager
     app.state.convert_manager = convert_manager
     app.state.convert_config_store = convert_config_store

--- a/fmriflow/server/routes/preproc.py
+++ b/fmriflow/server/routes/preproc.py
@@ -48,6 +48,17 @@ class ValidateConfigBody(BaseModel):
     backend_params: dict | None = None
 
 
+class RunFromConfigBody(BaseModel):
+    """Overrides shallow-merged on top of the YAML's preproc section."""
+    subject: str | None = None
+    bids_dir: str | None = None
+    output_dir: str | None = None
+    work_dir: str | None = None
+    sessions: list[str] | None = None
+    task: str | None = None
+    backend_params: dict | None = None
+
+
 # ── Endpoints ────────────────────────────────────────────────────────────
 
 @router.get("/preproc/backends")
@@ -110,6 +121,68 @@ async def start_run(request: Request, body: RunBody):
         return {"run_id": run_id, "status": "started"}
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/preproc/configs")
+async def list_preproc_configs(request: Request):
+    """List preprocessing YAML configs (with a top-level preproc: section)."""
+    store = request.app.state.preproc_config_store
+    summaries = store.list_configs()
+    return [
+        {
+            "filename": s.filename,
+            "path": s.path,
+            "subject": s.subject,
+            "backend": s.backend,
+            "bids_dir": s.bids_dir,
+            "output_dir": s.output_dir,
+            "container": s.container,
+            "container_type": s.container_type,
+            "mode": s.mode,
+        }
+        for s in summaries
+    ]
+
+
+@router.get("/preproc/configs/{filename}")
+async def get_preproc_config(request: Request, filename: str):
+    """Return full parsed config + raw YAML for one preproc config file."""
+    store = request.app.state.preproc_config_store
+    result = store.get_config(filename)
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Preproc config '{filename}' not found",
+        )
+    return result
+
+
+@router.post("/preproc/configs/{filename}/run")
+async def run_preproc_config(
+    request: Request,
+    filename: str,
+    body: RunFromConfigBody | None = None,
+):
+    """Start a preprocessing run from a YAML config file's preproc: section."""
+    store = request.app.state.preproc_config_store
+    config_info = store.get_config(filename)
+    if config_info is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Preproc config '{filename}' not found",
+        )
+
+    mgr = request.app.state.preproc_manager
+    overrides = body.model_dump(exclude_none=True) if body else None
+    try:
+        run_id = mgr.start_run_from_config_file(
+            config_info["path"], overrides=overrides,
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"run_id": run_id, "status": "started", "config": filename}
 
 
 @router.post("/preproc/validate-config")

--- a/fmriflow/server/services/preproc_config_store.py
+++ b/fmriflow/server/services/preproc_config_store.py
@@ -1,0 +1,122 @@
+"""PreprocConfigStore — indexes preprocessing YAML configs from a directory.
+
+Mirrors the analysis ``ConfigStore`` pattern: YAMLs live in a directory
+(default ``./experiments/preproc/``) and must contain a top-level ``preproc:``
+section that maps to :class:`fmriflow.preproc.manifest.PreprocConfig`.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PreprocConfigSummary:
+    """Lightweight metadata extracted from a preproc YAML."""
+    filename: str
+    path: str
+    subject: str
+    backend: str
+    bids_dir: str
+    output_dir: str
+    container: str
+    container_type: str
+    mode: str
+
+
+class PreprocConfigStore:
+    """Indexes preprocessing config files from a directory."""
+
+    def __init__(self, configs_dir: Path):
+        self.configs_dir = configs_dir
+        self._cache: list[PreprocConfigSummary] = []
+        self._last_scan = 0.0
+
+    def scan(self) -> None:
+        """Re-scan configs directory for .yaml files with a preproc: section."""
+        self._cache = []
+        if not self.configs_dir.is_dir():
+            logger.warning("Preproc configs directory not found: %s", self.configs_dir)
+            return
+
+        for yaml_path in sorted(self.configs_dir.glob('*.yaml')):
+            if yaml_path.name.startswith('_'):
+                continue
+            try:
+                summary = self._extract_summary(yaml_path)
+                if summary:
+                    self._cache.append(summary)
+            except Exception as e:
+                logger.debug("Skipping %s: %s", yaml_path, e)
+
+        self._last_scan = time.time()
+        logger.info(
+            "Scanned %d preproc config(s) from %s",
+            len(self._cache), self.configs_dir,
+        )
+
+    def _maybe_rescan(self) -> None:
+        if time.time() - self._last_scan > 10.0:
+            self.scan()
+
+    def _extract_summary(self, path: Path) -> PreprocConfigSummary | None:
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+
+        if not isinstance(data, dict):
+            return None
+
+        section = data.get("preproc")
+        if not isinstance(section, dict):
+            return None
+
+        params = section.get("backend_params") or {}
+        if not isinstance(params, dict):
+            params = {}
+
+        return PreprocConfigSummary(
+            filename=path.name,
+            path=str(path.resolve()),
+            subject=str(section.get("subject", "")),
+            backend=str(section.get("backend", "")),
+            bids_dir=str(section.get("bids_dir", "")),
+            output_dir=str(section.get("output_dir", "")),
+            container=str(params.get("container", "")),
+            container_type=str(params.get("container_type", "")),
+            mode=str(params.get("mode", "")),
+        )
+
+    def list_configs(self) -> list[PreprocConfigSummary]:
+        """Return summaries of all preproc configs."""
+        self._maybe_rescan()
+        return self._cache
+
+    def get_config(self, filename: str) -> dict[str, Any] | None:
+        """Return full parsed config + raw YAML for one file."""
+        self._maybe_rescan()
+        resolved = (self.configs_dir / filename).resolve()
+        if not resolved.is_relative_to(self.configs_dir.resolve()):
+            return None
+        if not resolved.is_file():
+            return None
+
+        raw = resolved.read_text()
+        try:
+            config = yaml.safe_load(raw) or {}
+        except Exception:
+            config = {}
+
+        return {
+            'filename': filename,
+            'path': str(resolved),
+            'config': config,
+            'yaml_string': raw,
+        }

--- a/fmriflow/server/services/preproc_manager.py
+++ b/fmriflow/server/services/preproc_manager.py
@@ -174,6 +174,43 @@ class PreprocManager:
         thread.start()
         return run_id
 
+    def start_run_from_config_file(
+        self,
+        config_path: str,
+        overrides: dict | None = None,
+    ) -> str:
+        """Start a preprocessing run from a YAML config file.
+
+        The file must contain a top-level ``preproc:`` section matching the
+        :class:`fmriflow.preproc.manifest.PreprocConfig` schema. Optional
+        ``overrides`` is shallow-merged on top of the section before running.
+        """
+        import yaml as _yaml
+
+        path = Path(config_path)
+        if not path.is_file():
+            raise FileNotFoundError(f"Preproc config not found: {path}")
+
+        with open(path) as f:
+            data = _yaml.safe_load(f) or {}
+        section = data.get("preproc")
+        if not isinstance(section, dict):
+            raise ValueError(
+                f"Config '{path.name}' has no 'preproc:' section"
+            )
+
+        params: dict = dict(section)
+        if overrides:
+            params.update({k: v for k, v in overrides.items() if v is not None})
+
+        missing = [k for k in ("subject", "backend", "output_dir") if not params.get(k)]
+        if missing:
+            raise ValueError(
+                f"Preproc config missing required fields: {', '.join(missing)}"
+            )
+
+        return self.start_run(params)
+
     def _execute_run(self, handle: PreprocRunHandle, params: dict) -> None:
         """Execute preprocessing in a background thread."""
         import logging as _logging

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -29,6 +29,8 @@ import type {
   BatchSummary,
   SavedConvertConfig,
   SavedConvertConfigDetail,
+  PreprocConfigSummary,
+  PreprocConfigDetail,
 } from './types'
 
 const BASE = '/api'
@@ -305,6 +307,25 @@ export async function validatePreprocConfig(params: {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(params),
+  })
+}
+
+export async function fetchPreprocConfigs(): Promise<PreprocConfigSummary[]> {
+  return json(`${BASE}/preproc/configs`)
+}
+
+export async function fetchPreprocConfigDetail(filename: string): Promise<PreprocConfigDetail> {
+  return json(`${BASE}/preproc/configs/${encodeURIComponent(filename)}`)
+}
+
+export async function runPreprocConfigFile(
+  filename: string,
+  overrides?: Record<string, unknown>,
+): Promise<{ run_id: string; status: string; config: string }> {
+  return json(`${BASE}/preproc/configs/${encodeURIComponent(filename)}/run`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(overrides || {}),
   })
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -194,6 +194,25 @@ export interface ConfigDetail {
   yaml_string: string
 }
 
+export interface PreprocConfigSummary {
+  filename: string
+  path: string
+  subject: string
+  backend: string
+  bids_dir: string
+  output_dir: string
+  container: string
+  container_type: string
+  mode: string
+}
+
+export interface PreprocConfigDetail {
+  filename: string
+  path: string
+  config: Record<string, unknown>
+  yaml_string: string
+}
+
 export interface StageStatus {
   status: 'pending' | 'running' | 'done' | 'warning' | 'failed'
   detail: string

--- a/frontend/src/components/dashboard/ConfigDetail.tsx
+++ b/frontend/src/components/dashboard/ConfigDetail.tsx
@@ -256,7 +256,7 @@ export function ConfigDetail({
           <div style={{ ...fieldValue, fontSize: 11 }}>{features}</div>
         </div>
         <div style={fieldCard}>
-          <div style={fieldLabel}>Preprocessing</div>
+          <div style={fieldLabel}>Preparation</div>
           <div style={{ ...fieldValue, fontSize: 11 }}>{prepSummary}</div>
         </div>
         <div style={fieldCard}>

--- a/frontend/src/components/dashboard/StageTracker.tsx
+++ b/frontend/src/components/dashboard/StageTracker.tsx
@@ -6,7 +6,7 @@ interface StageTrackerProps {
   stageStatuses: Record<string, StageStatus>
 }
 
-const ALL_STAGES = ['stimuli', 'responses', 'features', 'preprocess', 'model', 'analyze', 'report']
+const ALL_STAGES = ['stimuli', 'responses', 'features', 'prepare', 'model', 'analyze', 'report']
 
 const containerStyle: CSSProperties = {
   display: 'flex',

--- a/frontend/src/components/preproc/PreprocConfigBrowser.tsx
+++ b/frontend/src/components/preproc/PreprocConfigBrowser.tsx
@@ -1,0 +1,290 @@
+/** Tab: browse preproc YAML configs and run them. */
+import { useEffect } from 'react'
+import type { CSSProperties } from 'react'
+import { usePreprocStore } from '../../stores/preproc-store'
+import { PreprocProgress } from './PreprocProgress'
+
+const containerStyle: CSSProperties = {
+  display: 'flex',
+  height: 'calc(100vh - 48px - 80px)',
+  backgroundColor: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  borderRadius: 8,
+  overflow: 'hidden',
+}
+
+const sidebarStyle: CSSProperties = {
+  width: 280,
+  backgroundColor: 'var(--bg-secondary)',
+  borderRight: '1px solid var(--border)',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+}
+
+const sidebarHeader: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '12px 16px',
+  borderBottom: '1px solid var(--border)',
+}
+
+const sidebarTitle: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  color: 'var(--text-secondary)',
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+}
+
+const listStyle: CSSProperties = { flex: 1, overflowY: 'auto' }
+
+const itemStyle = (active: boolean): CSSProperties => ({
+  padding: '10px 16px',
+  cursor: 'pointer',
+  backgroundColor: active ? 'rgba(0, 229, 255, 0.08)' : 'transparent',
+  borderLeft: active ? '3px solid var(--accent-cyan)' : '3px solid transparent',
+  borderBottom: '1px solid var(--border)',
+})
+
+const itemName: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: 'var(--text-primary)',
+  marginBottom: 2,
+  fontFamily: 'monospace',
+}
+
+const itemMeta: CSSProperties = {
+  fontSize: 10,
+  color: 'var(--text-secondary)',
+}
+
+const mainPanel: CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+  padding: '20px 24px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+}
+
+const emptyState: CSSProperties = {
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: 'var(--text-secondary)',
+  fontSize: 13,
+  gap: 8,
+  height: '100%',
+}
+
+const rescanBtn: CSSProperties = {
+  padding: '4px 10px',
+  fontSize: 10,
+  fontWeight: 600,
+  fontFamily: 'inherit',
+  border: '1px solid var(--border)',
+  borderRadius: 4,
+  cursor: 'pointer',
+  backgroundColor: 'transparent',
+  color: 'var(--text-secondary)',
+}
+
+const detailHeader: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: 12,
+}
+
+const runBtn = (disabled: boolean): CSSProperties => ({
+  padding: '8px 20px',
+  fontSize: 12,
+  fontWeight: 700,
+  fontFamily: 'inherit',
+  border: `1px solid ${disabled ? 'var(--border)' : 'var(--accent-cyan)'}`,
+  borderRadius: 6,
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  backgroundColor: disabled ? 'transparent' : 'rgba(0, 229, 255, 0.1)',
+  color: disabled ? 'var(--text-secondary)' : 'var(--accent-cyan)',
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+})
+
+const summaryGrid: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '120px 1fr',
+  gap: '6px 16px',
+  fontSize: 12,
+  padding: '12px 0',
+}
+
+const summaryLabel: CSSProperties = {
+  color: 'var(--text-secondary)',
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: 0.5,
+  fontSize: 10,
+}
+
+const summaryValue: CSSProperties = {
+  color: 'var(--text-primary)',
+  fontFamily: 'monospace',
+  wordBreak: 'break-all',
+}
+
+const yamlPre: CSSProperties = {
+  backgroundColor: 'var(--bg-secondary)',
+  borderRadius: 6,
+  padding: '12px 14px',
+  fontSize: 11,
+  lineHeight: 1.6,
+  fontFamily: 'monospace',
+  color: 'var(--text-primary)',
+  overflow: 'auto',
+  maxHeight: 420,
+  whiteSpace: 'pre',
+  border: '1px solid var(--border)',
+}
+
+const sectionLabel: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  color: 'var(--text-secondary)',
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  marginTop: 4,
+}
+
+export function PreprocConfigBrowser() {
+  const {
+    preprocConfigs,
+    preprocConfigsLoading,
+    selectedPreprocConfig,
+    selectedPreprocConfigLoading,
+    loadPreprocConfigs,
+    selectPreprocConfig,
+    runPreprocConfig,
+    runId,
+    runEvents,
+    runStartTime,
+    runError,
+    running,
+    clearRun,
+  } = usePreprocStore()
+
+  useEffect(() => {
+    loadPreprocConfigs()
+  }, [loadPreprocConfigs])
+
+  const selectedFilename = selectedPreprocConfig?.filename
+
+  return (
+    <>
+      <div style={containerStyle}>
+        <div style={sidebarStyle}>
+          <div style={sidebarHeader}>
+            <span style={sidebarTitle}>Configs ({preprocConfigs.length})</span>
+            <button style={rescanBtn} onClick={() => loadPreprocConfigs()}>
+              {preprocConfigsLoading ? '...' : 'Refresh'}
+            </button>
+          </div>
+          <div style={listStyle}>
+            {preprocConfigs.length === 0 && !preprocConfigsLoading && (
+              <div style={{ padding: 16, fontSize: 11, color: 'var(--text-secondary)' }}>
+                No YAMLs found. Add one under <code>experiments/preproc/</code> with a top-level <code>preproc:</code> section.
+              </div>
+            )}
+            {preprocConfigs.map((cfg) => (
+              <div
+                key={cfg.filename}
+                style={itemStyle(cfg.filename === selectedFilename)}
+                onClick={() => selectPreprocConfig(cfg.filename)}
+              >
+                <div style={itemName}>{cfg.filename}</div>
+                <div style={itemMeta}>
+                  {cfg.subject} · {cfg.backend}{cfg.mode ? ` · ${cfg.mode}` : ''}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={mainPanel}>
+          {!selectedPreprocConfig && !selectedPreprocConfigLoading && (
+            <div style={emptyState}>
+              <div>Select a config on the left.</div>
+              <div style={{ fontSize: 11 }}>
+                Each YAML must have a top-level <code>preproc:</code> section.
+              </div>
+            </div>
+          )}
+          {selectedPreprocConfigLoading && (
+            <div style={emptyState}>Loading…</div>
+          )}
+          {selectedPreprocConfig && (
+            <>
+              <div style={detailHeader}>
+                <div>
+                  <div style={{ fontSize: 14, fontWeight: 700, color: 'var(--text-primary)', fontFamily: 'monospace' }}>
+                    {selectedPreprocConfig.filename}
+                  </div>
+                  <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginTop: 2 }}>
+                    {selectedPreprocConfig.path}
+                  </div>
+                </div>
+                <button
+                  style={runBtn(running)}
+                  disabled={running}
+                  onClick={() => runPreprocConfig(selectedPreprocConfig.filename)}
+                >
+                  {running ? 'Running…' : 'Run'}
+                </button>
+              </div>
+
+              <div style={summaryGrid}>
+                {(() => {
+                  const summary = preprocConfigs.find((c) => c.filename === selectedPreprocConfig.filename)
+                  if (!summary) return null
+                  return (
+                    <>
+                      <div style={summaryLabel}>Subject</div>
+                      <div style={summaryValue}>{summary.subject || '-'}</div>
+                      <div style={summaryLabel}>Backend</div>
+                      <div style={summaryValue}>{summary.backend || '-'}</div>
+                      <div style={summaryLabel}>Mode</div>
+                      <div style={summaryValue}>{summary.mode || '-'}</div>
+                      <div style={summaryLabel}>BIDS dir</div>
+                      <div style={summaryValue}>{summary.bids_dir || '-'}</div>
+                      <div style={summaryLabel}>Output dir</div>
+                      <div style={summaryValue}>{summary.output_dir || '-'}</div>
+                      <div style={summaryLabel}>Container</div>
+                      <div style={summaryValue}>{summary.container || '-'}</div>
+                    </>
+                  )
+                })()}
+              </div>
+
+              <div style={sectionLabel}>YAML</div>
+              <pre style={yamlPre}>{selectedPreprocConfig.yaml_string}</pre>
+            </>
+          )}
+        </div>
+      </div>
+
+      {(runId || running || runError) && (
+        <PreprocProgress
+          events={runEvents}
+          startTime={runStartTime}
+          running={running}
+          error={runError}
+          onDismiss={clearRun}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/preproc/RunForm.tsx
+++ b/frontend/src/components/preproc/RunForm.tsx
@@ -328,6 +328,7 @@ export function RunForm() {
   const [memMb, setMemMb] = useState('')
   const [lowMem, setLowMem] = useState(false)
   const [stopOnFirstCrash, setStopOnFirstCrash] = useState(false)
+  const [skipBidsValidation, setSkipBidsValidation] = useState(false)
 
   // custom-specific
   const [command, setCommand] = useState('')
@@ -417,6 +418,7 @@ export function RunForm() {
       if (memMb) backendParams.mem_mb = parseInt(memMb, 10)
       if (lowMem) backendParams.low_mem = true
       if (stopOnFirstCrash) backendParams.stop_on_first_crash = true
+      if (skipBidsValidation) backendParams.skip_bids_validation = true
 
       // Extra args
       if (extraArgs.trim()) backendParams.extra_args = extraArgs.trim()
@@ -772,6 +774,12 @@ export function RunForm() {
         {/* ── Advanced ── */}
         {isFmriprep && (
           <Section title="Advanced" open={openSections.advanced} onToggle={() => toggle('advanced')}>
+            <div style={checkRow}>
+              <span style={labelStyle} />
+              <input type="checkbox" checked={skipBidsValidation}
+                onChange={(e) => setSkipBidsValidation(e.target.checked)} />
+              <span style={checkLabel}>Skip BIDS validation (--skip-bids-validation)</span>
+            </div>
             <div style={fieldRow}>
               <span style={labelStyle}>Extra Args</span>
               <input style={{ ...inputStyle, maxWidth: 500 }} value={extraArgs}

--- a/frontend/src/stores/dashboard-store.ts
+++ b/frontend/src/stores/dashboard-store.ts
@@ -11,7 +11,7 @@ import {
   connectRunWs,
 } from '../api/client'
 
-const ALL_STAGES = ['stimuli', 'responses', 'features', 'preprocess', 'model', 'analyze', 'report']
+const ALL_STAGES = ['stimuli', 'responses', 'features', 'prepare', 'model', 'analyze', 'report']
 
 function deriveStageStatuses(events: RunEvent[]): Record<string, StageStatus> {
   const statuses: Record<string, StageStatus> = {}

--- a/frontend/src/stores/preproc-store.ts
+++ b/frontend/src/stores/preproc-store.ts
@@ -7,6 +7,8 @@ import type {
   PreprocEvent,
   CollectResult,
   ConfigSummary,
+  PreprocConfigSummary,
+  PreprocConfigDetail,
 } from '../api/types'
 import {
   fetchPreprocBackends,
@@ -19,9 +21,12 @@ import {
   validatePreprocConfig,
   connectPreprocWs,
   fetchConfigs,
+  fetchPreprocConfigs,
+  fetchPreprocConfigDetail,
+  runPreprocConfigFile,
 } from '../api/client'
 
-type Tab = 'backends' | 'manifests' | 'collect' | 'run'
+type Tab = 'backends' | 'manifests' | 'collect' | 'run' | 'configs'
 
 interface PreprocState {
   tab: Tab
@@ -40,6 +45,12 @@ interface PreprocState {
 
   // Configs (for validate-against dropdown)
   configs: ConfigSummary[]
+
+  // Preproc configs (YAML files with preproc: section)
+  preprocConfigs: PreprocConfigSummary[]
+  preprocConfigsLoading: boolean
+  selectedPreprocConfig: PreprocConfigDetail | null
+  selectedPreprocConfigLoading: boolean
 
   // Collect
   collectResult: CollectResult | null
@@ -65,6 +76,9 @@ interface PreprocState {
   collect: (params: Parameters<typeof collectPreprocOutputs>[0]) => Promise<void>
   startRun: (params: Parameters<typeof startPreprocRun>[0]) => Promise<void>
   validateConfig: (params: Parameters<typeof validatePreprocConfig>[0]) => Promise<void>
+  loadPreprocConfigs: () => Promise<void>
+  selectPreprocConfig: (filename: string) => Promise<void>
+  runPreprocConfig: (filename: string) => Promise<void>
   clearRun: () => void
   clearCollect: () => void
 }
@@ -83,6 +97,11 @@ export const usePreprocStore = create<PreprocState>((set, get) => ({
   validating: false,
 
   configs: [],
+
+  preprocConfigs: [],
+  preprocConfigsLoading: false,
+  selectedPreprocConfig: null,
+  selectedPreprocConfigLoading: false,
 
   collectResult: null,
   collecting: false,
@@ -204,6 +223,56 @@ export const usePreprocStore = create<PreprocState>((set, get) => ({
       set({ configErrors: result.errors })
     } catch (e) {
       set({ configErrors: [String(e)] })
+    }
+  },
+
+  loadPreprocConfigs: async () => {
+    set({ preprocConfigsLoading: true })
+    try {
+      const preprocConfigs = await fetchPreprocConfigs()
+      set({ preprocConfigs, preprocConfigsLoading: false })
+    } catch {
+      set({ preprocConfigsLoading: false })
+    }
+  },
+
+  selectPreprocConfig: async (filename) => {
+    set({ selectedPreprocConfig: null, selectedPreprocConfigLoading: true })
+    try {
+      const detail = await fetchPreprocConfigDetail(filename)
+      set({ selectedPreprocConfig: detail, selectedPreprocConfigLoading: false })
+    } catch {
+      set({ selectedPreprocConfigLoading: false })
+    }
+  },
+
+  runPreprocConfig: async (filename) => {
+    set({
+      running: true, runError: null, runEvents: [],
+      runStartTime: Date.now(), runId: null, configErrors: null,
+    })
+    try {
+      const result = await runPreprocConfigFile(filename)
+      set({ runId: result.run_id })
+
+      const ws = connectPreprocWs(result.run_id)
+      ws.onmessage = (msg) => {
+        const event: PreprocEvent = JSON.parse(msg.data)
+        set((s) => ({ runEvents: [...s.runEvents, event] }))
+        if (event.event === 'done' || event.event === 'failed') {
+          ws.close()
+          set({
+            running: false,
+            runError: event.event === 'failed' ? (event.error || 'failed') : null,
+          })
+          get().rescan()
+        }
+      }
+      ws.onerror = () => {
+        set({ running: false, runError: 'WebSocket connection failed' })
+      }
+    } catch (e) {
+      set({ running: false, runError: String(e) })
     }
   },
 

--- a/frontend/src/views/PreprocManager.tsx
+++ b/frontend/src/views/PreprocManager.tsx
@@ -5,12 +5,14 @@ import { BackendStatus } from '../components/preproc/BackendStatus'
 import { ManifestBrowser } from '../components/preproc/ManifestBrowser'
 import { CollectForm } from '../components/preproc/CollectForm'
 import { RunForm } from '../components/preproc/RunForm'
+import { PreprocConfigBrowser } from '../components/preproc/PreprocConfigBrowser'
 
-type Tab = 'backends' | 'manifests' | 'collect' | 'run'
+type Tab = 'backends' | 'manifests' | 'collect' | 'run' | 'configs'
 
 const tabs: { key: Tab; label: string }[] = [
   { key: 'backends', label: 'Backends' },
   { key: 'manifests', label: 'Manifests' },
+  { key: 'configs', label: 'Configs' },
   { key: 'collect', label: 'Collect' },
   { key: 'run', label: 'Run' },
 ]
@@ -52,6 +54,7 @@ export function PreprocManager() {
 
       {tab === 'backends' && <BackendStatus />}
       {tab === 'manifests' && <ManifestBrowser />}
+      {tab === 'configs' && <PreprocConfigBrowser />}
       {tab === 'collect' && <CollectForm />}
       {tab === 'run' && <RunForm />}
     </div>


### PR DESCRIPTION
## Summary

Extends preprocessing to be driven from YAML configs the same way analysis already is, and wires up apptainer so fmriprep actually runs in a container on machines without Docker or modern Singularity.

- **YAML config flow for preproc** — drop a YAML with a top-level `preproc:` section under `experiments/preproc/`, see it in a new **Configs** tab, hit Run. Mirrors the analysis ConfigStore pattern.
- **Apptainer support** — backend resolves the singularity-compatible runtime in order: `\$FMRIFLOW_SINGULARITY_BIN` → `apptainer` → `singularity`. Unblocks current fmriprep images on machines where the on-PATH singularity is too old.
- **skip-bids-validation toggle** — new param on `FmriprepParams` + checkbox in the Run form's Advanced section for datasets that intentionally deviate from strict BIDS.
- **Auto-mkdir bind sources** — apptainer refuses to bind-mount paths that don't exist; `FmriprepBackend.run()` now `mkdir -p`s `output_dir` and `work_dir` before launching.
- **Dashboard stage-name fix** — tracker was still looking for a stale `preprocess` stage that no longer exists; now uses `prepare`.

## Type / scope

`feat(preproc)`, `feat(server)`, `feat(fe)`, `fix(fe)` — four clean commits inside one PR (see the commit list).

## Test plan

- [ ] Backend imports cleanly (`python -c "from fmriflow.server.app import create_app; create_app()"`).
- [ ] `GET /api/preproc/configs` returns the list when `experiments/preproc/*.yaml` exists with a `preproc:` section.
- [ ] `POST /api/preproc/configs/{file}/run` launches a run and events stream over `/ws/preproc/{run_id}`.
- [ ] Configs tab in the Preprocessing view renders summary grid + YAML + Run button.
- [ ] With `FMRIFLOW_SINGULARITY_BIN` pointing at apptainer, a fmriprep smoke run completes (or fails with a fmriprep error, not a mount error).
- [ ] With `skip_bids_validation: true`, the in-container bids-validator is bypassed.
- [ ] Run dashboard stage tracker lights up during the `prepare` stage.

## Notes / not included

- Frontend CSS is inline per project convention — no new stylesheets.
- `experiments/` and `devdocs/` are gitignored, so the `fmriprep_AH.yaml` example and the two new error entries (`0024_bids_dir_points_to_subject_not_root`, `0025_apptainer_bind_mount_source_missing`) live only on disk.