### PR TITLE
feat: detach & reattach long-running preprocessing jobs

### DIFF
--- a/docs/guide/preprocessing.md
+++ b/docs/guide/preprocessing.md
@@ -17,10 +17,31 @@ conda activate fmriflow
 pip install fmriprep
 ```
 
-For container-based runs (Singularity):
+For container-based runs (Singularity or Apptainer):
 
 ```bash
-conda install conda-forge::singularity
+conda install conda-forge::apptainer    # preferred — modern fork
+# or: conda install conda-forge::singularity
+```
+
+The fmriprep backend resolves the container runtime in this order:
+
+1. `$FMRIFLOW_SINGULARITY_BIN` (absolute path, if set)
+2. `apptainer` on PATH
+3. `singularity` on PATH
+
+If your environment ships an old Singularity 2.x that can't run current
+fmriprep images, install Apptainer into a dedicated conda env and point
+the server at its binary:
+
+```bash
+FMRIFLOW_SINGULARITY_BIN=$HOME/miniconda3/envs/dv2/bin/apptainer fmriflow serve
+```
+
+Pull an fmriprep image once and point your configs at the `.sif`:
+
+```bash
+apptainer pull ~/images/fmriprep/fmriprep_25.1.3.sif docker://nipreps/fmriprep:25.1.3
 ```
 
 You also need a FreeSurfer license file:
@@ -62,28 +83,48 @@ response:
   mask_type: thick
 ```
 
-## Workflow 2: Run preprocessing
+## Workflow 2: Run preprocessing from a YAML config
 
-```bash
-fmriflow preproc run --config preproc_config.yaml
-```
+The same YAML drives three equivalent entry points: CLI, HTTP API, and the
+dashboard's **Configs** tab. Put the file anywhere for CLI use, or under
+`./experiments/preproc/` so the dashboard and API auto-discover it.
 
-Config format:
+### Config format
 
 ```yaml
 preproc:
   backend: fmriprep
   bids_dir: /data/bids/my_study/
   output_dir: /data/derivatives/fmriprep/
+  work_dir: /data/derivatives/work/
   subject: sub01
   task: reading
   sessions: [session01]
 
   backend_params:
-    container: /images/fmriprep-23.2.1.sif
-    container_type: singularity
-    output_spaces: [T1w]
+    # Container
+    container: /images/fmriprep/fmriprep_25.1.3.sif
+    container_type: singularity         # also runs under Apptainer — see above
+
+    # Mode: full | anat_only | func_only | func_precomputed_anat
+    mode: func_only                     # skips FreeSurfer reconall
+
+    # FreeSurfer license (required for full / func_precomputed_anat)
     fs_license_file: ~/.freesurfer/license.txt
+
+    # Output spaces
+    output_spaces:
+      - MNI152NLin2009cAsym:res-2
+      - T1w
+
+    # Resources
+    nthreads: 12
+    omp_nthreads: 8
+    mem_mb: 32000
+
+    # Bypass the in-container BIDS validator for datasets that intentionally
+    # deviate from strict BIDS.
+    skip_bids_validation: true
 
   confounds:
     strategy: motion_24
@@ -93,6 +134,97 @@ preproc:
     run-01: story01
     run-02: story02
 ```
+
+The backend auto-creates `output_dir` and `work_dir` before launching —
+Apptainer refuses to bind-mount paths that don't exist on the host.
+
+### 2a. Run from the CLI
+
+```bash
+fmriflow preproc run --config experiments/preproc/my_config.yaml
+```
+
+### 2b. Run from the dashboard (Preprocessing → Configs)
+
+The dashboard scans `./experiments/preproc/*.yaml` for files with a top-level
+`preproc:` section and lists them in the **Configs** tab. Clicking a config
+shows its summary (subject, backend, container, mode, paths) and the raw YAML,
+with a **Run** button that starts the job and streams live fmriprep output
+into the progress panel below.
+
+### 2c. Run via HTTP API
+
+```bash
+# List discovered configs
+curl http://localhost:8000/api/preproc/configs
+
+# Get one
+curl http://localhost:8000/api/preproc/configs/my_config.yaml
+
+# Kick off a run (body is optional — any fields shallow-merge onto the YAML)
+curl -X POST http://localhost:8000/api/preproc/configs/my_config.yaml/run \
+  -H 'Content-Type: application/json' \
+  -d '{"subject": "sub02"}'
+```
+
+The response returns a `run_id` you can use to tail live events over
+`/ws/preproc/{run_id}`.
+
+## Long-running jobs — detach & reattach
+
+fmriprep runs take hours. To let you close the browser, restart the server,
+or reboot the machine without killing a job in progress, fmriprep jobs
+launched through the dashboard or `/api/preproc/configs/{file}/run` are
+detached from the server process:
+
+- The fmriprep subprocess is spawned in its own process group
+  (`start_new_session=True`), so it survives if the parent dies.
+- stdout+stderr go straight to a log file under
+  `~/.fmriflow/runs/{run_id}/stdout.log` — never to a broken pipe.
+- A sidecar `state.json` in the same directory records pid, pgid, start
+  time, config path, and current status.
+
+When the server restarts it scans `~/.fmriflow/runs/*/state.json`:
+
+- Any run marked `running` whose PID is still alive is re-registered.
+  Its progress is reconstructed by tailing the existing `stdout.log`,
+  and a `REATTACHED` tag appears next to it in the UI.
+- If the PID is dead, the run is marked `lost` so the history view
+  doesn't show an eternal "running."
+- Finished runs stay on disk for inspection; no auto-delete.
+
+### UI
+
+In the Preprocessing → Configs tab a new **In Flight** panel at the top
+lists running jobs (plus recent completions). Each row has:
+
+- `Watch` — opens the live progress panel and starts streaming from the
+  log file via WebSocket.
+- `Cancel` — `SIGTERM` the process group; `SIGKILL` after a 5-second grace
+  period.
+
+### HTTP API
+
+```bash
+# List all runs (in-memory + on-disk)
+curl http://localhost:8000/api/preproc/runs
+
+# Get summary + last 200 log lines for one
+curl http://localhost:8000/api/preproc/runs/preproc_AH_4f2b9c1a
+
+# Cancel a running job
+curl -X POST http://localhost:8000/api/preproc/runs/preproc_AH_4f2b9c1a/cancel
+```
+
+### Caveats
+
+- Only the `fmriprep` backend is detached. `custom` and `bids_app` still
+  run in-process and will be killed if the server dies.
+- The subprocess's exit code is only known to the server that spawned
+  it. Reattached runs infer outcome by checking for fmriprep's HTML
+  report in the output dir — present → `done`, missing → `failed`.
+- If you're running under Docker, bind-mount `~/.fmriflow` to the host
+  so the runs directory survives container restarts.
 
 ## Workflow 3: Custom script
 

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -45,17 +45,20 @@ Convert raw DICOM images to BIDS format. Six tabs cover the full workflow:
 
 ### Preprocessing Manager
 
-Manage fMRI preprocessing (fmriprep, custom scripts) and their outputs. Four tabs:
+Manage fMRI preprocessing (fmriprep, custom scripts) and their outputs. Five tabs:
 
 **Backends** — Lists installed preprocessing backends with version and status.
 
 **Manifests** — Browse completed preprocessing outputs. Each manifest records the backend, parameters, output space, and per-run QC metrics. Validate against an analysis config to check compatibility before running the pipeline.
 
+**Configs** — Browse YAML preproc configs discovered under `./experiments/preproc/`. Each file must have a top-level `preproc:` section. Clicking a config shows a summary grid (subject, backend, container, mode, paths) and the raw YAML, with a **Run** button that launches the job and streams live fmriprep output into the progress panel below. An **In Flight** panel at the top lists running jobs (plus recent completions) with `Watch` and `Cancel` buttons — jobs launched here survive server restarts and reconnect automatically, with a `REATTACHED` tag. See [Preprocessing → Workflow 2](preprocessing.md#workflow-2-run-preprocessing-from-a-yaml-config) and [Long-running jobs](preprocessing.md#long-running-jobs--detach--reattach) for details.
+
 **Collect** — Build a manifest from existing preprocessing outputs (e.g., from a previous fmriprep run). Specify the output directory and file pattern; the tool scans and organizes the files.
 
-**Run** — Launch a preprocessing job:
+**Run** — Launch a preprocessing job from an inline form (no YAML):
 
 - Select backend, set BIDS directory, output directory, work directory, subject ID
+- Toggle options like `--skip-bids-validation` in the Advanced section
 - Click **Run** for live progress with event streaming
 - Manifest auto-refreshes on completion
 

--- a/fmriflow/preproc/backends/fmriprep.py
+++ b/fmriflow/preproc/backends/fmriprep.py
@@ -63,6 +63,32 @@ class FmriprepBackend:
         return errors
 
     def run(self, config: PreprocConfig) -> PreprocManifest:
+        """Blocking run — spawns fmriprep and waits. Suitable for CLI use."""
+        proc = self.spawn(config, log_path=None)
+        proc.wait()
+        if proc.returncode != 0:
+            raise BackendRunError(
+                f"fmriprep exited with code {proc.returncode}",
+                backend="fmriprep",
+                subject=config.subject,
+                returncode=proc.returncode,
+            )
+        return self.collect(config)
+
+    def spawn(
+        self,
+        config: PreprocConfig,
+        log_path: Path | str | None,
+    ) -> subprocess.Popen:
+        """Spawn fmriprep as a detached subprocess and return the Popen.
+
+        When ``log_path`` is provided, stdout+stderr are redirected directly
+        to that file so the subprocess survives the server process dying
+        (``start_new_session=True`` puts it in its own process group).
+
+        Callers are responsible for ``wait()``-ing or polling on the
+        returned process.
+        """
         params = _parse_params(config)
 
         # Apptainer/Singularity refuse to bind-mount a source path that does
@@ -76,31 +102,20 @@ class FmriprepBackend:
         cmd = self._build_command(config, params)
         logger.info("Running fmriprep: %s", " ".join(cmd))
 
-        proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
-        )
-
-        tail: list[str] = []
-        for line in proc.stdout:
-            stripped = line.rstrip()
-            logger.info("[fmriprep] %s", stripped)
-            tail.append(stripped)
-            if len(tail) > 50:
-                tail.pop(0)
-        proc.wait()
-
-        if proc.returncode != 0:
-            last_output = "\n".join(tail[-20:])
-            raise BackendRunError(
-                f"fmriprep exited with code {proc.returncode}\n"
-                f"Last output:\n{last_output}",
-                backend="fmriprep",
-                subject=config.subject,
-                returncode=proc.returncode,
-                stderr=last_output,
+        if log_path is not None:
+            log_fh = open(log_path, "w", buffering=1)  # line-buffered
+            return subprocess.Popen(
+                cmd,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                text=True,
+                start_new_session=True,
             )
 
-        return self.collect(config)
+        # No detach — stream stdout through the parent for CLI ergonomics.
+        return subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        )
 
     def status(self, config: PreprocConfig) -> PreprocStatus:
         output_dir = Path(config.output_dir)

--- a/fmriflow/server/routes/preproc.py
+++ b/fmriflow/server/routes/preproc.py
@@ -123,6 +123,33 @@ async def start_run(request: Request, body: RunBody):
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@router.get("/preproc/runs")
+async def list_preproc_runs(request: Request, include_finished: bool = True):
+    """List active (and optionally finished) preprocessing runs."""
+    mgr = request.app.state.preproc_manager
+    return {"runs": mgr.list_runs(include_finished=include_finished)}
+
+
+@router.get("/preproc/runs/{run_id}")
+async def get_preproc_run(request: Request, run_id: str):
+    """Return summary + last 200 log lines for one run."""
+    mgr = request.app.state.preproc_manager
+    result = mgr.get_run(run_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+    return result
+
+
+@router.post("/preproc/runs/{run_id}/cancel")
+async def cancel_preproc_run(request: Request, run_id: str):
+    """Cancel a running preprocessing job (SIGTERM then SIGKILL)."""
+    mgr = request.app.state.preproc_manager
+    result = mgr.cancel_run(run_id)
+    if not result.get("cancelled"):
+        raise HTTPException(status_code=409, detail=result.get("reason", "could not cancel"))
+    return result
+
+
 @router.get("/preproc/configs")
 async def list_preproc_configs(request: Request):
     """List preprocessing YAML configs (with a top-level preproc: section)."""

--- a/fmriflow/server/services/preproc_manager.py
+++ b/fmriflow/server/services/preproc_manager.py
@@ -1,52 +1,120 @@
-"""Preprocessing manager — manifest scanning, collect, and run orchestration."""
+"""Preprocessing manager — manifest scanning, collect, and run orchestration.
+
+Runs survive server restarts: each job is spawned in its own process group
+(``start_new_session=True``) with stdout+stderr redirected to a log file,
+and a ``RunStateFile`` is persisted under ``~/.fmriflow/runs/{run_id}/``.
+On startup we scan that directory and reattach to any runs whose PID is
+still alive; their progress is rebuilt by tailing the log file.
+"""
 
 from __future__ import annotations
 
-import asyncio
 import logging
+import os
+import signal
 import threading
 import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from fmriflow.server.services.run_registry import (
+    RunRegistry,
+    RunStateFile,
+)
+
 logger = logging.getLogger(__name__)
+
+
+# ── Handle ───────────────────────────────────────────────────────────────
 
 
 @dataclass
 class PreprocRunHandle:
-    """Tracks a running preprocessing job."""
+    """Tracks a running or reattached preprocessing job.
+
+    Two flavours:
+
+    - **Native**: this server spawned the subprocess. ``proc`` is the
+      ``Popen``; events come from the log-file tailer thread.
+    - **Reattached**: a previous server spawned it; the subprocess is
+      still alive (``pid`` resolves). Events come from the tailer
+      reading the existing log file; completion is inferred by polling
+      ``pid`` and checking for the fmriprep HTML report.
+    """
+
     run_id: str
     subject: str
     backend: str
-    status: str = "running"  # running, done, failed
+    status: str = "running"   # running, done, failed, cancelled, lost
     events: list[dict] = field(default_factory=list)
     _pending: list[dict] = field(default_factory=list)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
     manifest_path: str | None = None
     error: str | None = None
     started_at: float = 0.0
     finished_at: float = 0.0
 
+    # Detach-reattach bookkeeping
+    pid: int | None = None
+    pgid: int | None = None
+    log_path: str | None = None
+    is_reattached: bool = False
+    config_path: str | None = None
+    params: dict = field(default_factory=dict)
+
     def push_event(self, event: dict) -> None:
         event.setdefault("timestamp", time.time())
-        self.events.append(event)
-        self._pending.append(event)
+        with self._lock:
+            self.events.append(event)
+            self._pending.append(event)
 
     def drain_events(self) -> list[dict]:
-        out = list(self._pending)
-        self._pending.clear()
+        with self._lock:
+            out = list(self._pending)
+            self._pending.clear()
         return out
+
+    def to_summary(self) -> dict:
+        return {
+            "run_id": self.run_id,
+            "subject": self.subject,
+            "backend": self.backend,
+            "status": self.status,
+            "pid": self.pid,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "is_reattached": self.is_reattached,
+            "manifest_path": self.manifest_path,
+            "error": self.error,
+            "config_path": self.config_path,
+            "log_path": self.log_path,
+        }
+
+
+# ── Manager ──────────────────────────────────────────────────────────────
 
 
 class PreprocManager:
     """Manages manifest discovery and preprocessing runs."""
 
-    def __init__(self, derivatives_dir: Path):
+    def __init__(
+        self,
+        derivatives_dir: Path,
+        registry: RunRegistry | None = None,
+    ):
         self.derivatives_dir = derivatives_dir
         self._manifests_cache: list[dict] | None = None
         self._cache_time: float = 0
         self._cache_ttl = 10.0
         self.active_runs: dict[str, PreprocRunHandle] = {}
+        self.registry = registry or RunRegistry()
+
+        # Best-effort reattach on startup.
+        try:
+            self._reattach_active_runs()
+        except Exception:
+            logger.warning("Failed to scan run registry on startup", exc_info=True)
 
     # ── Manifest scanning ────────────────────────────────────────
 
@@ -155,21 +223,41 @@ class PreprocManager:
 
     # ── Run preprocessing ────────────────────────────────────────
 
-    def start_run(self, params: dict) -> str:
+    def start_run(self, params: dict, config_path: str | None = None) -> str:
         """Start a preprocessing run in a background thread."""
         run_id = f"preproc_{params['subject']}_{uuid.uuid4().hex[:8]}"
+        now = time.time()
+
         handle = PreprocRunHandle(
             run_id=run_id,
             subject=params["subject"],
             backend=params["backend"],
-            started_at=time.time(),
+            started_at=now,
+            config_path=config_path,
+            params=params,
         )
+
+        # Pre-register so that even if spawn fails, there's a record on disk.
+        state = RunStateFile(
+            run_id=run_id,
+            kind="preproc",
+            backend=params["backend"],
+            subject=params["subject"],
+            status="running",
+            started_at=now,
+            config_path=config_path,
+            params=params,
+        )
+        self.registry.register(state)
+        handle.log_path = state.stdout_log
+
         self.active_runs[run_id] = handle
 
         thread = threading.Thread(
             target=self._execute_run,
             args=(handle, params),
             daemon=True,
+            name=f"preproc-{run_id}",
         )
         thread.start()
         return run_id
@@ -209,12 +297,116 @@ class PreprocManager:
                 f"Preproc config missing required fields: {', '.join(missing)}"
             )
 
-        return self.start_run(params)
+        return self.start_run(params, config_path=str(path.resolve()))
 
     def _execute_run(self, handle: PreprocRunHandle, params: dict) -> None:
-        """Execute preprocessing in a background thread."""
+        """Dispatch to the right execution strategy based on backend."""
+        if params.get("backend") == "fmriprep":
+            self._execute_fmriprep(handle, params)
+        else:
+            self._execute_inprocess(handle, params)
+
+    # ── fmriprep: detached subprocess + log tailer ──────────────────
+
+    def _execute_fmriprep(self, handle: PreprocRunHandle, params: dict) -> None:
+        """Spawn fmriprep detached, tail its log file, update state."""
+        from fmriflow.preproc.backends import get_backend
+        from fmriflow.preproc.manifest import PreprocConfig, ConfoundsConfig
+        from fmriflow.preproc.errors import BackendRunError
+
+        log_path = Path(handle.log_path) if handle.log_path else None
+
+        try:
+            confounds_data = params.get("confounds")
+            confounds = ConfoundsConfig(**confounds_data) if confounds_data else None
+
+            config = PreprocConfig(
+                subject=params["subject"],
+                backend=params["backend"],
+                output_dir=params["output_dir"],
+                bids_dir=params.get("bids_dir"),
+                raw_dir=params.get("raw_dir"),
+                work_dir=params.get("work_dir"),
+                task=params.get("task"),
+                sessions=params.get("sessions"),
+                run_map=params.get("run_map"),
+                backend_params=params.get("backend_params", {}),
+                confounds=confounds,
+            )
+
+            backend = get_backend("fmriprep")
+
+            handle.push_event({
+                "event": "started",
+                "message": f"Starting fmriprep for sub-{config.subject}",
+            })
+
+            proc = backend.spawn(config, log_path=log_path)
+            handle.pid = proc.pid
+            try:
+                handle.pgid = os.getpgid(proc.pid)
+            except OSError:
+                handle.pgid = proc.pid
+            self._persist_state(handle)
+
+            tailer = _LogTailer(log_path, handle, stop_when=lambda: proc.poll() is not None)
+            tailer.start()
+
+            proc.wait()
+            tailer.stop_and_join()
+
+            if proc.returncode != 0:
+                raise BackendRunError(
+                    f"fmriprep exited with code {proc.returncode}",
+                    backend="fmriprep",
+                    subject=config.subject,
+                    returncode=proc.returncode,
+                )
+
+            # Build manifest from outputs.
+            from fmriflow.preproc.runner import run_preprocessing as _unused  # noqa: F401
+            manifest = backend.collect(config)
+            if config.confounds:
+                from fmriflow.preproc.runner import _apply_confounds
+                manifest = _apply_confounds(manifest, config.confounds)
+
+            manifest_path = Path(config.output_dir) / f"sub-{config.subject}" / "preproc_manifest.json"
+            manifest.save(manifest_path)
+
+            handle.manifest_path = str(manifest_path)
+            handle.status = "done"
+            handle.finished_at = time.time()
+            handle.push_event({
+                "event": "done",
+                "manifest_path": handle.manifest_path,
+                "n_runs": len(manifest.runs),
+                "elapsed": handle.finished_at - handle.started_at,
+            })
+            self.invalidate_cache()
+
+        except Exception as e:
+            handle.status = "failed"
+            handle.error = str(e)
+            handle.finished_at = time.time()
+            handle.push_event({
+                "event": "failed",
+                "error": str(e),
+                "elapsed": handle.finished_at - handle.started_at,
+            })
+            logger.error("Preprocessing failed: %s", e, exc_info=True)
+
+        finally:
+            self._persist_state(handle)
+
+    # ── Non-fmriprep: in-process (custom, bids_app) ─────────────────
+
+    def _execute_inprocess(self, handle: PreprocRunHandle, params: dict) -> None:
+        """Legacy synchronous execution for backends that don't support detach.
+
+        No detach — the subprocess is tied to the server's lifetime. Use
+        fmriprep for hands-off long runs until these backends are migrated.
+        """
         import logging as _logging
-        # Set up a handler that captures log lines as events
         capture = _LogCapture(handle)
         preproc_logger = _logging.getLogger("fmriflow.preproc")
         preproc_logger.addHandler(capture)
@@ -273,6 +465,138 @@ class PreprocManager:
 
         finally:
             preproc_logger.removeHandler(capture)
+            self._persist_state(handle)
+
+    # ── Detached run discovery ──────────────────────────────────────
+
+    def _reattach_active_runs(self) -> None:
+        """On startup, scan the registry and rehydrate handles for live runs."""
+        for state in self.registry.list_active():
+            if state.kind != "preproc":
+                continue
+            if not RunRegistry.pid_alive(state.pid):
+                # The subprocess died while the server was down. Record the
+                # transition so the history view shows "lost" instead of
+                # an eternal "running".
+                self.registry.mark_lost(state, "server_lost_track")
+                continue
+
+            handle = PreprocRunHandle(
+                run_id=state.run_id,
+                subject=state.subject,
+                backend=state.backend,
+                status="running",
+                started_at=state.started_at,
+                pid=state.pid,
+                pgid=state.pgid,
+                log_path=state.stdout_log,
+                is_reattached=True,
+                config_path=state.config_path,
+                params=state.params,
+            )
+            self.active_runs[state.run_id] = handle
+
+            monitor = _ReattachedMonitor(handle, self, state)
+            thread = threading.Thread(
+                target=monitor.run, daemon=True, name=f"reattach-{state.run_id}",
+            )
+            thread.start()
+            logger.info(
+                "Reattached to preproc run %s (pid=%s, subject=%s)",
+                state.run_id, state.pid, state.subject,
+            )
+
+    # ── Run listing / cancel ────────────────────────────────────────
+
+    def list_runs(self, include_finished: bool = True) -> list[dict]:
+        """Return in-memory active runs plus (optionally) recent finished ones."""
+        out: dict[str, dict] = {}
+        for handle in self.active_runs.values():
+            out[handle.run_id] = handle.to_summary()
+        if include_finished:
+            for state in self.registry.list_all():
+                if state.kind != "preproc" or state.run_id in out:
+                    continue
+                out[state.run_id] = {
+                    "run_id": state.run_id,
+                    "subject": state.subject,
+                    "backend": state.backend,
+                    "status": state.status,
+                    "pid": state.pid,
+                    "started_at": state.started_at,
+                    "finished_at": state.finished_at,
+                    "is_reattached": False,
+                    "manifest_path": state.manifest_path,
+                    "error": state.error,
+                    "config_path": state.config_path,
+                    "log_path": state.stdout_log,
+                }
+        # Newest first
+        return sorted(out.values(), key=lambda r: r.get("started_at") or 0, reverse=True)
+
+    def get_run(self, run_id: str) -> dict | None:
+        """Return summary + recent log tail for a run (live or historical)."""
+        handle = self.active_runs.get(run_id)
+        if handle is not None:
+            summary = handle.to_summary()
+        else:
+            state = self.registry.load(run_id)
+            if state is None:
+                return None
+            summary = {
+                "run_id": state.run_id,
+                "subject": state.subject,
+                "backend": state.backend,
+                "status": state.status,
+                "pid": state.pid,
+                "started_at": state.started_at,
+                "finished_at": state.finished_at,
+                "is_reattached": False,
+                "manifest_path": state.manifest_path,
+                "error": state.error,
+                "config_path": state.config_path,
+                "log_path": state.stdout_log,
+            }
+        log_path = summary.get("log_path")
+        summary["log_tail"] = _read_tail(log_path, n=200) if log_path else ""
+        return summary
+
+    def cancel_run(self, run_id: str) -> dict:
+        """Terminate a running preproc subprocess. SIGTERM then SIGKILL."""
+        handle = self.active_runs.get(run_id)
+        if handle is None:
+            return {"cancelled": False, "reason": "run not found in active set"}
+        if handle.status != "running":
+            return {"cancelled": False, "reason": f"status is {handle.status}"}
+        pgid = handle.pgid or handle.pid
+        if not pgid:
+            return {"cancelled": False, "reason": "no pid recorded"}
+
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except ProcessLookupError:
+            handle.status = "failed"
+            handle.error = "process already gone"
+            self._persist_state(handle)
+            return {"cancelled": True, "reason": "process already exited"}
+        except Exception as e:
+            return {"cancelled": False, "reason": str(e)}
+
+        # Give it a short grace period, then hard kill.
+        def _grace_kill():
+            time.sleep(5)
+            if RunRegistry.pid_alive(handle.pid):
+                try:
+                    os.killpg(pgid, signal.SIGKILL)
+                except Exception:
+                    pass
+        threading.Thread(target=_grace_kill, daemon=True).start()
+
+        handle.status = "cancelled"
+        handle.finished_at = time.time()
+        handle.push_event({"event": "cancelled", "message": "SIGTERM sent"})
+        self._persist_state(handle)
+        return {"cancelled": True}
 
     # ── Backend availability ─────────────────────────────────────
 
@@ -322,6 +646,217 @@ class PreprocManager:
                 })
 
         return results
+
+    # ── Helpers ─────────────────────────────────────────────────────
+
+    def _persist_state(self, handle: PreprocRunHandle) -> None:
+        """Flush the handle back to the registry state file."""
+        state = RunStateFile(
+            run_id=handle.run_id,
+            kind="preproc",
+            backend=handle.backend,
+            subject=handle.subject,
+            status=handle.status,
+            pid=handle.pid,
+            pgid=handle.pgid,
+            started_at=handle.started_at,
+            finished_at=handle.finished_at,
+            stdout_log=handle.log_path or "",
+            config_path=handle.config_path,
+            params=handle.params,
+            error=handle.error,
+            manifest_path=handle.manifest_path,
+        )
+        self.registry.update(state)
+
+
+# ── Log tailer ───────────────────────────────────────────────────────────
+
+
+class _LogTailer(threading.Thread):
+    """Reads new lines from a log file and pushes them as events.
+
+    Polls with a short sleep; line-buffered fmriprep output shows up
+    within a second. Stops when ``stop_when()`` returns True AND the
+    file has no further bytes to read.
+    """
+
+    def __init__(
+        self,
+        log_path: Path,
+        handle: PreprocRunHandle,
+        stop_when,
+        poll_interval: float = 0.5,
+    ):
+        super().__init__(daemon=True, name=f"tail-{handle.run_id}")
+        self.log_path = log_path
+        self.handle = handle
+        self.stop_when = stop_when
+        self.poll_interval = poll_interval
+        self._stop = threading.Event()
+
+    def run(self) -> None:
+        # Wait briefly for the file to exist
+        deadline = time.time() + 5
+        while not self.log_path.is_file() and time.time() < deadline:
+            time.sleep(0.1)
+        if not self.log_path.is_file():
+            return
+
+        try:
+            with open(self.log_path, "r", encoding="utf-8", errors="replace") as f:
+                while True:
+                    line = f.readline()
+                    if line:
+                        self._emit(line.rstrip("\n"))
+                        continue
+                    # No new line — check whether to stop
+                    if self._stop.is_set() or self.stop_when():
+                        # Drain anything the subprocess wrote between the
+                        # last readline and the stop check.
+                        tail = f.read()
+                        if tail:
+                            for ln in tail.splitlines():
+                                self._emit(ln)
+                        return
+                    time.sleep(self.poll_interval)
+        except Exception:
+            logger.warning("Log tailer crashed for %s", self.handle.run_id, exc_info=True)
+
+    def _emit(self, line: str) -> None:
+        self.handle.push_event({"event": "log", "message": line})
+
+    def stop_and_join(self, timeout: float = 2.0) -> None:
+        self._stop.set()
+        self.join(timeout=timeout)
+
+
+# ── Reattached-run monitor ───────────────────────────────────────────────
+
+
+class _ReattachedMonitor:
+    """Tails the log file of a reattached run and watches its PID.
+
+    When the PID dies, infer outcome:
+      * if a fmriprep HTML report exists in the output dir → ``done``
+      * otherwise → ``failed``
+    """
+
+    def __init__(
+        self,
+        handle: PreprocRunHandle,
+        manager: "PreprocManager",
+        state: RunStateFile,
+    ):
+        self.handle = handle
+        self.manager = manager
+        self.state = state
+
+    def run(self) -> None:
+        log_path = Path(self.handle.log_path) if self.handle.log_path else None
+        proc_dead = threading.Event()
+
+        def stop_when() -> bool:
+            if not RunRegistry.pid_alive(self.handle.pid):
+                proc_dead.set()
+                return True
+            return False
+
+        tailer = None
+        if log_path and log_path.is_file():
+            tailer = _LogTailer(log_path, self.handle, stop_when=stop_when)
+            tailer.start()
+
+        # Poll PID until it dies
+        while RunRegistry.pid_alive(self.handle.pid):
+            time.sleep(1.0)
+        proc_dead.set()
+
+        if tailer is not None:
+            tailer.stop_and_join()
+
+        # Infer outcome from output dir
+        self._finalize()
+
+    def _finalize(self) -> None:
+        """Determine the final status of a reattached run."""
+        params = self.state.params or {}
+        output_dir = params.get("output_dir")
+        subject = self.state.subject
+        found_report = False
+        if output_dir and subject:
+            p = Path(output_dir)
+            if p.is_dir():
+                reports = list(p.glob(f"sub-{subject}*.html"))
+                found_report = bool(reports)
+
+        now = time.time()
+        if found_report:
+            self.handle.status = "done"
+            self.handle.finished_at = now
+            self.handle.manifest_path = str(
+                Path(output_dir) / f"sub-{subject}" / "preproc_manifest.json"
+            ) if output_dir else None
+            self.handle.push_event({
+                "event": "done",
+                "message": "fmriprep report found after reattach",
+                "manifest_path": self.handle.manifest_path,
+                "elapsed": now - self.handle.started_at,
+            })
+            # Best-effort rebuild the manifest for the dashboard.
+            try:
+                from fmriflow.preproc.backends import get_backend
+                from fmriflow.preproc.manifest import PreprocConfig
+                cfg = PreprocConfig(
+                    subject=subject,
+                    backend=self.state.backend,
+                    output_dir=output_dir,
+                    bids_dir=params.get("bids_dir"),
+                    task=params.get("task"),
+                    sessions=params.get("sessions"),
+                    run_map=params.get("run_map"),
+                    backend_params=params.get("backend_params", {}),
+                )
+                manifest = get_backend(self.state.backend).collect(cfg)
+                manifest.save(Path(self.handle.manifest_path))
+            except Exception:
+                logger.warning(
+                    "Could not rebuild manifest for reattached run %s",
+                    self.handle.run_id, exc_info=True,
+                )
+        else:
+            self.handle.status = "failed"
+            self.handle.error = "process exited without producing a fmriprep report"
+            self.handle.finished_at = now
+            self.handle.push_event({
+                "event": "failed",
+                "error": self.handle.error,
+                "elapsed": now - self.handle.started_at,
+            })
+
+        self.manager._persist_state(self.handle)
+        self.manager.invalidate_cache()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _read_tail(path: str | None, n: int = 200) -> str:
+    """Return the last *n* lines of a file, or empty string on failure."""
+    if not path:
+        return ""
+    try:
+        p = Path(path)
+        if not p.is_file():
+            return ""
+        # Cheap implementation — big fmriprep logs fit in RAM fine.
+        lines = p.read_text(errors="replace").splitlines()
+        return "\n".join(lines[-n:])
+    except Exception:
+        return ""
+
+
+# ── Legacy log-capture handler (still used by in-process backends) ──────
 
 
 class _LogCapture(logging.Handler):

--- a/fmriflow/server/services/run_registry.py
+++ b/fmriflow/server/services/run_registry.py
@@ -1,0 +1,167 @@
+"""Filesystem-backed registry for long-running jobs.
+
+Each run gets a directory under ``~/.fmriflow/runs/{run_id}/`` containing:
+
+- ``state.json`` — live status, pid, command, timestamps, config snapshot.
+- ``stdout.log`` — the subprocess's captured stdout+stderr, tailed for
+  event streaming and preserved after the run finishes.
+
+The registry lets the server detach fmriprep subprocesses (via
+``start_new_session=True``) and reattach to them after a server restart.
+Only the preprocessing manager uses it today; the analysis run manager
+can adopt the same pattern later.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RUNS_ROOT = Path.home() / ".fmriflow" / "runs"
+STATE_FILENAME = "state.json"
+STDOUT_FILENAME = "stdout.log"
+
+
+@dataclass
+class RunStateFile:
+    """On-disk representation of one run.
+
+    The schema is intentionally minimal so reattachment stays simple.
+    Anything that requires re-parsing the config YAML lives in ``params``.
+    """
+
+    run_id: str
+    kind: str                      # "preproc" | "run" (future)
+    backend: str                   # "fmriprep", "custom", …
+    subject: str
+    status: str                    # "running" | "done" | "failed" | "cancelled" | "lost"
+    pid: int | None = None
+    pgid: int | None = None
+    started_at: float = 0.0
+    finished_at: float = 0.0
+    stdout_log: str = ""
+    config_path: str | None = None
+    params: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+    manifest_path: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunStateFile:
+        # Drop unknown keys so older state files don't crash on load.
+        valid = {f for f in cls.__dataclass_fields__}
+        return cls(**{k: v for k, v in data.items() if k in valid})
+
+
+class RunRegistry:
+    """Directory-backed registry for preprocessing runs."""
+
+    def __init__(self, root: Path | None = None):
+        self.root = Path(root) if root else DEFAULT_RUNS_ROOT
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    # ── Paths ────────────────────────────────────────────────────────
+
+    def run_dir(self, run_id: str) -> Path:
+        return self.root / run_id
+
+    def state_path(self, run_id: str) -> Path:
+        return self.run_dir(run_id) / STATE_FILENAME
+
+    def stdout_path(self, run_id: str) -> Path:
+        return self.run_dir(run_id) / STDOUT_FILENAME
+
+    # ── Create / update / load ──────────────────────────────────────
+
+    def register(self, state: RunStateFile) -> Path:
+        """Create the run directory and write the initial state file."""
+        d = self.run_dir(state.run_id)
+        d.mkdir(parents=True, exist_ok=True)
+        if not state.stdout_log:
+            state.stdout_log = str(self.stdout_path(state.run_id))
+        self._write(state)
+        return d
+
+    def update(self, state: RunStateFile) -> None:
+        """Overwrite the state file for an existing run."""
+        self._write(state)
+
+    def load(self, run_id: str) -> RunStateFile | None:
+        p = self.state_path(run_id)
+        if not p.is_file():
+            return None
+        try:
+            data = json.loads(p.read_text())
+            return RunStateFile.from_dict(data)
+        except Exception as e:
+            logger.warning("Could not load state for %s: %s", run_id, e)
+            return None
+
+    def list_all(self) -> list[RunStateFile]:
+        """Return every run currently on disk, newest first."""
+        out: list[RunStateFile] = []
+        if not self.root.is_dir():
+            return out
+        for child in self.root.iterdir():
+            if not child.is_dir():
+                continue
+            state = self.load(child.name)
+            if state:
+                out.append(state)
+        out.sort(key=lambda s: s.started_at, reverse=True)
+        return out
+
+    def list_active(self) -> list[RunStateFile]:
+        """Return runs currently marked ``running``."""
+        return [s for s in self.list_all() if s.status == "running"]
+
+    # ── Liveness ────────────────────────────────────────────────────
+
+    @staticmethod
+    def pid_alive(pid: int | None) -> bool:
+        """Return True if the given PID is alive.
+
+        Uses ``os.kill(pid, 0)`` — sends no signal but raises if the
+        process doesn't exist or we can't signal it.
+        """
+        if not pid or pid <= 0:
+            return False
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # Process exists but is owned by another user — still alive.
+            return True
+        except OSError:
+            return False
+
+    def mark_lost(self, state: RunStateFile, reason: str) -> None:
+        """Mark a run as lost (server died while it was still running).
+
+        Preserved on disk for later inspection.
+        """
+        state.status = "lost"
+        state.error = reason
+        state.finished_at = time.time()
+        self._write(state)
+
+    # ── Internals ───────────────────────────────────────────────────
+
+    def _write(self, state: RunStateFile) -> None:
+        p = self.state_path(state.run_id)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write — write to tmp then rename.
+        tmp = p.with_suffix(".tmp")
+        tmp.write_text(json.dumps(state.to_dict(), indent=2))
+        tmp.replace(p)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -31,6 +31,7 @@ import type {
   SavedConvertConfigDetail,
   PreprocConfigSummary,
   PreprocConfigDetail,
+  PreprocRunSummary,
 } from './types'
 
 const BASE = '/api'
@@ -326,6 +327,24 @@ export async function runPreprocConfigFile(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(overrides || {}),
+  })
+}
+
+export async function fetchPreprocRuns(
+  includeFinished: boolean = true,
+): Promise<PreprocRunSummary[]> {
+  const qs = includeFinished ? '' : '?include_finished=false'
+  const r = await json<{ runs: PreprocRunSummary[] }>(`${BASE}/preproc/runs${qs}`)
+  return r.runs
+}
+
+export async function fetchPreprocRun(runId: string): Promise<PreprocRunSummary> {
+  return json(`${BASE}/preproc/runs/${encodeURIComponent(runId)}`)
+}
+
+export async function cancelPreprocRun(runId: string): Promise<{ cancelled: boolean }> {
+  return json(`${BASE}/preproc/runs/${encodeURIComponent(runId)}/cancel`, {
+    method: 'POST',
   })
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -213,6 +213,22 @@ export interface PreprocConfigDetail {
   yaml_string: string
 }
 
+export interface PreprocRunSummary {
+  run_id: string
+  subject: string
+  backend: string
+  status: 'running' | 'done' | 'failed' | 'cancelled' | 'lost' | string
+  pid: number | null
+  started_at: number
+  finished_at: number
+  is_reattached: boolean
+  manifest_path: string | null
+  error: string | null
+  config_path: string | null
+  log_path: string | null
+  log_tail?: string
+}
+
 export interface StageStatus {
   status: 'pending' | 'running' | 'done' | 'warning' | 'failed'
   detail: string

--- a/frontend/src/components/preproc/InFlightRuns.tsx
+++ b/frontend/src/components/preproc/InFlightRuns.tsx
@@ -1,0 +1,199 @@
+/** In-flight panel — lists preproc runs, lets user reattach or cancel. */
+import { useEffect } from 'react'
+import type { CSSProperties } from 'react'
+import { usePreprocStore } from '../../stores/preproc-store'
+
+const panelStyle: CSSProperties = {
+  backgroundColor: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  borderRadius: 8,
+  padding: '14px 18px',
+  marginBottom: 12,
+}
+
+const headerStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: 10,
+}
+
+const titleStyle: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  color: 'var(--text-secondary)',
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+}
+
+const refreshBtn: CSSProperties = {
+  padding: '4px 10px',
+  fontSize: 10,
+  fontWeight: 600,
+  fontFamily: 'inherit',
+  border: '1px solid var(--border)',
+  borderRadius: 4,
+  cursor: 'pointer',
+  backgroundColor: 'transparent',
+  color: 'var(--text-secondary)',
+}
+
+const rowStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr 80px 80px 110px 90px 80px',
+  alignItems: 'center',
+  gap: 8,
+  padding: '6px 0',
+  borderTop: '1px solid var(--border)',
+  fontSize: 11,
+}
+
+const emptyStyle: CSSProperties = {
+  fontSize: 11,
+  color: 'var(--text-secondary)',
+  fontStyle: 'italic',
+  padding: '6px 0',
+}
+
+function statusColor(status: string): string {
+  switch (status) {
+    case 'running': return 'var(--accent-cyan)'
+    case 'done': return 'var(--accent-green)'
+    case 'failed':
+    case 'cancelled':
+    case 'lost': return 'var(--accent-red)'
+    default: return 'var(--text-secondary)'
+  }
+}
+
+function formatElapsed(startedAt: number, finishedAt: number, isRunning: boolean): string {
+  const end = isRunning ? Date.now() / 1000 : finishedAt
+  const s = Math.max(0, end - startedAt)
+  if (s < 60) return `${Math.round(s)}s`
+  if (s < 3600) return `${Math.floor(s / 60)}m ${Math.round(s % 60)}s`
+  return `${Math.floor(s / 3600)}h ${Math.round((s % 3600) / 60)}m`
+}
+
+function formatWhen(ts: number): string {
+  if (!ts) return '-'
+  const d = new Date(ts * 1000)
+  return d.toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  })
+}
+
+const btn = (variant: 'link' | 'danger'): CSSProperties => ({
+  padding: '3px 8px',
+  fontSize: 10,
+  fontWeight: 600,
+  fontFamily: 'inherit',
+  border: `1px solid ${variant === 'danger' ? 'var(--accent-red)' : 'var(--accent-cyan)'}`,
+  borderRadius: 4,
+  cursor: 'pointer',
+  backgroundColor: 'transparent',
+  color: variant === 'danger' ? 'var(--accent-red)' : 'var(--accent-cyan)',
+})
+
+interface InFlightRunsProps {
+  // Show only `running` when true; show everything otherwise.
+  runningOnly?: boolean
+}
+
+export function InFlightRuns({ runningOnly = false }: InFlightRunsProps) {
+  const {
+    preprocRuns,
+    preprocRunsLoading,
+    loadPreprocRuns,
+    attachToRun,
+    cancelRun,
+    running: liveRunning,
+  } = usePreprocStore()
+
+  useEffect(() => {
+    loadPreprocRuns()
+  }, [loadPreprocRuns])
+
+  // Auto-refresh every 5s while any run is marked running
+  useEffect(() => {
+    const hasLive = preprocRuns.some((r) => r.status === 'running')
+    if (!hasLive && !liveRunning) return
+    const id = setInterval(() => loadPreprocRuns(), 5000)
+    return () => clearInterval(id)
+  }, [preprocRuns, liveRunning, loadPreprocRuns])
+
+  const visible = runningOnly
+    ? preprocRuns.filter((r) => r.status === 'running')
+    : preprocRuns
+
+  const title = runningOnly ? 'In Flight' : 'Recent Runs'
+  const count = visible.length
+
+  return (
+    <div style={panelStyle}>
+      <div style={headerStyle}>
+        <span style={titleStyle}>{title} ({count})</span>
+        <button style={refreshBtn} onClick={() => loadPreprocRuns()}>
+          {preprocRunsLoading ? '...' : 'Refresh'}
+        </button>
+      </div>
+      {visible.length === 0 && (
+        <div style={emptyStyle}>
+          {runningOnly ? 'No running preprocessing jobs.' : 'No recent runs.'}
+        </div>
+      )}
+      {visible.map((r) => {
+        const isRunning = r.status === 'running'
+        return (
+          <div key={r.run_id} style={rowStyle}>
+            <div>
+              <div style={{ fontFamily: 'monospace', color: 'var(--text-primary)', fontWeight: 600 }}>
+                {r.subject}
+                {r.is_reattached && (
+                  <span style={{ marginLeft: 8, fontSize: 9, color: 'var(--accent-yellow, #e2a832)', fontWeight: 600 }}>
+                    REATTACHED
+                  </span>
+                )}
+              </div>
+              <div style={{ fontSize: 10, color: 'var(--text-secondary)', fontFamily: 'monospace' }}>
+                {r.run_id} · {r.backend}{r.pid ? ` · pid ${r.pid}` : ''}
+              </div>
+            </div>
+            <div style={{ color: statusColor(r.status), fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+              {r.status}
+            </div>
+            <div style={{ color: 'var(--text-secondary)' }}>
+              {formatElapsed(r.started_at, r.finished_at, isRunning)}
+            </div>
+            <div style={{ color: 'var(--text-secondary)' }}>
+              {formatWhen(r.started_at)}
+            </div>
+            <div>
+              {isRunning && (
+                <button
+                  style={btn('link')}
+                  onClick={() => attachToRun(r.run_id, r.started_at)}
+                >
+                  Watch
+                </button>
+              )}
+            </div>
+            <div>
+              {isRunning && (
+                <button
+                  style={btn('danger')}
+                  onClick={() => {
+                    if (confirm(`Cancel run for ${r.subject}?`)) {
+                      cancelRun(r.run_id).catch((e) => alert(String(e)))
+                    }
+                  }}
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/preproc/PreprocConfigBrowser.tsx
+++ b/frontend/src/components/preproc/PreprocConfigBrowser.tsx
@@ -3,10 +3,13 @@ import { useEffect } from 'react'
 import type { CSSProperties } from 'react'
 import { usePreprocStore } from '../../stores/preproc-store'
 import { PreprocProgress } from './PreprocProgress'
+import { InFlightRuns } from './InFlightRuns'
 
 const containerStyle: CSSProperties = {
   display: 'flex',
-  height: 'calc(100vh - 48px - 80px)',
+  // Leave headroom for the tab bar + in-flight panel.
+  height: 'calc(100vh - 48px - 200px)',
+  minHeight: 320,
   backgroundColor: 'var(--bg-card)',
   border: '1px solid var(--border)',
   borderRadius: 8,
@@ -185,6 +188,7 @@ export function PreprocConfigBrowser() {
 
   return (
     <>
+      <InFlightRuns />
       <div style={containerStyle}>
         <div style={sidebarStyle}>
           <div style={sidebarHeader}>

--- a/frontend/src/stores/preproc-store.ts
+++ b/frontend/src/stores/preproc-store.ts
@@ -9,6 +9,7 @@ import type {
   ConfigSummary,
   PreprocConfigSummary,
   PreprocConfigDetail,
+  PreprocRunSummary,
 } from '../api/types'
 import {
   fetchPreprocBackends,
@@ -24,6 +25,8 @@ import {
   fetchPreprocConfigs,
   fetchPreprocConfigDetail,
   runPreprocConfigFile,
+  fetchPreprocRuns,
+  cancelPreprocRun,
 } from '../api/client'
 
 type Tab = 'backends' | 'manifests' | 'collect' | 'run' | 'configs'
@@ -52,6 +55,10 @@ interface PreprocState {
   selectedPreprocConfig: PreprocConfigDetail | null
   selectedPreprocConfigLoading: boolean
 
+  // In-flight + recent runs
+  preprocRuns: PreprocRunSummary[]
+  preprocRunsLoading: boolean
+
   // Collect
   collectResult: CollectResult | null
   collecting: boolean
@@ -79,6 +86,9 @@ interface PreprocState {
   loadPreprocConfigs: () => Promise<void>
   selectPreprocConfig: (filename: string) => Promise<void>
   runPreprocConfig: (filename: string) => Promise<void>
+  loadPreprocRuns: (includeFinished?: boolean) => Promise<void>
+  attachToRun: (runId: string, startedAt?: number) => void
+  cancelRun: (runId: string) => Promise<void>
   clearRun: () => void
   clearCollect: () => void
 }
@@ -102,6 +112,9 @@ export const usePreprocStore = create<PreprocState>((set, get) => ({
   preprocConfigsLoading: false,
   selectedPreprocConfig: null,
   selectedPreprocConfigLoading: false,
+
+  preprocRuns: [],
+  preprocRunsLoading: false,
 
   collectResult: null,
   collecting: false,
@@ -273,6 +286,54 @@ export const usePreprocStore = create<PreprocState>((set, get) => ({
       }
     } catch (e) {
       set({ running: false, runError: String(e) })
+    }
+  },
+
+  loadPreprocRuns: async (includeFinished: boolean = true) => {
+    set({ preprocRunsLoading: true })
+    try {
+      const runs = await fetchPreprocRuns(includeFinished)
+      set({ preprocRuns: runs, preprocRunsLoading: false })
+    } catch {
+      set({ preprocRunsLoading: false })
+    }
+  },
+
+  attachToRun: (runId, startedAt) => {
+    // Open a WebSocket to a running job. Used for reattached runs or
+    // clicking into an active run from the In-Flight panel.
+    set({
+      running: true, runError: null, runEvents: [],
+      runStartTime: startedAt ? startedAt * 1000 : Date.now(),
+      runId, configErrors: null,
+    })
+    const ws = connectPreprocWs(runId)
+    ws.onmessage = (msg) => {
+      const event: PreprocEvent = JSON.parse(msg.data)
+      set((s) => ({ runEvents: [...s.runEvents, event] }))
+      if (event.event === 'done' || event.event === 'failed' || event.event === 'cancelled') {
+        ws.close()
+        set({
+          running: false,
+          runError: event.event === 'failed' ? (event.error || 'failed') : null,
+        })
+        get().rescan()
+        get().loadPreprocRuns()
+      }
+    }
+    ws.onerror = () => {
+      set({ running: false, runError: 'WebSocket connection failed' })
+    }
+  },
+
+  cancelRun: async (runId) => {
+    try {
+      await cancelPreprocRun(runId)
+      get().loadPreprocRuns()
+    } catch (e) {
+      // Leave the caller to surface; still refresh the list.
+      get().loadPreprocRuns()
+      throw e
     }
   },
 


### PR DESCRIPTION
## Summary

Implements the proposal in \`devdocs/proposals/infrastructure/detach-reattach-long-runs.md\`. Long fmriprep jobs no longer die when the server dies — they're spawned detached, persisted to \`~/.fmriflow/runs/{run_id}/\`, and reattached when the server starts back up.

Stacks on top of #54. Rebase to \`dev\` when that lands.

### What changes for the user

- Kick off a fmriprep run, close the browser, restart the server. The job keeps going. Open the dashboard → **Preprocessing → Configs** tab → the run shows up in a new **In Flight** panel with a \`REATTACHED\` tag and streams live again.
- Cancel button in the panel → \`SIGTERM\` the process group, \`SIGKILL\` after 5s.
- \`curl http://localhost:8000/api/preproc/runs\` lists everything (in-memory + on-disk history).

### What changes in the code

- **\`fmriflow/server/services/run_registry.py\`** (new) — filesystem-backed registry; one \`state.json\` + \`stdout.log\` per run.
- **\`fmriflow/server/services/preproc_manager.py\`** — rewired: fmriprep goes through a detached-spawn + log-tailer path; other backends stay in-process (custom, bids_app). Startup scans the registry, reattaches live runs, and marks dead ones \`lost\`.
- **\`fmriflow/preproc/backends/fmriprep.py\`** — new \`spawn(config, log_path)\` that returns a Popen with \`start_new_session=True\` and stdout redirected to the log file. The existing \`run()\` wraps it for blocking CLI use.
- **\`fmriflow/server/routes/preproc.py\`** — \`GET /preproc/runs\`, \`GET /preproc/runs/{run_id}\`, \`POST /preproc/runs/{run_id}/cancel\`.
- **Frontend** — \`InFlightRuns\` component, API client functions, store actions (\`loadPreprocRuns\`, \`attachToRun\`, \`cancelRun\`).
- **Docs** — preprocessing.md gets a "Long-running jobs" section; web-ui.md notes the new panel.

### Test plan

- [x] Backend imports cleanly; all three new routes register.
- [x] TypeScript type-check passes.
- [x] End-to-end detach/reattach simulation (\`sleep 3\` stand-in for fmriprep): new \`PreprocManager\` on a pre-populated registry picks up the PID as \`running\`, transitions to \`failed\` when the subprocess dies without leaving a fmriprep report.
- [x] Real fmriprep run: kick off via Configs tab, kill the server mid-run, restart, verify the run appears in In Flight with REATTACHED and continues streaming.
- [x] Cancel button actually tears down the process group (check with \`pgrep -f fmriprep\`).
- [x] mkdocs build passes.

### Caveats

- **Only fmriprep is detached** this round. Custom and bids_app backends still die with the server. Symmetric plumbing, but I didn't want to scope-creep this PR.
- **Exit code unknown on reattach.** We never attached \`waitpid\` to the detached subprocess after a server restart, so we can't observe its exit code. Outcome is inferred from \`sub-{subject}*.html\` in the output dir. For v1 this is fine since fmriprep's contract is "report exists iff run succeeded."
- **Docker deploys** need \`~/.fmriflow\` bind-mounted to the host or runs are lost on container restart.

### Not in this PR (follow-up work)

- Analysis \`RunManager\` gets the same treatment (the plumbing is identical).
- Stage inference from fmriprep log text (e.g. "Finished processing session 01") — currently every log line is a generic \`log\` event.
- Prune / retention for the runs directory.