### PR TITLE
Live nipype monitoring + Structural QC + Workflows polish

### DIFF
--- a/docs/guide/post-preproc.md
+++ b/docs/guide/post-preproc.md
@@ -57,6 +57,37 @@ Outputs land at `{output_dir}/{run_id}/<node_id>/` with a top-level
 `post_preproc_manifest.json` recording params, inputs, outputs, and
 per-node duration for every node that executed.
 
+## Workflows & subworkflows
+
+Once you have a graph that does something useful, click **Save workflow** in
+the builder's top bar. The graph is written to
+`~/.fmriflow/post_preproc_workflows/<name>.yaml` along with auto-derived
+`inputs:` and `outputs:` — every unwired input handle and every
+unconsumed output handle becomes a workflow-level port. Edit the YAML by
+hand later to rename or trim ports.
+
+**Load** brings a saved graph back onto the canvas with all node
+positions, parameters, and edges preserved.
+
+**+ Subworkflow** drops a saved workflow as a single node in the current
+graph. The wrapper node's left/right handles are the workflow's declared
+`inputs` and `outputs`. Wire it just like any built-in node — the runner
+recurses into the inner graph at run time. Cycles
+(`wf A → embeds → wf A`) raise an error rather than recursing forever.
+
+## Iterating over runs
+
+To run a node once per `run_name` in the source manifest (nipype's
+`MapNode`), select the node and tick **Iterate over runs from source
+manifest**. The runner expands the iteration over every `runs[*]` in the
+upstream `PreprocManifest`, writes one output sub-directory per
+iteration (`<node_id>/000/`, `<node_id>/001/`, …), and records the list
+of outputs in the post-preproc manifest.
+
+v1 limitation: iterating nodes are sinks — they can't have outgoing
+edges. If you need to feed mapped outputs into a downstream node, use a
+saved subworkflow as the iterating unit instead.
+
 ## API
 
 | Method | Path | Purpose |

--- a/docs/guide/post-preproc.md
+++ b/docs/guide/post-preproc.md
@@ -88,6 +88,34 @@ v1 limitation: iterating nodes are sinks — they can't have outgoing
 edges. If you need to feed mapped outputs into a downstream node, use a
 saved subworkflow as the iterating unit instead.
 
+## Use as a workflow stage
+
+A saved post-preproc workflow can run as a stage of the overarching
+fMRIflow workflow (see [Workflows](workflows.md)). Add a `post_preproc`
+entry to the workflow's `stages:` list pointing at a small stage YAML:
+
+```yaml
+# experiments/post_preproc/smooth_AN.yaml
+graph: smooth_then_mask           # name of a saved post-preproc workflow
+subject: sub01
+source_manifest_path: ./derivatives/sub-01/preproc_manifest.json
+output_dir: ./derivatives/post_preproc/sub01
+bindings:
+  in_file:                        # name of an exposed workflow input
+    source_run: r1                # take this run's output_file from preproc
+  # any_other_input:
+  #   path: /abs/file.nii.gz      # or pin to a literal path
+```
+
+`bindings` translate the workflow's exposed `inputs:` ports into concrete
+files. Each key looks up the saved workflow's `inputs[K] = {from:
+<inner_id>.<inner_handle>}` declaration and injects a literal `_inputs`
+value on that inner node — same mechanism the side panel uses, just
+declared up front in YAML so a workflow run can press one button.
+
+The Workflows view renders the post-preproc stage as a green
+"Post-preproc" block between Preproc/Autoflatten and Analysis.
+
 ## API
 
 | Method | Path | Purpose |

--- a/docs/guide/post-preproc.md
+++ b/docs/guide/post-preproc.md
@@ -1,0 +1,69 @@
+# Post-Preprocessing (nipype-style nodes)
+
+After fmriprep finishes, you often want to run a few more steps —
+smoothing, masking, custom transforms — before handing volumes off to
+analysis. The **Post-preproc** view lets you compose those steps as a
+graph of nipype-style nodes, validate it, and run it against a subject's
+preproc manifest.
+
+## Open it
+
+Sidebar → **Preprocessing** → **Post-preproc (nipype)**.
+
+## Composing a graph
+
+The view has three panels:
+
+- **Palette** (left): every registered nipype node. Click one to drop it
+  on the canvas.
+- **Canvas** (center): drag nodes to reposition, drag from a node's right
+  port to another node's left port to wire `out_file` → `in_file`.
+- **Parameters** (right): click a node on the canvas to edit its params.
+
+A typical graph starts with a **`preproc_run` source node** (pick a
+`run_name` from the upstream manifest) and chains downstream nodes:
+
+```
+preproc_run → smooth → mask_apply
+```
+
+## Built-in nodes
+
+| Node | Inputs | Outputs | Params |
+|------|--------|---------|--------|
+| `preproc_run` | — | `out_file` | `run_name` |
+| `smooth` | `in_file` | `out_file` | `fwhm` (mm) |
+| `mask_apply` | `in_file`, `mask_file` | `out_file` | `mask_path` (fallback) |
+
+Authoring your own node is the same workflow as any other module — open
+the **Editor**, pick category **nipype_nodes**, write a class with
+`INPUTS`, `OUTPUTS`, `PARAM_SCHEMA`, and a `run(inputs, out_dir, params)`
+method.
+
+## Running
+
+Top bar:
+
+- **subject** — string ID for record-keeping (the source manifest is the
+  authoritative input).
+- **source preproc_manifest.json path** — the upstream manifest produced
+  by fmriprep / preproc.
+- **output_dir** — where the post-preproc run writes its outputs and
+  `post_preproc_manifest.json`.
+- **Validate** — server-side check (DAG, handle names, known node types).
+- **Run** — start a threaded run; the panel polls until done.
+
+Outputs land at `{output_dir}/{run_id}/<node_id>/` with a top-level
+`post_preproc_manifest.json` recording params, inputs, outputs, and
+per-node duration for every node that executed.
+
+## API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/api/post-preproc/nodes` | list registered nodes + schemas |
+| `POST` | `/api/post-preproc/graphs/validate` | validate a ReactFlow graph |
+| `POST` | `/api/post-preproc/run` | start a run |
+| `GET`  | `/api/post-preproc/runs` | list known runs |
+| `GET`  | `/api/post-preproc/runs/{run_id}` | one run + manifest if done |
+| `GET`  | `/api/post-preproc/manifests/{subject}?output_dir=…` | read a manifest from disk |

--- a/docs/guide/structural-qc.md
+++ b/docs/guide/structural-qc.md
@@ -7,23 +7,61 @@ small reviewer surface for exactly that.
 
 ## Where to find it
 
-Open the **Workflows** view, pick a subject's preproc manifest, and scroll
-to the **Structural QC** section under the Runs table. The colored dot in
-the section header reflects the current status.
+Three entry points to the same panel:
+
+- **Preprocessing → Preproc** → click a subject's manifest → scroll to
+  the **Structural QC** section under the Runs table.
+- **Workflows → Workflow run detail.** Once the preproc stage finishes
+  (`status: done`), the Preproc block in the workflow graph gains a
+  **Structural QC →** button — clicking it opens the panel as a modal
+  for the subject that just preprocessed.
+- **Preprocessing → QC Reviews** → click a row to reopen the panel
+  for any subject that already has a saved review.
 
 ## What you can do
 
-- **Show fmriprep report** — toggles the fmriprep-generated HTML report
-  inline. This is usually enough to decide on routine subjects.
-- **Show 3D viewer** — opens an embedded [niivue](https://github.com/niivue/niivue)
-  canvas with `mri/T1.mgz` plus the left/right pial surfaces overlaid.
-  Drag to rotate; scroll to zoom.
-- **Pick a status** — *Pending*, *Approve*, *Needs edits*, *Rejected*.
+### Inspect the images
+
+- **Show fmriprep report** — toggles the fmriprep HTML report inline
+  (skull-strip overlay, T1↔surface alignment, segmentation slices,
+  motion summaries). This alone is enough to decide on routine subjects.
+- **Show 3D viewer** — opens an embedded
+  [niivue](https://github.com/niivue/niivue) canvas with `mri/T1.mgz`
+  plus FreeSurfer surfaces. Drag to rotate; scroll to zoom. The viewer
+  has a toolbar with:
+    - **View**: *Multi* (default — multi-planar slice view), *Axial*,
+      *Coronal*, *Sagittal*, *3D* render.
+    - **Volume on / off**: hide the T1 in 3D so the cortex meshes are
+      unobstructed.
+    - **Surfaces** (multi-toggle): *pial* (green), *white* (red),
+      *inflated* (blue) — colour-coded to match freeview's defaults
+      (pial=green, white=red). Toggle any combination on at once;
+      *clear* hides them all.
+    - **X-ray** slider (0..1): drives niivue's global mesh-transparency
+      pass. Lower values = outer mesh wins (opaque); higher values =
+      inner mesh shows through. Useful when both pial and white are on
+      and you want to see one through the other in 3D.
+    - **⤢ Fullscreen**: pop the canvas out to a `position: fixed`
+      overlay. Niivue stays mounted across the toggle, so the volume
+      isn't re-downloaded.
+- **Copy freeview command** *(only when status = Needs edits)* — for
+  the cases the in-browser viewer can't handle (segmentation editing
+  etc.), copies a ready-made `freeview` invocation to your clipboard,
+  pre-loading T1, the brainmask, aseg, and pial/white surfaces. Files
+  that don't exist on disk are silently skipped.
+
+### Approve / reject the run
+
+- **Pick a status** — *Pending* (the default for a never-reviewed
+  subject), *Approve*, *Needs edits*, or *Rejected*. The chosen status
+  is reflected by the coloured dot in the section header.
 - **Reviewer + notes** — free text, saved alongside the status.
-- **Copy freeview command** *(only when status = Needs edits)* — copies a
-  ready-made `freeview` invocation to your clipboard, pre-loading T1, the
-  brainmask, aseg, and pial/white surfaces. Files that don't exist on disk
-  are silently skipped.
+  Anything you type sticks with the YAML on disk so a future reviewer
+  can pick up where you left off.
+- **Save review** — writes the (status, reviewer, notes, timestamp,
+  freeview-command-used) tuple to disk. Both the **Preprocessing →
+  Preproc** sidebar pill and the **QC Reviews** view pick up the
+  change on next reload.
 
 The intended workflow:
 

--- a/docs/guide/structural-qc.md
+++ b/docs/guide/structural-qc.md
@@ -12,9 +12,11 @@ Three entry points to the same panel:
 - **Preprocessing → Preproc** → click a subject's manifest → scroll to
   the **Structural QC** section under the Runs table.
 - **Workflows → Workflow run detail.** Once the preproc stage finishes
-  (`status: done`), the Preproc block in the workflow graph gains a
-  **Structural QC →** button — clicking it opens the panel as a modal
-  for the subject that just preprocessed.
+  (`status: done`), the Preproc block in the workflow graph gains two
+  pill buttons: **Structural QC →** opens this panel as a modal for
+  the subject that just preprocessed, and **View DAG →** opens the
+  live nipype DAG modal (works on already-finished runs too — empty
+  state shown if the run has no parsed events).
 - **Preprocessing → QC Reviews** → click a row to reopen the panel
   for any subject that already has a saved review.
 

--- a/docs/guide/structural-qc.md
+++ b/docs/guide/structural-qc.md
@@ -34,6 +34,25 @@ The intended workflow:
    `recon-all -autorecon2`.
 4. Come back and flip the status to **Approve**.
 
+## Reviewing across many subjects
+
+Two surfaces help you find and act on saved reviews:
+
+- **Status pill in the Preproc manifest list.** Sidebar →
+  **Preprocessing → Preproc**. Each manifest row shows a small
+  pill on the right reflecting the saved review status
+  (*pending / approved / needs edits / rejected*).
+- **QC Reviews view.** Sidebar → **Preprocessing → QC Reviews**.
+  Lists every saved review across every dataset (newest first).
+  Filter chips at the top — *All / Pending / Approved / Needs
+  edits / Rejected* — show live counts. Clicking a row opens the
+  same Structural QC panel for that subject in a modal; closing
+  the modal reloads the list so any edits show up immediately.
+
+The view also surfaces the underlying YAMLs you'd otherwise have to
+grep on disk: dataset, reviewer, last-saved timestamp, notes, and a
+truncated notes preview (hover to see the full text).
+
 ## Where reviews are stored
 
 Each review is one YAML file at:
@@ -50,6 +69,7 @@ For scripts and CI:
 
 | Method | Path | Purpose |
 |--------|------|---------|
+| `GET`  | `/api/structural-qc/reviews` | list all reviews across all datasets (optional `?dataset=` filter) |
 | `GET`  | `/api/preproc/subjects/{subject}/structural-qc` | current review (or default *pending*) |
 | `POST` | `/api/preproc/subjects/{subject}/structural-qc` | save a review |
 | `GET`  | `/api/preproc/subjects/{subject}/structural-qc/freeview-command` | freeview command for the subject |

--- a/docs/guide/structural-qc.md
+++ b/docs/guide/structural-qc.md
@@ -1,0 +1,61 @@
+# Structural QC Review
+
+After fmriprep finishes the structural side of preprocessing (skull strip,
+T1↔surface alignment, FreeSurfer segmentation), you usually want to *look
+at it* before letting any functional analysis depend on it. fMRIflow has a
+small reviewer surface for exactly that.
+
+## Where to find it
+
+Open the **Workflows** view, pick a subject's preproc manifest, and scroll
+to the **Structural QC** section under the Runs table. The colored dot in
+the section header reflects the current status.
+
+## What you can do
+
+- **Show fmriprep report** — toggles the fmriprep-generated HTML report
+  inline. This is usually enough to decide on routine subjects.
+- **Show 3D viewer** — opens an embedded [niivue](https://github.com/niivue/niivue)
+  canvas with `mri/T1.mgz` plus the left/right pial surfaces overlaid.
+  Drag to rotate; scroll to zoom.
+- **Pick a status** — *Pending*, *Approve*, *Needs edits*, *Rejected*.
+- **Reviewer + notes** — free text, saved alongside the status.
+- **Copy freeview command** *(only when status = Needs edits)* — copies a
+  ready-made `freeview` invocation to your clipboard, pre-loading T1, the
+  brainmask, aseg, and pial/white surfaces. Files that don't exist on disk
+  are silently skipped.
+
+The intended workflow:
+
+1. Inspect the subject in the browser.
+2. If something is wrong, mark **Needs edits** and click **Copy freeview
+   command**.
+3. Paste it into a terminal, fix the surfaces in freeview, then re-run
+   `recon-all -autorecon2`.
+4. Come back and flip the status to **Approve**.
+
+## Where reviews are stored
+
+Each review is one YAML file at:
+
+    ~/.fmriflow/structural_qc/<dataset>/<subject>.yaml
+
+The format is stable and easy to grep — you can list all approved subjects
+in a dataset with a simple shell loop, or check it into a separate repo if
+you want a review log.
+
+## API
+
+For scripts and CI:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/api/preproc/subjects/{subject}/structural-qc` | current review (or default *pending*) |
+| `POST` | `/api/preproc/subjects/{subject}/structural-qc` | save a review |
+| `GET`  | `/api/preproc/subjects/{subject}/structural-qc/freeview-command` | freeview command for the subject |
+| `GET`  | `/api/preproc/subjects/{subject}/structural-qc/report` | fmriprep HTML report |
+| `GET`  | `/api/preproc/subjects/{subject}/structural-qc/fs-file?rel=mri/T1.mgz` | a single FreeSurfer file (whitelisted suffixes only) |
+
+The FS-file endpoint is what powers the niivue viewer; it refuses paths
+that escape the FreeSurfer subject directory and only serves a small set
+of suffixes (`.mgz`, `.pial`, `.white`, `.inflated`, `.nii.gz`, etc.).

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -21,11 +21,13 @@ workflow:
       config: experiments/preproc/fmriprep_AN.yaml
     - stage: autoflatten
       config: experiments/autoflatten/AN.yaml
+    - stage: post_preproc
+      config: experiments/post_preproc/smooth_AN.yaml
     - stage: analysis
       config: experiments/mkr_AN.yaml
 ```
 
-- `stages[].stage` must be one of `convert`, `preproc`, `autoflatten`, `analysis`.
+- `stages[].stage` must be one of `convert`, `preproc`, `autoflatten`, `post_preproc`, `analysis`.
 - `stages[].config` is a path to an existing stage YAML. Relative paths resolve against the workflow YAML's parent dir first, then against the server's cwd.
 - Stages run **in list order**, one at a time, stop-on-first-failure.
 - You can omit any stage — a workflow can be just `preproc → analysis` if convert isn't needed.
@@ -37,6 +39,7 @@ The workflow config store scans `./experiments/workflows/`. Same pattern as the 
 - `./experiments/preproc/`
 - `./experiments/convert/`
 - `./experiments/autoflatten/`
+- `./experiments/post_preproc/` — see [Post-preproc stage YAML](post-preproc.md#use-as-a-workflow-stage)
 - `./experiments/workflows/` — **this page**
 
 ## Running

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -111,6 +111,23 @@ status-callback shim is sketched in
 `devdocs/proposals/frontend/live-fmriprep-node-monitoring.md` as a
 future v2.
 
+#### Drill-in: the live nipype DAG
+
+**Double-click** the Preproc block (when its strip has at least one
+node) to open a full-screen ReactFlow view of the live nipype graph,
+laid out top-to-bottom by `dagre`. Each leaf is a real nipype node
+(colored by status, with elapsed seconds); each parent is a virtual
+summary box for a sub-workflow that rolls up `running / done / failed`
+counts of its descendants.
+
+The modal polls the same `/api/preproc/runs/{run_id}/live` endpoint as
+the strip and re-lays out on each refresh. Once the run finishes, the
+DAG remains viewable from the saved JSONL — useful for postmortems on
+failed runs ("which sub-workflow blew up?"). v1 derives the DAG from
+the dotted node paths nipype prints, not from a real dependency graph
+— so it shows hierarchy, not data flow. A real-DAG view requires the
+status-callback shim in v2.
+
 ## How orchestration works
 
 The `WorkflowManager` runs one background thread per active workflow. For each stage it:

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -134,6 +134,24 @@ status-callback shim is sketched in
 `devdocs/proposals/frontend/live-fmriprep-node-monitoring.md` as a
 future v2.
 
+##### Status reconciliation: `completed_assumed`
+
+fmriprep's nipype prints the full dotted path on `[Node] Setting-up`
+but only the leaf on `[Node] Finished`. The strip pairs them with a
+per-leaf FIFO queue at parse time, and when the parent preproc run
+finishes (`state.json: status=done`) any node we never saw a terminal
+log line for is flipped to **`completed_assumed`** (rendered in a
+softer green with an `N assumed` count). Failed/cancelled runs leave
+the orphans as `running` so the failure context is preserved.
+
+Old runs from before the parser fix shipped can have their JSONL
+backfilled in place::
+
+    python scripts/backfill_nipype_events.py [--dry-run] PATH
+
+`PATH` is either the JSONL itself or a directory tree to walk; a
+`.bak` sidecar is written next to each rewritten file.
+
 #### Drill-in: the live nipype DAG
 
 **Double-click** the Preproc block (when its strip has at least one

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -75,6 +75,42 @@ curl http://localhost:8000/api/workflows/runs/workflow_abc123def456
 curl -X POST http://localhost:8000/api/workflows/runs/workflow_abc123def456/cancel
 ```
 
+### Live nipype-node monitoring (Preproc stage)
+
+When the Preproc stage runs **fmriprep**, the Workflows view tails its
+stdout for nipype's `[Node]` lines and surfaces a per-node status
+strip under the Preproc block. Each node renders as a small pill
+colored by status (cyan = running, green = ok, red = failed) and
+grouped by the top two segments of its workflow path
+(`fmriprep_wf.bold_preproc_wf`, `fmriprep_wf.sdc_estimate_wf`, …).
+
+The strip is **default-collapsed** with a one-line summary
+(`3 running / 47 done / 1 failed · 51 seen`); click the chevron to
+expand. Hovering a pill shows the full dotted node path and elapsed
+seconds.
+
+Behind the scenes:
+
+- `_LogTailer` already streams stdout line by line. Each line is
+  also fed to a small stateful parser
+  (`fmriflow/preproc/nipype_log.py::NipypeLogParser`) that emits
+  `node_start`, `node_done`, `node_fail` events.
+- Events are appended to
+  `~/.fmriflow/runs/{run_id}/nipype_events.jsonl`.
+- The frontend polls
+  `GET /api/preproc/runs/{run_id}/live` every 2 s while the stage
+  is running; the response includes a `nipype_status` block built
+  by re-parsing the JSONL.
+- The JSONL on disk is the source of truth, so the strip
+  rehydrates after a server restart / detach-reattach.
+
+This is **log-tailing only** — no fmriprep monkey-patching, no nipype
+plugin shim. If the log format ever drifts, unmatched lines are
+dropped and the rest of the strip keeps working. A richer
+status-callback shim is sketched in
+`devdocs/proposals/frontend/live-fmriprep-node-monitoring.md` as a
+future v2.
+
 ## How orchestration works
 
 The `WorkflowManager` runs one background thread per active workflow. For each stage it:

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -78,6 +78,26 @@ curl http://localhost:8000/api/workflows/runs/workflow_abc123def456
 curl -X POST http://localhost:8000/api/workflows/runs/workflow_abc123def456/cancel
 ```
 
+### Structural QC drill-in (Preproc stage)
+
+Once the Preproc stage finishes (`status: done`), the Preproc block
+gains a **Structural QC →** button. Clicking it opens the same
+reviewer panel that lives under the Preproc-manager manifest detail
+view, in a modal: fmriprep report, niivue T1 + pial viewer,
+Approve / Needs edits / Rejected status, and the *Copy freeview
+command* fallback. The modal looks up the subject from the
+preproc child run's summary, so it works whether the workflow ran
+to completion just now or hours ago.
+
+Manifest discovery: the panel relies on the Preproc manager
+finding the subject's manifest. The manager scans both:
+
+1. The configured `--derivatives-dir` (default `./derivatives`).
+2. The output dirs of every completed preproc run on the run
+   registry — so manifests written outside the configured
+   derivatives root (e.g. under `./testing/<study>/...`) are
+   discovered automatically without restarting the server.
+
 ### Live nipype-node monitoring (Preproc stage)
 
 When the Preproc stage runs **fmriprep**, the Workflows view tails its

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -152,6 +152,39 @@ backfilled in place::
 `PATH` is either the JSONL itself or a directory tree to walk; a
 `.bak` sidecar is written next to each rewritten file.
 
+#### Drill into a node's outputs
+
+**Click a leaf** in the live DAG to open a side drawer with that
+node's `work_dir` contents. fmriprep typically drops a handful of
+files per leaf — `command.txt`, `_inputs.pklz`, `_node.pklz`,
+`result_<leaf>.pklz`, intermediate NIfTIs, and any logs.
+
+The drawer renders each file by type:
+
+- `*.nii.gz`, `*.mgz` → niivue 3D viewer
+- `*.json`, `*.tsv`, `*.csv`, `*.txt`, `*.log`, `*.rst`,
+  `*.cfg` → inline `<pre>` (JSON pretty-printed)
+- `*.svg`, `*.png`, `*.jpg`, etc. → inline image
+- `*.html` → iframe
+- `*.pkl`, `*.pklz` → server-side `pickle.load` + JSON-safe
+  rendering. fmriprep's `result_*.pklz` files reference paths
+  inside the singularity container that don't exist on the host —
+  if pickle resurrection fails for that reason, the drawer shows
+  the error message; the file is still on disk.
+- Anything else → "Copy path" button
+
+Failed nodes also surface their `crash-*.txt` files at the top of
+the drawer (discovered under
+`{output_dir}/sub-{subject}/log/<ts>/crash-*` regardless of
+timestamp). API endpoints behind the drawer:
+
+- `GET /api/preproc/runs/{run_id}/node/{node_path:path}/files`
+  — list whitelisted artefacts + matching crash files.
+- `GET /api/preproc/runs/{run_id}/node/{node_path:path}/file?rel=…`
+  — serve a single file (suffix-whitelisted, safe-join).
+- `GET /api/preproc/runs/{run_id}/node/{node_path:path}/pickle?rel=…`
+  — load and JSON-encode a pickle.
+
 #### Drill-in: the live nipype DAG
 
 **Double-click** the Preproc block (when its strip has at least one

--- a/fmriflow/modules/__init__.py
+++ b/fmriflow/modules/__init__.py
@@ -68,3 +68,4 @@ def register_builtins(registry):
     import fmriflow.modules.nipype_nodes.source  # noqa: F401
     import fmriflow.modules.nipype_nodes.smooth  # noqa: F401
     import fmriflow.modules.nipype_nodes.mask_apply  # noqa: F401
+    import fmriflow.modules.nipype_nodes.subworkflow  # noqa: F401

--- a/fmriflow/modules/__init__.py
+++ b/fmriflow/modules/__init__.py
@@ -63,3 +63,8 @@ def register_builtins(registry):
     import fmriflow.modules.reporters.weights  # noqa: F401
     import fmriflow.modules.reporters.histogram  # noqa: F401
     import fmriflow.modules.reporters.webgl  # noqa: F401
+
+    # Post-fmriprep nipype-style nodes
+    import fmriflow.modules.nipype_nodes.source  # noqa: F401
+    import fmriflow.modules.nipype_nodes.smooth  # noqa: F401
+    import fmriflow.modules.nipype_nodes.mask_apply  # noqa: F401

--- a/fmriflow/modules/_decorators.py
+++ b/fmriflow/modules/_decorators.py
@@ -26,6 +26,7 @@ _preparation_steps: dict[str, type] = {}
 _analyzers: dict[str, type] = {}
 _models: dict[str, type] = {}
 _reporters: dict[str, type] = {}
+_nipype_nodes: dict[str, type] = {}
 
 
 # ── Decorator factories ──────────────────────────────────────────────────
@@ -50,3 +51,4 @@ preparation_step = _make_decorator(_preparation_steps)
 analyzer = _make_decorator(_analyzers)
 model = _make_decorator(_models)
 reporter = _make_decorator(_reporters)
+nipype_node = _make_decorator(_nipype_nodes)

--- a/fmriflow/modules/nipype_nodes/__init__.py
+++ b/fmriflow/modules/nipype_nodes/__init__.py
@@ -1,0 +1,13 @@
+"""Built-in post-fmriprep nipype-style nodes.
+
+Each node defines:
+  - ``name`` (registered via ``@nipype_node("name")``)
+  - ``INPUTS``: list of input handle names (e.g. ``["in_file"]``)
+  - ``OUTPUTS``: list of output handle names
+  - ``PARAM_SCHEMA``: dict for the UI/CLI form
+  - ``run(inputs, out_dir, params) -> dict[str, Path]``: produce outputs from inputs
+
+v1 is implemented in pure Python (nibabel + scipy) so it works without
+nipype installed. A future v2 may swap to nipype ``Workflow`` execution
+when the user opts into the optional ``[nipype]`` extra.
+"""

--- a/fmriflow/modules/nipype_nodes/mask_apply.py
+++ b/fmriflow/modules/nipype_nodes/mask_apply.py
@@ -1,0 +1,57 @@
+"""Apply a binary mask to a volume — zero out voxels outside the mask."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fmriflow.modules._decorators import nipype_node
+
+
+@nipype_node("mask_apply")
+class MaskApplyNode:
+    """Multiply ``in_file`` voxels by a binary mask."""
+
+    INPUTS = ["in_file", "mask_file"]
+    OUTPUTS = ["out_file"]
+
+    PARAM_SCHEMA: dict[str, Any] = {
+        "mask_path": {
+            "type": "str",
+            "default": "",
+            "description": (
+                "Optional explicit mask path (used if no mask_file edge is "
+                "connected)."
+            ),
+        },
+    }
+
+    def run(
+        self,
+        inputs: dict[str, Path],
+        out_dir: Path,
+        params: dict[str, Any],
+    ) -> dict[str, Path]:
+        import nibabel as nib
+        import numpy as np
+
+        in_file = Path(inputs["in_file"])
+        mask_path = inputs.get("mask_file") or params.get("mask_path") or ""
+        if not mask_path:
+            raise ValueError(
+                "mask_apply: requires either a mask_file edge or mask_path param"
+            )
+        mask_path = Path(mask_path)
+
+        img = nib.load(str(in_file))
+        mask = nib.load(str(mask_path)).get_fdata().astype(bool)
+        data = img.get_fdata()
+        if data.ndim == 4:
+            out = data * mask[..., None]
+        else:
+            out = data * mask
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{in_file.stem.replace('.nii', '')}_masked.nii.gz"
+        nib.Nifti1Image(out, img.affine, img.header).to_filename(str(out_path))
+        return {"out_file": out_path}

--- a/fmriflow/modules/nipype_nodes/smooth.py
+++ b/fmriflow/modules/nipype_nodes/smooth.py
@@ -1,0 +1,55 @@
+"""Spatial Gaussian smoothing of a 3D/4D NIfTI volume."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fmriflow.modules._decorators import nipype_node
+
+
+@nipype_node("smooth")
+class SmoothNode:
+    """Apply isotropic Gaussian smoothing with a given FWHM (mm)."""
+
+    INPUTS = ["in_file"]
+    OUTPUTS = ["out_file"]
+
+    PARAM_SCHEMA: dict[str, Any] = {
+        "fwhm": {
+            "type": "float",
+            "default": 5.0,
+            "min": 0.0,
+            "description": "Full-width at half-maximum of the Gaussian kernel (mm).",
+        },
+    }
+
+    def run(
+        self,
+        inputs: dict[str, Path],
+        out_dir: Path,
+        params: dict[str, Any],
+    ) -> dict[str, Path]:
+        import nibabel as nib
+        import numpy as np
+        from scipy.ndimage import gaussian_filter
+
+        fwhm = float(params.get("fwhm", 5.0))
+        in_file = Path(inputs["in_file"])
+        img = nib.load(str(in_file))
+        data = img.get_fdata()
+        # FWHM (mm) -> sigma (voxels) via voxel sizes from the affine.
+        zooms = img.header.get_zooms()[:3]
+        sigmas = [fwhm / (2.355 * z) for z in zooms]
+
+        if data.ndim == 4:
+            out = np.empty_like(data)
+            for t in range(data.shape[3]):
+                out[..., t] = gaussian_filter(data[..., t], sigma=sigmas)
+        else:
+            out = gaussian_filter(data, sigma=sigmas)
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{in_file.stem.replace('.nii', '')}_smooth-{fwhm:g}.nii.gz"
+        nib.Nifti1Image(out, img.affine, img.header).to_filename(str(out_path))
+        return {"out_file": out_path}

--- a/fmriflow/modules/nipype_nodes/source.py
+++ b/fmriflow/modules/nipype_nodes/source.py
@@ -1,0 +1,41 @@
+"""Source node — emits a file from the upstream PreprocManifest as input."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fmriflow.modules._decorators import nipype_node
+
+
+@nipype_node("preproc_run")
+class PreprocRunSourceNode:
+    """Source: emit a single run's preprocessed BOLD file from the upstream manifest.
+
+    Configure ``run_name`` to pick which run; the runner resolves the path
+    against the source ``PreprocManifest.output_dir``.
+    """
+
+    INPUTS: list[str] = []
+    OUTPUTS = ["out_file"]
+
+    PARAM_SCHEMA: dict[str, Any] = {
+        "run_name": {
+            "type": "str",
+            "default": "",
+            "description": "run_name from the source PreprocManifest's runs[].",
+        },
+    }
+
+    def run(
+        self,
+        inputs: dict[str, Path],
+        out_dir: Path,
+        params: dict[str, Any],
+    ) -> dict[str, Path]:
+        # The runner is responsible for resolving the source-manifest run and
+        # populating ``params['_resolved_path']`` before calling us.
+        resolved = params.get("_resolved_path")
+        if not resolved:
+            raise ValueError("preproc_run: runner did not resolve a source path")
+        return {"out_file": Path(resolved)}

--- a/fmriflow/modules/nipype_nodes/subworkflow.py
+++ b/fmriflow/modules/nipype_nodes/subworkflow.py
@@ -1,0 +1,46 @@
+"""Subworkflow placeholder node.
+
+The runner intercepts ``node.type == "subworkflow"`` and executes the
+saved workflow's inner graph, so this class' :meth:`run` is never invoked
+in practice. It exists to register the type in the module registry and
+provide ``PARAM_SCHEMA`` for the UI palette.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fmriflow.modules._decorators import nipype_node
+
+
+@nipype_node("subworkflow")
+class SubworkflowNode:
+    """Embed a saved post-preproc workflow as a single node.
+
+    Inputs and outputs are determined per-instance by the wrapped
+    workflow's ``inputs:`` and ``outputs:`` declarations and surfaced as
+    handles on the canvas.
+    """
+
+    INPUTS: list[str] = []
+    OUTPUTS: list[str] = []
+
+    PARAM_SCHEMA: dict[str, Any] = {
+        "workflow_name": {
+            "type": "str",
+            "default": "",
+            "description": "Name of a saved post-preproc workflow.",
+        },
+    }
+
+    def run(
+        self,
+        inputs: dict[str, Path],
+        out_dir: Path,
+        params: dict[str, Any],
+    ) -> dict[str, Path]:
+        raise RuntimeError(
+            "subworkflow.run() should never be called — the runner "
+            "intercepts subworkflow nodes. Did you call this directly?"
+        )

--- a/fmriflow/post_preproc/__init__.py
+++ b/fmriflow/post_preproc/__init__.py
@@ -1,0 +1,12 @@
+"""Post-fmriprep stage: compose nipype-style nodes against a PreprocManifest."""
+
+from fmriflow.post_preproc.manifest import PostPreprocManifest, PostPreprocConfig
+from fmriflow.post_preproc.graph import PostPreprocGraph, GraphNode, GraphEdge
+
+__all__ = [
+    "PostPreprocManifest",
+    "PostPreprocConfig",
+    "PostPreprocGraph",
+    "GraphNode",
+    "GraphEdge",
+]

--- a/fmriflow/post_preproc/graph.py
+++ b/fmriflow/post_preproc/graph.py
@@ -1,0 +1,176 @@
+"""Post-preproc graph: ReactFlow-shape nodes/edges with topology helpers.
+
+The shape mirrors what the frontend's @xyflow/react ships, so the graph
+round-trips between UI and server without reshaping::
+
+    {
+      "nodes": [
+        {"id": "n1", "type": "smooth", "data": {"params": {...}}, "position": {...}},
+        ...
+      ],
+      "edges": [
+        {"id": "e1", "source": "n1", "target": "n2",
+         "sourceHandle": "out_file", "targetHandle": "in_file"}
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class GraphNode:
+    id: str
+    type: str
+    params: dict[str, Any] = field(default_factory=dict)
+    position: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class GraphEdge:
+    id: str
+    source: str
+    target: str
+    source_handle: str = "out_file"
+    target_handle: str = "in_file"
+
+
+@dataclass
+class PostPreprocGraph:
+    nodes: list[GraphNode] = field(default_factory=list)
+    edges: list[GraphEdge] = field(default_factory=list)
+
+    # ── ReactFlow JSON round-trip ───────────────────────────────────
+
+    @classmethod
+    def from_reactflow(cls, data: dict[str, Any]) -> PostPreprocGraph:
+        nodes = []
+        for n in data.get("nodes", []):
+            d = n.get("data") or {}
+            nodes.append(
+                GraphNode(
+                    id=n["id"],
+                    type=n["type"],
+                    params=d.get("params", {}) or {},
+                    position=n.get("position", {}) or {},
+                )
+            )
+        edges = []
+        for e in data.get("edges", []):
+            edges.append(
+                GraphEdge(
+                    id=e["id"],
+                    source=e["source"],
+                    target=e["target"],
+                    source_handle=e.get("sourceHandle") or "out_file",
+                    target_handle=e.get("targetHandle") or "in_file",
+                )
+            )
+        return cls(nodes=nodes, edges=edges)
+
+    def to_reactflow(self) -> dict[str, Any]:
+        return {
+            "nodes": [
+                {
+                    "id": n.id,
+                    "type": n.type,
+                    "data": {"params": n.params},
+                    "position": n.position or {"x": 0, "y": 0},
+                }
+                for n in self.nodes
+            ],
+            "edges": [
+                {
+                    "id": e.id,
+                    "source": e.source,
+                    "target": e.target,
+                    "sourceHandle": e.source_handle,
+                    "targetHandle": e.target_handle,
+                }
+                for e in self.edges
+            ],
+        }
+
+    # ── topology ────────────────────────────────────────────────────
+
+    def topo_order(self) -> list[GraphNode]:
+        """Kahn's algorithm. Raises ValueError on cycles."""
+        in_degree: dict[str, int] = {n.id: 0 for n in self.nodes}
+        adj: dict[str, list[str]] = {n.id: [] for n in self.nodes}
+        for e in self.edges:
+            if e.target in in_degree:
+                in_degree[e.target] += 1
+            if e.source in adj:
+                adj[e.source].append(e.target)
+
+        queue = [nid for nid, d in in_degree.items() if d == 0]
+        ordered: list[str] = []
+        while queue:
+            nid = queue.pop(0)
+            ordered.append(nid)
+            for nxt in adj.get(nid, []):
+                in_degree[nxt] -= 1
+                if in_degree[nxt] == 0:
+                    queue.append(nxt)
+
+        if len(ordered) != len(self.nodes):
+            raise ValueError("Graph has a cycle")
+
+        by_id = {n.id: n for n in self.nodes}
+        return [by_id[i] for i in ordered]
+
+    def predecessors(self, node_id: str) -> list[GraphEdge]:
+        """All edges that feed into node_id."""
+        return [e for e in self.edges if e.target == node_id]
+
+    # ── validation ──────────────────────────────────────────────────
+
+    def validate_against(self, node_specs: dict[str, Any]) -> list[str]:
+        """Return a list of error strings; empty if valid.
+
+        ``node_specs`` maps node-type name -> a class with INPUTS/OUTPUTS lists.
+        """
+        errors: list[str] = []
+        seen_ids: set[str] = set()
+        for n in self.nodes:
+            if n.id in seen_ids:
+                errors.append(f"Duplicate node id: {n.id}")
+            seen_ids.add(n.id)
+            if n.type not in node_specs:
+                errors.append(f"Unknown node type: {n.type!r} (id={n.id})")
+
+        ids = {n.id for n in self.nodes}
+        for e in self.edges:
+            if e.source not in ids:
+                errors.append(f"Edge {e.id} references unknown source {e.source!r}")
+            if e.target not in ids:
+                errors.append(f"Edge {e.id} references unknown target {e.target!r}")
+            tnode = next((n for n in self.nodes if n.id == e.target), None)
+            if tnode and tnode.type in node_specs:
+                spec = node_specs[tnode.type]
+                inputs = getattr(spec, "INPUTS", [])
+                if e.target_handle not in inputs:
+                    errors.append(
+                        f"Edge {e.id}: target handle {e.target_handle!r} "
+                        f"not in {tnode.type}.INPUTS={inputs}"
+                    )
+            snode = next((n for n in self.nodes if n.id == e.source), None)
+            if snode and snode.type in node_specs:
+                spec = node_specs[snode.type]
+                outputs = getattr(spec, "OUTPUTS", [])
+                if e.source_handle not in outputs:
+                    errors.append(
+                        f"Edge {e.id}: source handle {e.source_handle!r} "
+                        f"not in {snode.type}.OUTPUTS={outputs}"
+                    )
+
+        # Cycle check
+        try:
+            self.topo_order()
+        except ValueError as ex:
+            errors.append(str(ex))
+
+        return errors

--- a/fmriflow/post_preproc/graph.py
+++ b/fmriflow/post_preproc/graph.py
@@ -173,4 +173,24 @@ class PostPreprocGraph:
         except ValueError as ex:
             errors.append(str(ex))
 
+        # _iter validation
+        for n in self.nodes:
+            it = n.params.get("_iter") if isinstance(n.params.get("_iter"), dict) else None
+            if not it:
+                continue
+            handle = it.get("handle")
+            spec = node_specs.get(n.type)
+            if spec is not None:
+                inputs = list(getattr(spec, "INPUTS", []))
+                if handle not in inputs:
+                    errors.append(
+                        f"Node {n.id}: _iter handle {handle!r} not in "
+                        f"{n.type}.INPUTS={inputs}"
+                    )
+            # iterating nodes are sinks in v1
+            if any(e.source == n.id for e in self.edges):
+                errors.append(
+                    f"Node {n.id}: iterating nodes can't have outgoing edges in v1"
+                )
+
         return errors

--- a/fmriflow/post_preproc/manifest.py
+++ b/fmriflow/post_preproc/manifest.py
@@ -1,0 +1,76 @@
+"""PostPreprocManifest — recorded outputs of a post-preprocessing graph run."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class NodeRunRecord:
+    """One executed node in a post-preproc graph run."""
+    node_id: str
+    node_type: str          # e.g. "smooth"
+    params: dict[str, Any]
+    inputs: dict[str, str]   # handle -> source file path
+    outputs: dict[str, str]  # handle -> output file path
+    duration_s: float | None = None
+
+
+@dataclass(frozen=True)
+class PostPreprocManifest:
+    """Outputs and provenance for a post-preproc graph run."""
+
+    subject: str
+    dataset: str
+    source_manifest_path: str  # the upstream PreprocManifest
+    graph: dict[str, Any]       # ReactFlow-shape graph that produced this
+    nodes_run: list[NodeRunRecord]
+    output_dir: str
+    created: str = field(default_factory=now_iso)
+    pipeline_version: str | None = None
+    manifest_version: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def save(self, path: str | Path) -> Path:
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(self.to_json())
+        return p
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PostPreprocManifest:
+        runs = [NodeRunRecord(**r) for r in data.get("nodes_run", [])]
+        clean = {k: v for k, v in data.items() if k != "nodes_run"}
+        return cls(nodes_run=runs, **clean)
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> PostPreprocManifest:
+        return cls.from_dict(json.loads(Path(path).read_text()))
+
+
+@dataclass(frozen=True)
+class PostPreprocConfig:
+    """Configuration for executing a post-preproc graph against a subject."""
+
+    subject: str
+    source_manifest_path: str
+    graph: dict[str, Any]
+    output_dir: str
+    name: str | None = None  # optional user-given run name
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PostPreprocConfig:
+        return cls(**data)

--- a/fmriflow/post_preproc/runner.py
+++ b/fmriflow/post_preproc/runner.py
@@ -1,0 +1,101 @@
+"""Execute a post-preproc graph against a PreprocManifest."""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+from fmriflow.post_preproc.graph import PostPreprocGraph
+from fmriflow.post_preproc.manifest import (
+    NodeRunRecord,
+    PostPreprocConfig,
+    PostPreprocManifest,
+)
+from fmriflow.preproc.manifest import PreprocManifest
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_source_run(
+    source_manifest: PreprocManifest, run_name: str
+) -> str:
+    """Find run_name in the source manifest; return absolute output_file path."""
+    for r in source_manifest.runs:
+        if r.run_name == run_name:
+            return str(Path(source_manifest.output_dir) / r.output_file)
+    raise ValueError(
+        f"run_name {run_name!r} not in source manifest "
+        f"(have {[r.run_name for r in source_manifest.runs]})"
+    )
+
+
+def run_post_preproc(
+    config: PostPreprocConfig,
+    *,
+    registry,
+) -> PostPreprocManifest:
+    """Execute the graph in ``config`` and write a PostPreprocManifest."""
+    source_manifest = PreprocManifest.from_json(config.source_manifest_path)
+    graph = PostPreprocGraph.from_reactflow(config.graph)
+    out_root = Path(config.output_dir)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    # Per-node output dir under out_root.
+    node_out: dict[str, dict[str, Path]] = {}
+    runs: list[NodeRunRecord] = []
+
+    for node in graph.topo_order():
+        cls = registry.get_module_class("nipype_nodes", node.type)
+        instance = cls()
+
+        # Build inputs from incoming edges.
+        inputs: dict[str, Path] = {}
+        for edge in graph.predecessors(node.id):
+            src_outputs = node_out.get(edge.source, {})
+            if edge.source_handle not in src_outputs:
+                raise RuntimeError(
+                    f"Node {node.id}: predecessor {edge.source} missing "
+                    f"output {edge.source_handle!r}"
+                )
+            inputs[edge.target_handle] = src_outputs[edge.source_handle]
+
+        # Source nodes resolve from the source manifest.
+        params: dict[str, Any] = dict(node.params)
+        if node.type == "preproc_run":
+            run_name = params.get("run_name") or ""
+            params["_resolved_path"] = _resolve_source_run(
+                source_manifest, run_name
+            )
+
+        node_dir = out_root / node.id
+        t0 = time.time()
+        outputs = instance.run(inputs, node_dir, params)
+        elapsed = time.time() - t0
+
+        # Stringify for serialization.
+        outputs_str = {k: str(v) for k, v in outputs.items()}
+        node_out[node.id] = {k: Path(v) for k, v in outputs_str.items()}
+
+        runs.append(
+            NodeRunRecord(
+                node_id=node.id,
+                node_type=node.type,
+                params={k: v for k, v in node.params.items()},
+                inputs={k: str(v) for k, v in inputs.items()},
+                outputs=outputs_str,
+                duration_s=elapsed,
+            )
+        )
+
+    manifest = PostPreprocManifest(
+        subject=config.subject,
+        dataset=source_manifest.dataset,
+        source_manifest_path=str(config.source_manifest_path),
+        graph=config.graph,
+        nodes_run=runs,
+        output_dir=str(out_root),
+    )
+    manifest.save(out_root / "post_preproc_manifest.json")
+    return manifest

--- a/fmriflow/post_preproc/runner.py
+++ b/fmriflow/post_preproc/runner.py
@@ -1,4 +1,15 @@
-"""Execute a post-preproc graph against a PreprocManifest."""
+"""Execute a post-preproc graph against a PreprocManifest.
+
+The runner supports three node-shape special cases on top of plain
+"call instance.run()" execution:
+
+- **preproc_run**: source node that resolves a path from the upstream
+  PreprocManifest by ``run_name``.
+- **subworkflow**: opaque node that loads a saved workflow YAML and runs
+  it as a nested ``_run_graph`` call with wired-through inputs/outputs.
+- **_iter**: a node that iterates over a list of values for a given
+  input handle. Iterating nodes are sinks (no outgoing edges) in v1.
+"""
 
 from __future__ import annotations
 
@@ -21,7 +32,6 @@ logger = logging.getLogger(__name__)
 def _resolve_source_run(
     source_manifest: PreprocManifest, run_name: str
 ) -> str:
-    """Find run_name in the source manifest; return absolute output_file path."""
     for r in source_manifest.runs:
         if r.run_name == run_name:
             return str(Path(source_manifest.output_dir) / r.output_file)
@@ -31,60 +41,123 @@ def _resolve_source_run(
     )
 
 
-def run_post_preproc(
-    config: PostPreprocConfig,
-    *,
-    registry,
-) -> PostPreprocManifest:
-    """Execute the graph in ``config`` and write a PostPreprocManifest."""
-    source_manifest = PreprocManifest.from_json(config.source_manifest_path)
-    graph = PostPreprocGraph.from_reactflow(config.graph)
-    out_root = Path(config.output_dir)
-    out_root.mkdir(parents=True, exist_ok=True)
+def _all_source_run_paths(source_manifest: PreprocManifest) -> list[str]:
+    return [
+        str(Path(source_manifest.output_dir) / r.output_file)
+        for r in source_manifest.runs
+    ]
 
-    # Per-node output dir under out_root.
-    node_out: dict[str, dict[str, Path]] = {}
+
+def _build_node_inputs(
+    graph: PostPreprocGraph,
+    node,
+    node_out: dict[str, dict[str, Path]],
+    extra_inputs: dict[str, Path] | None,
+) -> dict[str, Path]:
+    """Resolve a node's input-handle map from edges, then `_inputs`, then
+    caller-supplied ``extra_inputs`` (subworkflow pass-through).
+
+    Precedence: incoming edge > caller extra_inputs > params._inputs.
+    """
+    inputs: dict[str, Path] = {}
+    for edge in graph.predecessors(node.id):
+        src_outputs = node_out.get(edge.source, {})
+        if edge.source_handle not in src_outputs:
+            raise RuntimeError(
+                f"Node {node.id}: predecessor {edge.source} missing "
+                f"output {edge.source_handle!r}"
+            )
+        inputs[edge.target_handle] = src_outputs[edge.source_handle]
+
+    if extra_inputs:
+        for handle, path in extra_inputs.items():
+            inputs.setdefault(handle, Path(path) if not isinstance(path, Path) else path)
+
+    literal_inputs = node.params.get("_inputs") or {}
+    if isinstance(literal_inputs, dict):
+        for handle, path in literal_inputs.items():
+            if handle in inputs or not path:
+                continue
+            inputs[handle] = Path(path)
+
+    return inputs
+
+
+def _run_graph(
+    graph_data: dict[str, Any],
+    *,
+    source_manifest: PreprocManifest,
+    out_root: Path,
+    registry,
+    workflow_stack: tuple[str, ...] = (),
+    workflow_store=None,
+    extra_inputs_per_node: dict[str, dict[str, Path]] | None = None,
+) -> tuple[list[NodeRunRecord], dict[str, dict[str, Any]]]:
+    """Run a graph; return (per-node records, node_out map).
+
+    ``node_out[node_id][handle]`` is a Path for ordinary outputs and a
+    ``list[Path]`` for nodes that ran with ``_iter``.
+    """
+    graph = PostPreprocGraph.from_reactflow(graph_data)
+    out_root.mkdir(parents=True, exist_ok=True)
+    extra_inputs_per_node = extra_inputs_per_node or {}
+
+    node_out: dict[str, dict[str, Any]] = {}
     runs: list[NodeRunRecord] = []
 
     for node in graph.topo_order():
+        node_dir = out_root / node.id
+        params: dict[str, Any] = dict(node.params)
+        extra = extra_inputs_per_node.get(node.id) or {}
+
+        # Iteration shortcut: collect values, run N times, accumulate lists.
+        iter_spec = params.get("_iter") if isinstance(params.get("_iter"), dict) else None
+
+        if node.type == "subworkflow":
+            outputs, record = _run_subworkflow_node(
+                node=node,
+                params=params,
+                inputs=_build_node_inputs(graph, node, node_out, extra),
+                out_dir=node_dir,
+                source_manifest=source_manifest,
+                registry=registry,
+                workflow_store=workflow_store,
+                workflow_stack=workflow_stack,
+            )
+            node_out[node.id] = outputs
+            runs.append(record)
+            continue
+
+        if iter_spec:
+            outputs, record = _run_iterating_node(
+                node=node,
+                params=params,
+                graph=graph,
+                node_out=node_out,
+                extra=extra,
+                out_dir=node_dir,
+                registry=registry,
+                source_manifest=source_manifest,
+                iter_spec=iter_spec,
+            )
+            node_out[node.id] = outputs
+            runs.append(record)
+            continue
+
+        # Normal node.
         cls = registry.get_module_class("nipype_nodes", node.type)
         instance = cls()
+        inputs = _build_node_inputs(graph, node, node_out, extra)
 
-        # Build inputs from incoming edges.
-        inputs: dict[str, Path] = {}
-        for edge in graph.predecessors(node.id):
-            src_outputs = node_out.get(edge.source, {})
-            if edge.source_handle not in src_outputs:
-                raise RuntimeError(
-                    f"Node {node.id}: predecessor {edge.source} missing "
-                    f"output {edge.source_handle!r}"
-                )
-            inputs[edge.target_handle] = src_outputs[edge.source_handle]
-
-        # Literal-path overrides for inputs without an edge: ``params._inputs``
-        # is a {handle: "/path/to/file"} map set from the UI's input fields.
-        literal_inputs = node.params.get("_inputs") or {}
-        if isinstance(literal_inputs, dict):
-            for handle, path in literal_inputs.items():
-                if handle in inputs:
-                    continue  # an edge wins over a literal path
-                if path:
-                    inputs[handle] = Path(path)
-
-        # Source nodes resolve from the source manifest.
-        params: dict[str, Any] = dict(node.params)
         if node.type == "preproc_run":
-            run_name = params.get("run_name") or ""
             params["_resolved_path"] = _resolve_source_run(
-                source_manifest, run_name
+                source_manifest, params.get("run_name") or ""
             )
 
-        node_dir = out_root / node.id
         t0 = time.time()
         outputs = instance.run(inputs, node_dir, params)
         elapsed = time.time() - t0
 
-        # Stringify for serialization.
         outputs_str = {k: str(v) for k, v in outputs.items()}
         node_out[node.id] = {k: Path(v) for k, v in outputs_str.items()}
 
@@ -99,6 +172,188 @@ def run_post_preproc(
             )
         )
 
+    return runs, node_out
+
+
+def _run_iterating_node(
+    *,
+    node,
+    params: dict[str, Any],
+    graph: PostPreprocGraph,
+    node_out: dict[str, dict[str, Any]],
+    extra: dict[str, Path],
+    out_dir: Path,
+    registry,
+    source_manifest: PreprocManifest,
+    iter_spec: dict[str, Any],
+) -> tuple[dict[str, list[str]], NodeRunRecord]:
+    """Run an iterating node once per value; collect outputs into lists."""
+    handle = iter_spec.get("handle") or "in_file"
+    values: list[str]
+    if iter_spec.get("from_source_manifest"):
+        values = _all_source_run_paths(source_manifest)
+    else:
+        raw = iter_spec.get("values") or []
+        values = [str(v) for v in raw]
+
+    if not values:
+        raise ValueError(
+            f"Iterating node {node.id}: _iter has no values to iterate over"
+        )
+
+    cls = registry.get_module_class("nipype_nodes", node.type)
+    instance = cls()
+    base_inputs = _build_node_inputs(graph, node, node_out, extra)
+    if handle in base_inputs:
+        raise ValueError(
+            f"Iterating node {node.id}: handle {handle!r} is also wired or "
+            f"set via _inputs; remove the wire/literal or the iteration."
+        )
+
+    # Iterating nodes must be sinks in v1 (no outgoing edges).
+    has_out = any(e.source == node.id for e in graph.edges)
+    if has_out:
+        raise ValueError(
+            f"Iterating node {node.id}: outgoing edges aren't supported "
+            f"yet. Use a literal sink for v1."
+        )
+
+    collected: dict[str, list[str]] = {}
+    iter_inputs_record: list[dict[str, str]] = []
+
+    t0 = time.time()
+    for i, value in enumerate(values):
+        per_dir = out_dir / f"{i:03d}"
+        inputs = dict(base_inputs)
+        inputs[handle] = Path(value)
+        per_params = dict(params)
+
+        if node.type == "preproc_run":
+            per_params["_resolved_path"] = value
+
+        outputs = instance.run(inputs, per_dir, per_params)
+        for k, v in outputs.items():
+            collected.setdefault(k, []).append(str(v))
+        iter_inputs_record.append({handle: str(value)})
+    elapsed = time.time() - t0
+
+    record = NodeRunRecord(
+        node_id=node.id,
+        node_type=node.type,
+        params={k: v for k, v in node.params.items()},
+        inputs={"_iter_handle": handle, "_iter_count": str(len(values))},
+        outputs={k: ",".join(v) for k, v in collected.items()},
+        duration_s=elapsed,
+    )
+    # Internally we keep the lists as the node's output shape.
+    return ({k: v for k, v in collected.items()}, record)  # type: ignore[return-value]
+
+
+def _run_subworkflow_node(
+    *,
+    node,
+    params: dict[str, Any],
+    inputs: dict[str, Path],
+    out_dir: Path,
+    source_manifest: PreprocManifest,
+    registry,
+    workflow_store,
+    workflow_stack: tuple[str, ...],
+) -> tuple[dict[str, Path], NodeRunRecord]:
+    name = params.get("workflow_name")
+    if not name:
+        raise ValueError(f"subworkflow {node.id}: missing workflow_name")
+    if workflow_store is None:
+        raise RuntimeError(
+            "subworkflow execution requires a workflow store; the runner "
+            "wasn't given one"
+        )
+    if name in workflow_stack:
+        raise RuntimeError(
+            f"subworkflow cycle: {' -> '.join(workflow_stack + (name,))}"
+        )
+    wf = workflow_store.get(name)
+    if wf is None:
+        raise FileNotFoundError(f"subworkflow {node.id}: workflow {name!r} not found")
+
+    inputs_map = wf.get("inputs") or {}
+    outputs_map = wf.get("outputs") or {}
+    inner_graph = wf.get("graph") or {"nodes": [], "edges": []}
+
+    # Build per-inner-node extra_inputs from the workflow's `inputs:` mapping
+    # plus the wrapper's incoming `inputs`.
+    extra_inputs_per_node: dict[str, dict[str, Path]] = {}
+    for wf_handle, target_path in inputs_map.items():
+        if wf_handle not in inputs:
+            continue
+        spec = target_path or {}
+        from_str = spec.get("from") if isinstance(spec, dict) else str(spec)
+        if not from_str or "." not in from_str:
+            raise ValueError(
+                f"subworkflow {name}: input {wf_handle!r} has bad target {spec!r}"
+            )
+        inner_id, inner_handle = from_str.split(".", 1)
+        extra_inputs_per_node.setdefault(inner_id, {})[inner_handle] = inputs[wf_handle]
+
+    inner_runs, inner_node_out = _run_graph(
+        inner_graph,
+        source_manifest=source_manifest,
+        out_root=out_dir,
+        registry=registry,
+        workflow_stack=workflow_stack + (name,),
+        workflow_store=workflow_store,
+        extra_inputs_per_node=extra_inputs_per_node,
+    )
+
+    # Map inner node outputs back up to the wrapper's declared outputs.
+    outputs: dict[str, Path] = {}
+    for wf_out, target in outputs_map.items():
+        spec = target or {}
+        from_str = spec.get("from") if isinstance(spec, dict) else str(spec)
+        if not from_str or "." not in from_str:
+            raise ValueError(
+                f"subworkflow {name}: output {wf_out!r} has bad source {spec!r}"
+            )
+        inner_id, inner_handle = from_str.split(".", 1)
+        produced = inner_node_out.get(inner_id, {}).get(inner_handle)
+        if produced is None:
+            raise RuntimeError(
+                f"subworkflow {name}: inner node {inner_id} did not produce "
+                f"output {inner_handle!r}"
+            )
+        # If iteration produced a list, take the first; v1 simplification.
+        outputs[wf_out] = (
+            Path(produced[0]) if isinstance(produced, list) and produced
+            else Path(produced)
+        )
+
+    record = NodeRunRecord(
+        node_id=node.id,
+        node_type="subworkflow",
+        params={k: v for k, v in node.params.items()},
+        inputs={k: str(v) for k, v in inputs.items()},
+        outputs={k: str(v) for k, v in outputs.items()},
+        duration_s=sum((r.duration_s or 0.0) for r in inner_runs),
+    )
+    return outputs, record
+
+
+def run_post_preproc(
+    config: PostPreprocConfig,
+    *,
+    registry,
+    workflow_store=None,
+) -> PostPreprocManifest:
+    """Top-level entry point. Executes ``config.graph`` and writes a manifest."""
+    source_manifest = PreprocManifest.from_json(config.source_manifest_path)
+    out_root = Path(config.output_dir)
+    runs, _ = _run_graph(
+        config.graph,
+        source_manifest=source_manifest,
+        out_root=out_root,
+        registry=registry,
+        workflow_store=workflow_store,
+    )
     manifest = PostPreprocManifest(
         subject=config.subject,
         dataset=source_manifest.dataset,

--- a/fmriflow/post_preproc/runner.py
+++ b/fmriflow/post_preproc/runner.py
@@ -61,6 +61,16 @@ def run_post_preproc(
                 )
             inputs[edge.target_handle] = src_outputs[edge.source_handle]
 
+        # Literal-path overrides for inputs without an edge: ``params._inputs``
+        # is a {handle: "/path/to/file"} map set from the UI's input fields.
+        literal_inputs = node.params.get("_inputs") or {}
+        if isinstance(literal_inputs, dict):
+            for handle, path in literal_inputs.items():
+                if handle in inputs:
+                    continue  # an edge wins over a literal path
+                if path:
+                    inputs[handle] = Path(path)
+
         # Source nodes resolve from the source manifest.
         params: dict[str, Any] = dict(node.params)
         if node.type == "preproc_run":

--- a/fmriflow/preproc/manifest.py
+++ b/fmriflow/preproc/manifest.py
@@ -80,6 +80,9 @@ class PreprocManifest:
     pipeline_version: str | None = None
     checksum: str | None = None
 
+    # FreeSurfer outputs (location of SUBJECTS_DIR if backend produced one)
+    freesurfer_subjects_dir: str | None = None
+
     # Post-step outputs
     autoflatten: dict[str, Any] | None = None
 

--- a/fmriflow/preproc/nipype_log.py
+++ b/fmriflow/preproc/nipype_log.py
@@ -90,6 +90,11 @@ class NipypeLogParser:
 
     def __init__(self) -> None:
         self._pending: _Pending | None = None
+        # fmriprep's nipype emits the full dotted path on "Setting-up"
+        # but only the leaf on "Finished" / "Error on". Track the most
+        # recent full path per leaf so terminal events can be rewritten
+        # back to their full path for clean aggregation.
+        self._full_by_leaf: dict[str, str] = {}
 
     def feed(self, line: str) -> Iterable[dict]:
         """Process one log line; yield 0 or 1 event dicts.
@@ -149,14 +154,23 @@ class NipypeLogParser:
             if time.time() - self._pending.received_at > 5.0:
                 self._pending = None
 
-    @staticmethod
-    def _make_event(match: re.Match, *, level: str, t: float) -> dict | None:
+    def _make_event(self, match: re.Match, *, level: str, t: float) -> dict | None:
         action = match.group("action")
         node = match.group("node")
         kind = _action_to_event(action, level)
         if kind is None:
             return None
         wf, leaf = _split_node_path(node)
+        # On node_start, remember the full dotted path keyed by leaf so
+        # later terminal events can be reattached. On terminal events
+        # whose payload is leaf-only, look the full path back up.
+        if kind == "node_start" and "." in node:
+            self._full_by_leaf[leaf] = node
+        elif kind in ("node_done", "node_fail") and "." not in node:
+            full = self._full_by_leaf.get(leaf)
+            if full is not None:
+                node = full
+                wf, leaf = _split_node_path(node)
         return {
             "event": kind,
             "node": node,

--- a/fmriflow/preproc/nipype_log.py
+++ b/fmriflow/preproc/nipype_log.py
@@ -1,0 +1,280 @@
+"""Parse fmriprep's nipype-formatted log lines into node-status events.
+
+fmriprep prints structured ``[Node]`` / ``[Workflow]`` lines on stdout
+that we already tail in ``preproc_manager._LogTailer``. This module is a
+small stateful parser that turns those lines into events the frontend
+can render as a per-node status strip.
+
+Recognised line shapes (real fmriprep stdout):
+
+    250504-12:31:02,123 nipype.workflow INFO:
+         [Node] Setting-up "fmriprep_wf.single_subject_01_wf...bold_split" in "/work/.../bold_split".
+    250504-12:31:18,847 nipype.workflow INFO:
+         [Node] Finished "fmriprep_wf...bold_split", elapsed time 16.7s.
+    250504-12:35:11,002 nipype.workflow ERROR:
+         [Node] Error on "fmriprep_wf.sdc_estimate_wf.fmap2field_wf.unwarp_wf" (...)
+
+Unknown / unmatched lines are silently dropped — the parser must
+degrade gracefully across nipype releases.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+# Match the leading nipype timestamp + level. Group: ts, level.
+# 250504-12:31:02,123 nipype.workflow INFO:
+_HEADER = re.compile(
+    r"^\s*(?P<ts>\d{6}-\d{2}:\d{2}:\d{2},\d{3})\s+nipype\.workflow\s+(?P<level>INFO|WARNING|ERROR|CRITICAL):"
+)
+
+# Same line OR a continuation may carry the [Node] / [Workflow] payload.
+# Captures: action, node_path. Action is one of the verbs we know.
+_NODE = re.compile(
+    r"\[(?P<kind>Node|Workflow|MultiProc)\]\s+"
+    r"(?P<action>Setting-up|Running|Executing node|Finished|Cached|Collecting|Error on|crashed|Skipping)\s+"
+    r"\"(?P<node>[^\"]+)\""
+)
+
+
+@dataclass
+class _Pending:
+    """A header we've matched but whose [Node] payload may be on the next line."""
+    ts: str
+    level: str
+    received_at: float
+
+
+def _parse_ts(ts: str) -> float:
+    """Parse nipype's ``YYMMDD-HH:MM:SS,mmm`` timestamp into a unix float.
+
+    Returns ``time.time()`` on parse failure — the events file's
+    monotonic order is more important than absolute accuracy.
+    """
+    try:
+        # Naive local-time parse; fmriprep doesn't include tz. Treat as UTC for stability.
+        dt = datetime.strptime(ts, "%y%m%d-%H:%M:%S,%f").replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except ValueError:
+        return time.time()
+
+
+def _split_node_path(node: str) -> tuple[str, str]:
+    """Return (workflow_path, leaf) — leaf = last dotted segment."""
+    if "." not in node:
+        return ("", node)
+    head, _, leaf = node.rpartition(".")
+    return (head, leaf)
+
+
+def _action_to_event(action: str, level: str) -> str | None:
+    """Map a (verb, log-level) pair to one of our event kinds."""
+    a = action.lower()
+    if a in ("setting-up", "running", "executing node"):
+        return "node_start"
+    if a in ("finished", "cached", "collecting"):
+        return "node_done"
+    if a in ("error on", "crashed") or level in ("ERROR", "CRITICAL"):
+        return "node_fail"
+    return None
+
+
+class NipypeLogParser:
+    """Stateful line-by-line parser; emits node-status events."""
+
+    def __init__(self) -> None:
+        self._pending: _Pending | None = None
+
+    def feed(self, line: str) -> Iterable[dict]:
+        """Process one log line; yield 0 or 1 event dicts.
+
+        Each event::
+
+            {
+              "event": "node_start" | "node_done" | "node_fail",
+              "node": "<full.dotted.path>",
+              "workflow": "<root.sub...>",   # parent workflow (dotted path minus leaf)
+              "leaf": "<leaf-name>",
+              "t": <unix float>,
+              "level": "INFO" | "ERROR" | ...,
+            }
+        """
+        if line is None:
+            return
+        line = line.rstrip("\r\n")
+
+        # Case 1: a single line containing both header and payload.
+        h = _HEADER.search(line)
+        if h:
+            payload = line[h.end():]
+            n = _NODE.search(payload)
+            if n:
+                ts_unix = _parse_ts(h.group("ts"))
+                ev = self._make_event(
+                    n, level=h.group("level"), t=ts_unix,
+                )
+                self._pending = None
+                if ev is not None:
+                    yield ev
+                return
+            # Header without payload — payload may be on the next line.
+            self._pending = _Pending(
+                ts=h.group("ts"),
+                level=h.group("level"),
+                received_at=time.time(),
+            )
+            return
+
+        # Case 2: line is a continuation of a previously-matched header.
+        if self._pending is not None:
+            n = _NODE.search(line)
+            if n is not None:
+                ts_unix = _parse_ts(self._pending.ts)
+                ev = self._make_event(
+                    n, level=self._pending.level, t=ts_unix,
+                )
+                self._pending = None
+                if ev is not None:
+                    yield ev
+                return
+            # Drop the pending state if the next line clearly isn't ours
+            # (e.g. blank, or starts another header). We only allow ~5 s of
+            # carry-over to avoid forever-pending state on log gaps.
+            if time.time() - self._pending.received_at > 5.0:
+                self._pending = None
+
+    @staticmethod
+    def _make_event(match: re.Match, *, level: str, t: float) -> dict | None:
+        action = match.group("action")
+        node = match.group("node")
+        kind = _action_to_event(action, level)
+        if kind is None:
+            return None
+        wf, leaf = _split_node_path(node)
+        return {
+            "event": kind,
+            "node": node,
+            "workflow": wf,
+            "leaf": leaf,
+            "t": t,
+            "level": level,
+        }
+
+
+# ── JSONL append + aggregation ───────────────────────────────────────────
+
+
+def append_jsonl(path: Path, event: dict) -> None:
+    """Append one JSON event as a line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(event, ensure_ascii=False))
+        f.write("\n")
+
+
+@dataclass
+class NipypeNodeStatus:
+    node: str
+    leaf: str
+    workflow: str
+    status: str  # "running" | "ok" | "failed"
+    started_at: float = 0.0
+    finished_at: float = 0.0
+    elapsed: float = 0.0
+    crash_file: str | None = None
+    level: str = "INFO"
+
+    def to_dict(self) -> dict:
+        return {
+            "node": self.node,
+            "leaf": self.leaf,
+            "workflow": self.workflow,
+            "status": self.status,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "elapsed": self.elapsed,
+            "crash_file": self.crash_file,
+            "level": self.level,
+        }
+
+
+@dataclass
+class NipypeStatusBlock:
+    counts: dict = field(default_factory=lambda: {
+        "running": 0, "ok": 0, "failed": 0, "total_seen": 0,
+    })
+    recent_nodes: list[NipypeNodeStatus] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "counts": dict(self.counts),
+            "recent_nodes": [n.to_dict() for n in self.recent_nodes],
+        }
+
+
+def parse_nipype_events_file(path: str | Path, *, cap: int = 200) -> NipypeStatusBlock:
+    """Collapse the JSONL events file into a NipypeStatusBlock.
+
+    Cap limits the number of nodes returned (most recent N).
+    Unfinished nodes (saw ``node_start`` but no terminal event) are
+    reported with status ``running``.
+    """
+    p = Path(path)
+    if not p.is_file():
+        return NipypeStatusBlock()
+
+    by_node: dict[str, NipypeNodeStatus] = {}
+    order: list[str] = []  # insertion order on first sighting
+    for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except (ValueError, json.JSONDecodeError):
+            continue
+        node = ev.get("node")
+        if not node:
+            continue
+        if node not in by_node:
+            by_node[node] = NipypeNodeStatus(
+                node=node,
+                leaf=ev.get("leaf") or node.rsplit(".", 1)[-1],
+                workflow=ev.get("workflow") or "",
+                status="running",
+                started_at=float(ev.get("t") or 0.0),
+                level=ev.get("level") or "INFO",
+            )
+            order.append(node)
+        n = by_node[node]
+        kind = ev.get("event")
+        if kind == "node_start" and n.started_at == 0.0:
+            n.started_at = float(ev.get("t") or 0.0)
+        elif kind == "node_done":
+            n.status = "ok"
+            n.finished_at = float(ev.get("t") or 0.0)
+            if n.started_at and n.finished_at:
+                n.elapsed = max(0.0, n.finished_at - n.started_at)
+        elif kind == "node_fail":
+            n.status = "failed"
+            n.finished_at = float(ev.get("t") or 0.0)
+            if n.started_at and n.finished_at:
+                n.elapsed = max(0.0, n.finished_at - n.started_at)
+            n.level = ev.get("level") or n.level
+
+    nodes = [by_node[k] for k in order]
+    counts = {
+        "running": sum(1 for n in nodes if n.status == "running"),
+        "ok":      sum(1 for n in nodes if n.status == "ok"),
+        "failed":  sum(1 for n in nodes if n.status == "failed"),
+        "total_seen": len(nodes),
+    }
+    if cap and len(nodes) > cap:
+        nodes = nodes[-cap:]
+    return NipypeStatusBlock(counts=counts, recent_nodes=nodes)

--- a/fmriflow/preproc/nipype_log.py
+++ b/fmriflow/preproc/nipype_log.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import re
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -91,10 +92,13 @@ class NipypeLogParser:
     def __init__(self) -> None:
         self._pending: _Pending | None = None
         # fmriprep's nipype emits the full dotted path on "Setting-up"
-        # but only the leaf on "Finished" / "Error on". Track the most
-        # recent full path per leaf so terminal events can be rewritten
-        # back to their full path for clean aggregation.
-        self._full_by_leaf: dict[str, str] = {}
+        # but only the leaf on "Finished" / "Error on". Per-leaf FIFO
+        # queue: appendleft on node_start (so the oldest in-flight is at
+        # the right end), pop on node_done/_fail. Survives sibling
+        # concurrency when finish order matches start order, and avoids
+        # the dict[leaf,str] last-write-wins bug where two starts of the
+        # same leaf would mis-pair the dones.
+        self._full_by_leaf: dict[str, deque[str]] = {}
 
     def feed(self, line: str) -> Iterable[dict]:
         """Process one log line; yield 0 or 1 event dicts.
@@ -161,16 +165,20 @@ class NipypeLogParser:
         if kind is None:
             return None
         wf, leaf = _split_node_path(node)
-        # On node_start, remember the full dotted path keyed by leaf so
-        # later terminal events can be reattached. On terminal events
-        # whose payload is leaf-only, look the full path back up.
+        # On node_start, append the full dotted path to the per-leaf
+        # FIFO queue. On terminal events whose payload is leaf-only, pop
+        # the oldest queued full path back. (No-op if the queue is
+        # empty or the start carried only a leaf.)
         if kind == "node_start" and "." in node:
-            self._full_by_leaf[leaf] = node
+            self._full_by_leaf.setdefault(leaf, deque()).append(node)
         elif kind in ("node_done", "node_fail") and "." not in node:
-            full = self._full_by_leaf.get(leaf)
-            if full is not None:
+            queue = self._full_by_leaf.get(leaf)
+            if queue:
+                full = queue.popleft()
                 node = full
                 wf, leaf = _split_node_path(node)
+                if not queue:
+                    del self._full_by_leaf[leaf]
         return {
             "event": kind,
             "node": node,
@@ -221,7 +229,8 @@ class NipypeNodeStatus:
 @dataclass
 class NipypeStatusBlock:
     counts: dict = field(default_factory=lambda: {
-        "running": 0, "ok": 0, "failed": 0, "total_seen": 0,
+        "running": 0, "ok": 0, "failed": 0,
+        "completed_assumed": 0, "total_seen": 0,
     })
     recent_nodes: list[NipypeNodeStatus] = field(default_factory=list)
 
@@ -232,12 +241,27 @@ class NipypeStatusBlock:
         }
 
 
+def _recompute_counts(nodes: list[NipypeNodeStatus]) -> dict:
+    return {
+        "running":           sum(1 for n in nodes if n.status == "running"),
+        "ok":                sum(1 for n in nodes if n.status == "ok"),
+        "failed":            sum(1 for n in nodes if n.status == "failed"),
+        "completed_assumed": sum(1 for n in nodes if n.status == "completed_assumed"),
+        "total_seen":        len(nodes),
+    }
+
+
 def parse_nipype_events_file(path: str | Path, *, cap: int = 200) -> NipypeStatusBlock:
     """Collapse the JSONL events file into a NipypeStatusBlock.
 
     Cap limits the number of nodes returned (most recent N).
-    Unfinished nodes (saw ``node_start`` but no terminal event) are
-    reported with status ``running``.
+
+    Performs a read-time **FIFO leaf-matching pass** so JSONLs written
+    before the parser's same-leaf fix (where Finished/Error lines
+    carried bare-leaf names) still aggregate cleanly without rewrite:
+    a leaf-only terminal event pops the oldest queued ``node_start`` of
+    that leaf and applies the terminal status to that full path. Truly
+    unmatched bare-leaf events are kept as their own nodes.
     """
     p = Path(path)
     if not p.is_file():
@@ -245,6 +269,9 @@ def parse_nipype_events_file(path: str | Path, *, cap: int = 200) -> NipypeStatu
 
     by_node: dict[str, NipypeNodeStatus] = {}
     order: list[str] = []  # insertion order on first sighting
+    # Per-leaf FIFO of full dotted paths still awaiting a terminal event.
+    starts_by_leaf: dict[str, deque[str]] = {}
+
     for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
         line = line.strip()
         if not line:
@@ -253,21 +280,41 @@ def parse_nipype_events_file(path: str | Path, *, cap: int = 200) -> NipypeStatu
             ev = json.loads(line)
         except (ValueError, json.JSONDecodeError):
             continue
+        kind = ev.get("event")
         node = ev.get("node")
-        if not node:
+        leaf = ev.get("leaf") or (node.rsplit(".", 1)[-1] if node else None)
+        if not node or not leaf:
             continue
+
+        # Reconciliation: rewrite leaf-only terminal events to their
+        # matching node_start's full path (FIFO).
+        if (
+            kind in ("node_done", "node_fail")
+            and "." not in node
+        ):
+            queue = starts_by_leaf.get(leaf)
+            if queue:
+                full = queue.popleft()
+                node = full
+                leaf = node.rsplit(".", 1)[-1]
+                if not queue:
+                    del starts_by_leaf[leaf]
+
+        if kind == "node_start" and "." in node:
+            starts_by_leaf.setdefault(leaf, deque()).append(node)
+
         if node not in by_node:
             by_node[node] = NipypeNodeStatus(
                 node=node,
-                leaf=ev.get("leaf") or node.rsplit(".", 1)[-1],
-                workflow=ev.get("workflow") or "",
+                leaf=leaf,
+                workflow=(ev.get("workflow") or
+                          (node.rsplit(".", 1)[0] if "." in node else "")),
                 status="running",
                 started_at=float(ev.get("t") or 0.0),
                 level=ev.get("level") or "INFO",
             )
             order.append(node)
         n = by_node[node]
-        kind = ev.get("event")
         if kind == "node_start" and n.started_at == 0.0:
             n.started_at = float(ev.get("t") or 0.0)
         elif kind == "node_done":
@@ -283,12 +330,37 @@ def parse_nipype_events_file(path: str | Path, *, cap: int = 200) -> NipypeStatu
             n.level = ev.get("level") or n.level
 
     nodes = [by_node[k] for k in order]
-    counts = {
-        "running": sum(1 for n in nodes if n.status == "running"),
-        "ok":      sum(1 for n in nodes if n.status == "ok"),
-        "failed":  sum(1 for n in nodes if n.status == "failed"),
-        "total_seen": len(nodes),
-    }
+    counts = _recompute_counts(nodes)
     if cap and len(nodes) > cap:
         nodes = nodes[-cap:]
     return NipypeStatusBlock(counts=counts, recent_nodes=nodes)
+
+
+def reconcile_with_run_state(
+    block: NipypeStatusBlock,
+    *,
+    run_status: str,
+) -> NipypeStatusBlock:
+    """Run-end sweep: if the parent preproc run finished cleanly, mark
+    any still-``running`` nodes as ``completed_assumed``.
+
+    fmriprep's nipype occasionally emits log lines whose terminal verbs
+    we don't recognise, or batches them in a way that drops the line
+    entirely. When the parent run says ``done``, those orphans are
+    almost certainly fine — surface them as ``completed_assumed`` so
+    the user sees that we didn't observe a Finished line directly.
+    Failed/cancelled/lost runs leave the orphans as ``running`` so the
+    failure context is preserved.
+    """
+    if run_status != "done":
+        return block
+    if not block.recent_nodes:
+        return block
+    flipped = False
+    for n in block.recent_nodes:
+        if n.status == "running":
+            n.status = "completed_assumed"
+            flipped = True
+    if flipped:
+        block.counts = _recompute_counts(block.recent_nodes)
+    return block

--- a/fmriflow/qc/__init__.py
+++ b/fmriflow/qc/__init__.py
@@ -1,0 +1,8 @@
+"""QC (review) module for fMRIflow."""
+
+from fmriflow.qc.structural_review import (
+    StructuralQCReview,
+    QC_STATUSES,
+)
+
+__all__ = ["StructuralQCReview", "QC_STATUSES"]

--- a/fmriflow/qc/structural_review.py
+++ b/fmriflow/qc/structural_review.py
@@ -1,0 +1,48 @@
+"""StructuralQCReview — reviewer sign-off on structural preprocessing.
+
+Reviewers inspect fmriprep + FreeSurfer structural outputs (in-browser via
+niivue or out-of-browser via freeview) and record an Approve / Needs edits /
+Rejected decision. One review per (dataset, subject).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+QC_STATUSES = ("pending", "approved", "needs_edits", "rejected")
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class StructuralQCReview:
+    """A reviewer's structural-QC decision for one subject."""
+
+    dataset: str
+    subject: str
+    status: str = "pending"
+    reviewer: str = ""
+    timestamp: str = field(default_factory=now_iso)
+    notes: str = ""
+    freeview_command_used: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status not in QC_STATUSES:
+            raise ValueError(
+                f"status must be one of {QC_STATUSES}, got {self.status!r}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StructuralQCReview:
+        # Tolerate unknown keys for forward-compat.
+        known = {f for f in cls.__dataclass_fields__}
+        clean = {k: v for k, v in data.items() if k in known}
+        return cls(**clean)

--- a/fmriflow/registry.py
+++ b/fmriflow/registry.py
@@ -24,6 +24,7 @@ from fmriflow.modules._decorators import (
     _analyzers,
     _models,
     _reporters,
+    _nipype_nodes,
 )
 
 logger = logging.getLogger(__name__)
@@ -49,6 +50,7 @@ class ModuleRegistry:
         self._analyzers = _analyzers
         self._models = _models
         self._reporters = _reporters
+        self._nipype_nodes = _nipype_nodes
 
     def discover(self) -> None:
         """Discover modules from builtins and entry_points."""
@@ -73,6 +75,7 @@ class ModuleRegistry:
             'fmriflow.analyzers': self._analyzers,
             'fmriflow.models': self._models,
             'fmriflow.reporters': self._reporters,
+            'fmriflow.nipype_nodes': self._nipype_nodes,
         }
 
         for group, registry_dict in groups.items():
@@ -164,6 +167,13 @@ class ModuleRegistry:
             return cls
         return wrapper
 
+    def nipype_node(self, name: str):
+        """Decorator to register a post-fmriprep nipype node wrapper."""
+        def wrapper(cls):
+            self._nipype_nodes[name] = cls
+            return cls
+        return wrapper
+
     # ─── Getters (return instances) ─────────────────────────────
 
     def get_stimulus_loader(self, name: str):
@@ -236,6 +246,13 @@ class ModuleRegistry:
                 f"Available: {list(self._reporters.keys())}")
         return self._reporters[name]()
 
+    def get_nipype_node(self, name: str):
+        if name not in self._nipype_nodes:
+            raise ModuleLookupError(
+                f"Nipype node '{name}' not found. "
+                f"Available: {list(self._nipype_nodes.keys())}")
+        return self._nipype_nodes[name]()
+
     # ─── Introspection ──────────────────────────────────────────
 
     def list_modules(self) -> dict[str, list[str]]:
@@ -251,6 +268,7 @@ class ModuleRegistry:
             'analyzers': sorted(self._analyzers.keys()),
             'models': sorted(self._models.keys()),
             'reporters': sorted(self._reporters.keys()),
+            'nipype_nodes': sorted(self._nipype_nodes.keys()),
         }
 
     def get_module_class(self, category: str, name: str) -> type:
@@ -266,6 +284,7 @@ class ModuleRegistry:
             'analyzers': self._analyzers,
             'models': self._models,
             'reporters': self._reporters,
+            'nipype_nodes': self._nipype_nodes,
         }
         if category not in registry_map:
             raise ModuleLookupError(f"Unknown category '{category}'")
@@ -295,6 +314,7 @@ class ModuleRegistry:
             'analyzers': 'analyze',
             'models': 'model',
             'reporters': 'report',
+            'nipype_nodes': 'post_preproc',
         }
 
         result = {}

--- a/fmriflow/server/app.py
+++ b/fmriflow/server/app.py
@@ -126,6 +126,7 @@ def create_app(
     from fmriflow.server.routes.triage import router as triage_router
     from fmriflow.server.routes.structural_qc import router as structural_qc_router
     from fmriflow.server.routes.post_preproc import router as post_preproc_router
+    from fmriflow.server.routes.node_outputs import router as node_outputs_router
     from fmriflow.server.ws import router as ws_router
 
     # Editor routes must come before module_router so that
@@ -144,6 +145,17 @@ def create_app(
     app.include_router(triage_router, prefix="/api")
     app.include_router(structural_qc_router, prefix="/api")
     app.include_router(post_preproc_router, prefix="/api")
+    # Node-outputs route must come BEFORE preproc_router because
+    # `/preproc/runs/{run_id}/node/...` would otherwise be shadowed by
+    # the more general `{run_id}` patterns. FastAPI's matcher walks the
+    # routes in include order, so re-include this one last to take
+    # precedence... actually, FastAPI uses first-match so we want this
+    # *registered* such that the more specific path is found first.
+    # `preproc_router` only handles `/preproc/runs/{run_id}` and
+    # `/preproc/runs/{run_id}/{exact-name}` (live, cancel, …) so the
+    # `/node/{path}/...` segment never collides — order doesn't matter
+    # in practice; we still register near the end for symmetry.
+    app.include_router(node_outputs_router, prefix="/api")
     app.include_router(ws_router)
 
     # Serve built frontend (if available)

--- a/fmriflow/server/app.py
+++ b/fmriflow/server/app.py
@@ -24,6 +24,7 @@ from fmriflow.server.services.workflow_manager import WorkflowManager
 from fmriflow.server.services.workflow_config_store import WorkflowConfigStore
 from fmriflow.server.services.structural_qc_store import StructuralQCStore
 from fmriflow.server.services.post_preproc_manager import PostPreprocManager
+from fmriflow.server.services.post_preproc_workflow_store import PostPreprocWorkflowStore
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +80,9 @@ def create_app(
         Path.home() / ".fmriflow" / "structural_qc"
     )
     post_preproc_manager = PostPreprocManager()
+    post_preproc_workflow_store = PostPreprocWorkflowStore(
+        Path.home() / ".fmriflow" / "post_preproc_workflows"
+    )
     workflow_manager.bind_stage_managers(
         convert=convert_manager,
         preproc=preproc_manager,
@@ -100,6 +104,7 @@ def create_app(
     app.state.workflow_manager = workflow_manager
     app.state.structural_qc_store = structural_qc_store
     app.state.post_preproc_manager = post_preproc_manager
+    app.state.post_preproc_workflow_store = post_preproc_workflow_store
 
     # API routes
     from fmriflow.server.routes.modules import router as module_router

--- a/fmriflow/server/app.py
+++ b/fmriflow/server/app.py
@@ -22,6 +22,7 @@ from fmriflow.server.services.autoflatten_manager import AutoflattenManager
 from fmriflow.server.services.autoflatten_config_store import AutoflattenConfigStore
 from fmriflow.server.services.workflow_manager import WorkflowManager
 from fmriflow.server.services.workflow_config_store import WorkflowConfigStore
+from fmriflow.server.services.structural_qc_store import StructuralQCStore
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,9 @@ def create_app(
     autoflatten_config_store = AutoflattenConfigStore(Path(autoflatten_configs_dir))
     workflow_config_store = WorkflowConfigStore(Path(workflow_configs_dir))
     workflow_manager = WorkflowManager()
+    structural_qc_store = StructuralQCStore(
+        Path.home() / ".fmriflow" / "structural_qc"
+    )
     workflow_manager.bind_stage_managers(
         convert=convert_manager,
         preproc=preproc_manager,
@@ -92,6 +96,7 @@ def create_app(
     app.state.autoflatten_config_store = autoflatten_config_store
     app.state.workflow_config_store = workflow_config_store
     app.state.workflow_manager = workflow_manager
+    app.state.structural_qc_store = structural_qc_store
 
     # API routes
     from fmriflow.server.routes.modules import router as module_router
@@ -106,6 +111,7 @@ def create_app(
     from fmriflow.server.routes.autoflatten import router as autoflatten_router
     from fmriflow.server.routes.workflows import router as workflows_router
     from fmriflow.server.routes.triage import router as triage_router
+    from fmriflow.server.routes.structural_qc import router as structural_qc_router
     from fmriflow.server.ws import router as ws_router
 
     # Editor routes must come before module_router so that
@@ -122,6 +128,7 @@ def create_app(
     app.include_router(autoflatten_router, prefix="/api")
     app.include_router(workflows_router, prefix="/api")
     app.include_router(triage_router, prefix="/api")
+    app.include_router(structural_qc_router, prefix="/api")
     app.include_router(ws_router)
 
     # Serve built frontend (if available)

--- a/fmriflow/server/app.py
+++ b/fmriflow/server/app.py
@@ -22,6 +22,7 @@ from fmriflow.server.services.autoflatten_manager import AutoflattenManager
 from fmriflow.server.services.autoflatten_config_store import AutoflattenConfigStore
 from fmriflow.server.services.workflow_manager import WorkflowManager
 from fmriflow.server.services.workflow_config_store import WorkflowConfigStore
+from fmriflow.server.services.post_preproc_manager import PostPreprocManager
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,7 @@ def create_app(
     autoflatten_config_store = AutoflattenConfigStore(Path(autoflatten_configs_dir))
     workflow_config_store = WorkflowConfigStore(Path(workflow_configs_dir))
     workflow_manager = WorkflowManager()
+    post_preproc_manager = PostPreprocManager()
     workflow_manager.bind_stage_managers(
         convert=convert_manager,
         preproc=preproc_manager,
@@ -92,6 +94,7 @@ def create_app(
     app.state.autoflatten_config_store = autoflatten_config_store
     app.state.workflow_config_store = workflow_config_store
     app.state.workflow_manager = workflow_manager
+    app.state.post_preproc_manager = post_preproc_manager
 
     # API routes
     from fmriflow.server.routes.modules import router as module_router
@@ -106,6 +109,7 @@ def create_app(
     from fmriflow.server.routes.autoflatten import router as autoflatten_router
     from fmriflow.server.routes.workflows import router as workflows_router
     from fmriflow.server.routes.triage import router as triage_router
+    from fmriflow.server.routes.post_preproc import router as post_preproc_router
     from fmriflow.server.ws import router as ws_router
 
     # Editor routes must come before module_router so that
@@ -122,6 +126,7 @@ def create_app(
     app.include_router(autoflatten_router, prefix="/api")
     app.include_router(workflows_router, prefix="/api")
     app.include_router(triage_router, prefix="/api")
+    app.include_router(post_preproc_router, prefix="/api")
     app.include_router(ws_router)
 
     # Serve built frontend (if available)

--- a/fmriflow/server/app.py
+++ b/fmriflow/server/app.py
@@ -83,10 +83,15 @@ def create_app(
     post_preproc_workflow_store = PostPreprocWorkflowStore(
         Path.home() / ".fmriflow" / "post_preproc_workflows"
     )
+    post_preproc_manager.bind_dependencies(
+        registry=registry,
+        workflow_store=post_preproc_workflow_store,
+    )
     workflow_manager.bind_stage_managers(
         convert=convert_manager,
         preproc=preproc_manager,
         autoflatten=autoflatten_manager,
+        post_preproc=post_preproc_manager,
         analysis=run_manager,
     )
 

--- a/fmriflow/server/app.py
+++ b/fmriflow/server/app.py
@@ -145,16 +145,10 @@ def create_app(
     app.include_router(triage_router, prefix="/api")
     app.include_router(structural_qc_router, prefix="/api")
     app.include_router(post_preproc_router, prefix="/api")
-    # Node-outputs route must come BEFORE preproc_router because
-    # `/preproc/runs/{run_id}/node/...` would otherwise be shadowed by
-    # the more general `{run_id}` patterns. FastAPI's matcher walks the
-    # routes in include order, so re-include this one last to take
-    # precedence... actually, FastAPI uses first-match so we want this
-    # *registered* such that the more specific path is found first.
     # `preproc_router` only handles `/preproc/runs/{run_id}` and
-    # `/preproc/runs/{run_id}/{exact-name}` (live, cancel, …) so the
-    # `/node/{path}/...` segment never collides — order doesn't matter
-    # in practice; we still register near the end for symmetry.
+    # `/preproc/runs/{run_id}/{exact-name}` (live, cancel, …), so
+    # `/preproc/runs/{run_id}/node/...` does not collide with those
+    # patterns. Include order does not affect matching here.
     app.include_router(node_outputs_router, prefix="/api")
     app.include_router(ws_router)
 

--- a/fmriflow/server/routes/modules.py
+++ b/fmriflow/server/routes/modules.py
@@ -37,6 +37,7 @@ STAGE_MODULE_CATEGORIES = {
     'model': ['models'],
     'analyze': ['analyzers'],
     'report': ['reporters'],
+    'post_preproc': ['nipype_nodes'],
 }
 
 STAGE_COLORS = {
@@ -76,6 +77,7 @@ async def get_module(request: Request, category: str, name: str):
         'analyzers': 'analyze',
         'models': 'model',
         'reporters': 'report',
+        'nipype_nodes': 'post_preproc',
     }
 
     doc = (cls.__doc__ or '').strip()

--- a/fmriflow/server/routes/node_outputs.py
+++ b/fmriflow/server/routes/node_outputs.py
@@ -1,0 +1,274 @@
+"""Per-nipype-node output endpoints.
+
+Three routes, all rooted at ``/api/preproc/runs/{run_id}/node/{node_path:path}``:
+
+- ``/files``  → list every artefact in the leaf's work_dir.
+- ``/file?rel=…`` → serve a single artefact (suffix-whitelisted, safe-join).
+- ``/pickle?rel=…`` → load a ``.pkl`` / ``.pklz`` and return a JSON
+  rendering of its contents (best-effort, opt-in).
+
+The leaf's work_dir is derived from the run's ``work_dir`` plus the
+dotted node path (``a.b.c`` → ``a/b/c``).
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import pickle
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import FileResponse
+
+router = APIRouter(tags=["node-outputs"])
+logger = logging.getLogger(__name__)
+
+# Suffixes we serve via the GET /file endpoint. Mirrors the Structural-QC
+# whitelist plus the formats fmriprep nodes commonly emit.
+_NODE_OUTPUT_SUFFIXES = {
+    ".nii", ".gz", ".mgz",
+    ".json", ".tsv", ".dat", ".csv", ".txt", ".rst", ".log", ".cfg",
+    ".svg", ".html", ".htm", ".png", ".jpg", ".jpeg", ".gif",
+    ".pklz", ".pkl",
+}
+
+# Suffixes the frontend can render in-browser without help.
+_VIEW_SUFFIXES = {
+    ".nii", ".gz", ".mgz",
+    ".json", ".tsv", ".csv", ".txt", ".rst", ".log", ".cfg",
+    ".svg", ".html", ".htm", ".png", ".jpg", ".jpeg", ".gif",
+}
+
+# Pickled outputs are listed but go through the dedicated /pickle route.
+_PICKLE_SUFFIXES = {".pklz", ".pkl"}
+
+_MEDIA_TYPES = {
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".html": "text/html",
+    ".htm": "text/html",
+    ".json": "application/json",
+    ".txt": "text/plain",
+    ".log": "text/plain",
+    ".cfg": "text/plain",
+    ".rst": "text/plain",
+    ".tsv": "text/tab-separated-values",
+    ".csv": "text/csv",
+    ".dat": "text/plain",
+}
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+def _summary(request: Request, run_id: str) -> dict:
+    mgr = request.app.state.preproc_manager
+    s = mgr.get_run(run_id)
+    if s is None:
+        raise HTTPException(404, f"Run '{run_id}' not found")
+    return s
+
+
+def _node_dir(work_dir: str | None, node_path: str) -> Path:
+    """Map a dotted node path to its work_dir leaf."""
+    if not work_dir:
+        raise HTTPException(409, "Run has no work_dir on record")
+    parts = [p for p in node_path.split(".") if p]
+    if not parts:
+        raise HTTPException(400, "Empty node path")
+    return Path(work_dir).joinpath(*parts)
+
+
+def _safe_join(root: Path, rel: str) -> Path:
+    """Resolve ``root / rel`` and refuse to leave ``root``."""
+    target = (root / rel).resolve()
+    root_resolved = root.resolve()
+    sep = "/"
+    if (
+        not str(target).startswith(str(root_resolved) + sep)
+        and target != root_resolved
+    ):
+        raise HTTPException(403, "Path escapes root")
+    return target
+
+
+def _kind_for(suffix: str, size: int) -> str:
+    """Decide whether the frontend should render this inline or
+    treat it as a link/special case."""
+    if suffix in _PICKLE_SUFFIXES:
+        return "pickle"
+    if suffix in _VIEW_SUFFIXES:
+        return "view"
+    return "link"
+
+
+# ── Pickle decoding ─────────────────────────────────────────────────────
+
+
+def _open_pickle(path: Path):
+    """Open a ``.pklz`` (gzip-wrapped) or ``.pkl`` for unpickling."""
+    if path.suffix.lower() == ".pklz":
+        return gzip.open(path, "rb")
+    return path.open("rb")
+
+
+def _to_jsonable(obj: Any, *, depth: int = 0, max_depth: int = 6) -> Any:
+    """Best-effort JSON serialisation of arbitrary pickled objects.
+
+    Renders dicts/lists/tuples/sets/scalars natively. Falls back to
+    ``repr(obj)`` for anything else, keeping the output bounded.
+    """
+    if depth > max_depth:
+        return f"…(max-depth {max_depth} reached)"
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return obj
+    if isinstance(obj, (bytes, bytearray)):
+        return f"<bytes len={len(obj)}>"
+    if isinstance(obj, dict):
+        return {
+            str(k): _to_jsonable(v, depth=depth + 1, max_depth=max_depth)
+            for k, v in list(obj.items())[:200]
+        }
+    if isinstance(obj, (list, tuple)):
+        return [
+            _to_jsonable(v, depth=depth + 1, max_depth=max_depth)
+            for v in list(obj)[:200]
+        ]
+    if isinstance(obj, set):
+        return [
+            _to_jsonable(v, depth=depth + 1, max_depth=max_depth)
+            for v in list(obj)[:200]
+        ]
+    # Numpy arrays / nipype Bunch / arbitrary objects.
+    try:
+        import numpy as np  # type: ignore
+        if isinstance(obj, np.ndarray):
+            return {
+                "__type__": "ndarray",
+                "shape": list(obj.shape),
+                "dtype": str(obj.dtype),
+                "preview": obj.flatten().tolist()[:50] if obj.size else [],
+            }
+    except Exception:  # pragma: no cover — numpy isn't required
+        pass
+    # Try a __dict__ traversal for nipype-style result objects.
+    if hasattr(obj, "__dict__"):
+        d = vars(obj)
+        if d:
+            return {
+                "__type__": type(obj).__name__,
+                **{
+                    str(k): _to_jsonable(v, depth=depth + 1, max_depth=max_depth)
+                    for k, v in list(d.items())[:200]
+                },
+            }
+    return repr(obj)[:1000]
+
+
+# ── routes ──────────────────────────────────────────────────────────────
+
+
+@router.get("/preproc/runs/{run_id}/node/{node_path:path}/files")
+async def list_node_files(request: Request, run_id: str, node_path: str):
+    """List artefacts in a node's work_dir."""
+    summary = _summary(request, run_id)
+    leaf = _node_dir(summary.get("work_dir"), node_path)
+    if not leaf.is_dir():
+        return {
+            "node": node_path,
+            "leaf_dir": str(leaf),
+            "exists": False,
+            "files": [],
+            "crashes": [],
+        }
+
+    files: list[dict] = []
+    for p in sorted(leaf.iterdir(), key=lambda x: x.name):
+        if not p.is_file():
+            continue
+        suffix = p.suffix.lower()
+        if suffix not in _NODE_OUTPUT_SUFFIXES:
+            continue
+        try:
+            size = p.stat().st_size
+        except OSError:
+            continue
+        files.append({
+            "name": p.name,
+            "rel": p.name,
+            "suffix": suffix,
+            "size": size,
+            "kind": _kind_for(suffix, size),
+        })
+
+    # Pull any matching crash files for this leaf, regardless of timestamp.
+    crashes: list[dict] = []
+    output_dir = summary.get("output_dir")
+    subject = summary.get("subject")
+    if output_dir and subject:
+        log_root = Path(output_dir) / f"sub-{subject}" / "log"
+        if log_root.is_dir():
+            leaf_name = node_path.rsplit(".", 1)[-1]
+            for cp in sorted(log_root.rglob(f"crash-*-{leaf_name}-*.txt")):
+                try:
+                    crashes.append({"name": cp.name, "path": str(cp),
+                                    "size": cp.stat().st_size})
+                except OSError:
+                    continue
+
+    return {
+        "node": node_path,
+        "leaf_dir": str(leaf),
+        "exists": True,
+        "files": files,
+        "crashes": crashes,
+    }
+
+
+@router.get("/preproc/runs/{run_id}/node/{node_path:path}/file")
+async def get_node_file(
+    request: Request, run_id: str, node_path: str, rel: str,
+):
+    """Serve a single file from a node's work_dir."""
+    summary = _summary(request, run_id)
+    leaf = _node_dir(summary.get("work_dir"), node_path)
+    suffix = Path(rel).suffix.lower()
+    if suffix not in _NODE_OUTPUT_SUFFIXES:
+        raise HTTPException(403, f"Suffix not allowed: {suffix}")
+    target = _safe_join(leaf, rel)
+    if not target.is_file():
+        raise HTTPException(404, f"File not found: {rel}")
+    media_type = _MEDIA_TYPES.get(suffix, "application/octet-stream")
+    return FileResponse(target, media_type=media_type)
+
+
+@router.get("/preproc/runs/{run_id}/node/{node_path:path}/pickle")
+async def get_node_pickle(
+    request: Request, run_id: str, node_path: str, rel: str,
+):
+    """Load a pickled file under a node's work_dir, return a JSON
+    rendering. Best-effort — unknown types fall back to ``repr``.
+    """
+    summary = _summary(request, run_id)
+    leaf = _node_dir(summary.get("work_dir"), node_path)
+    suffix = Path(rel).suffix.lower()
+    if suffix not in _PICKLE_SUFFIXES:
+        raise HTTPException(403, f"Not a pickle: {rel}")
+    target = _safe_join(leaf, rel)
+    if not target.is_file():
+        raise HTTPException(404, f"File not found: {rel}")
+    try:
+        with _open_pickle(target) as f:
+            obj = pickle.load(f)
+    except Exception as e:
+        return {"name": Path(rel).name, "error": f"{type(e).__name__}: {e}"}
+    return {
+        "name": Path(rel).name,
+        "type": type(obj).__name__,
+        "value": _to_jsonable(obj),
+    }

--- a/fmriflow/server/routes/node_outputs.py
+++ b/fmriflow/server/routes/node_outputs.py
@@ -173,6 +173,47 @@ def _to_jsonable(obj: Any, *, depth: int = 0, max_depth: int = 6) -> Any:
 # ── routes ──────────────────────────────────────────────────────────────
 
 
+@router.get("/preproc/runs/{run_id}/work_tree")
+async def list_work_tree(request: Request, run_id: str):
+    """Walk the run's work_dir and return every nipype leaf directory
+    discovered on disk.
+
+    A leaf is any directory containing ``_node.pklz`` (nipype writes
+    this for every executed node, cached or not) or ``result_*.pklz``.
+    Returned paths are dotted (``a.b.c``) relative to ``work_dir``.
+    """
+    summary = _summary(request, run_id)
+    work_dir = summary.get("work_dir")
+    if not work_dir:
+        return {"work_dir": None, "leaves": []}
+    root = Path(work_dir)
+    if not root.is_dir():
+        return {"work_dir": str(root), "leaves": []}
+
+    leaves: list[str] = []
+    # Limit walk to fmriprep workflow roots to bound work.
+    candidate_roots = [
+        p for p in root.iterdir()
+        if p.is_dir() and p.name.endswith("_wf")
+    ] or [root]
+
+    for wf_root in candidate_roots:
+        for p in wf_root.rglob("_node.pklz"):
+            leaf_dir = p.parent
+            try:
+                rel = leaf_dir.relative_to(root)
+            except ValueError:
+                continue
+            # Skip report sub-dirs and meta dirs.
+            parts = rel.parts
+            if any(seg.startswith("_report") for seg in parts):
+                continue
+            leaves.append(".".join(parts))
+
+    leaves = sorted(set(leaves))
+    return {"work_dir": str(root), "leaves": leaves}
+
+
 @router.get("/preproc/runs/{run_id}/node/{node_path:path}/files")
 async def list_node_files(request: Request, run_id: str, node_path: str):
     """List artefacts in a node's work_dir."""

--- a/fmriflow/server/routes/post_preproc.py
+++ b/fmriflow/server/routes/post_preproc.py
@@ -29,6 +29,14 @@ class RunBody(BaseModel):
     name: str | None = None
 
 
+class WorkflowSaveBody(BaseModel):
+    name: str
+    description: str = ""
+    graph: dict[str, Any]
+    inputs: dict[str, Any] = {}
+    outputs: dict[str, Any] = {}
+
+
 def _node_specs(registry):
     return registry._nipype_nodes
 
@@ -74,7 +82,8 @@ async def start_run(request: Request, body: RunBody):
         name=body.name,
     )
     mgr = request.app.state.post_preproc_manager
-    handle = mgr.start(cfg, registry)
+    workflow_store = getattr(request.app.state, "post_preproc_workflow_store", None)
+    handle = mgr.start(cfg, registry, workflow_store=workflow_store)
     return {
         "run_id": handle.run_id,
         "status": handle.status,
@@ -123,3 +132,42 @@ async def get_manifest(request: Request, subject: str, output_dir: str):
         raise HTTPException(404, f"No manifest at {p}")
     import json
     return json.loads(p.read_text())
+
+
+# ── Saved workflows ─────────────────────────────────────────────────────
+
+
+@router.get("/post-preproc/workflows")
+async def list_workflows(request: Request):
+    store = request.app.state.post_preproc_workflow_store
+    return store.list()
+
+
+@router.get("/post-preproc/workflows/{name}")
+async def get_workflow(request: Request, name: str):
+    store = request.app.state.post_preproc_workflow_store
+    wf = store.get(name)
+    if wf is None:
+        raise HTTPException(404, f"No workflow {name!r}")
+    return wf
+
+
+@router.post("/post-preproc/workflows")
+async def save_workflow(request: Request, body: WorkflowSaveBody):
+    store = request.app.state.post_preproc_workflow_store
+    path = store.save(
+        body.name,
+        body.graph,
+        description=body.description,
+        inputs=body.inputs,
+        outputs=body.outputs,
+    )
+    return {"saved": True, "path": str(path), "name": body.name}
+
+
+@router.delete("/post-preproc/workflows/{name}")
+async def delete_workflow(request: Request, name: str):
+    store = request.app.state.post_preproc_workflow_store
+    if not store.delete(name):
+        raise HTTPException(404, f"No workflow {name!r}")
+    return {"deleted": True, "name": name}

--- a/fmriflow/server/routes/post_preproc.py
+++ b/fmriflow/server/routes/post_preproc.py
@@ -1,0 +1,125 @@
+"""Post-preproc API: list nipype nodes, validate graphs, kick off runs."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from fmriflow.modules._schema import extract_schema
+from fmriflow.post_preproc.graph import PostPreprocGraph
+from fmriflow.post_preproc.manifest import PostPreprocConfig
+
+router = APIRouter(tags=["post-preproc"])
+logger = logging.getLogger(__name__)
+
+
+class ValidateBody(BaseModel):
+    graph: dict[str, Any]
+
+
+class RunBody(BaseModel):
+    subject: str
+    source_manifest_path: str
+    graph: dict[str, Any]
+    output_dir: str
+    name: str | None = None
+
+
+def _node_specs(registry):
+    return registry._nipype_nodes
+
+
+@router.get("/post-preproc/nodes")
+async def list_nodes(request: Request):
+    """Return all registered nipype-node modules with INPUTS/OUTPUTS/PARAM_SCHEMA."""
+    registry = request.app.state.registry
+    nodes = _node_specs(registry)
+    out = []
+    for name, cls in sorted(nodes.items()):
+        out.append({
+            "name": name,
+            "docstring": (cls.__doc__ or "").strip().split("\n")[0],
+            "inputs": list(getattr(cls, "INPUTS", [])),
+            "outputs": list(getattr(cls, "OUTPUTS", [])),
+            "params": extract_schema(cls),
+        })
+    return out
+
+
+@router.post("/post-preproc/graphs/validate")
+async def validate_graph(request: Request, body: ValidateBody):
+    registry = request.app.state.registry
+    g = PostPreprocGraph.from_reactflow(body.graph)
+    errors = g.validate_against(_node_specs(registry))
+    return {"valid": not errors, "errors": errors}
+
+
+@router.post("/post-preproc/run")
+async def start_run(request: Request, body: RunBody):
+    registry = request.app.state.registry
+    g = PostPreprocGraph.from_reactflow(body.graph)
+    errors = g.validate_against(_node_specs(registry))
+    if errors:
+        raise HTTPException(400, {"errors": errors})
+
+    cfg = PostPreprocConfig(
+        subject=body.subject,
+        source_manifest_path=body.source_manifest_path,
+        graph=body.graph,
+        output_dir=body.output_dir,
+        name=body.name,
+    )
+    mgr = request.app.state.post_preproc_manager
+    handle = mgr.start(cfg, registry)
+    return {
+        "run_id": handle.run_id,
+        "status": handle.status,
+        "output_dir": handle.output_dir,
+    }
+
+
+@router.get("/post-preproc/runs/{run_id}")
+async def get_run(request: Request, run_id: str):
+    mgr = request.app.state.post_preproc_manager
+    handle = mgr.get(run_id)
+    if handle is None:
+        raise HTTPException(404, f"Unknown run {run_id}")
+    return {
+        "run_id": handle.run_id,
+        "status": handle.status,
+        "error": handle.error,
+        "output_dir": handle.output_dir,
+        "manifest": handle.manifest,
+    }
+
+
+@router.get("/post-preproc/runs")
+async def list_runs(request: Request):
+    mgr = request.app.state.post_preproc_manager
+    return [
+        {
+            "run_id": h.run_id,
+            "status": h.status,
+            "output_dir": h.output_dir,
+            "subject": h.config.get("subject"),
+        }
+        for h in mgr.list()
+    ]
+
+
+@router.get("/post-preproc/manifests/{subject}")
+async def get_manifest(request: Request, subject: str, output_dir: str):
+    """Read a post_preproc_manifest.json from a given output_dir.
+
+    The frontend passes the subject's output_dir explicitly so we don't
+    need a global registry of post-preproc manifests yet.
+    """
+    p = Path(output_dir) / "post_preproc_manifest.json"
+    if not p.is_file():
+        raise HTTPException(404, f"No manifest at {p}")
+    import json
+    return json.loads(p.read_text())

--- a/fmriflow/server/routes/preproc.py
+++ b/fmriflow/server/routes/preproc.py
@@ -156,15 +156,26 @@ async def get_preproc_run_live(
     if result is None:
         raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
 
-    from fmriflow.preproc.nipype_log import parse_nipype_events_file
+    from fmriflow.preproc.nipype_log import (
+        parse_nipype_events_file,
+        reconcile_with_run_state,
+    )
 
     jsonl_path = result.get("nipype_jsonl_path")
     if jsonl_path:
         block = parse_nipype_events_file(jsonl_path, cap=cap)
+        # Run-end sweep: when the parent preproc run is `done`, mark
+        # any still-`running` nodes as `completed_assumed`. fmriprep
+        # occasionally drops terminal log lines we'd otherwise match;
+        # this is the safety net.
+        block = reconcile_with_run_state(
+            block, run_status=result.get("status", ""),
+        )
         result["nipype_status"] = block.to_dict()
     else:
         result["nipype_status"] = {
-            "counts": {"running": 0, "ok": 0, "failed": 0, "total_seen": 0},
+            "counts": {"running": 0, "ok": 0, "failed": 0,
+                       "completed_assumed": 0, "total_seen": 0},
             "recent_nodes": [],
         }
     return result

--- a/fmriflow/server/routes/preproc.py
+++ b/fmriflow/server/routes/preproc.py
@@ -140,6 +140,36 @@ async def get_preproc_run(request: Request, run_id: str):
     return result
 
 
+@router.get("/preproc/runs/{run_id}/live")
+async def get_preproc_run_live(
+    request: Request, run_id: str, cap: int = 200,
+):
+    """Live status for one preproc run, including parsed nipype-node events.
+
+    Returns the run's summary plus a ``nipype_status`` block built by
+    parsing ``nipype_events.jsonl`` next to the run's stdout log. When
+    the backend isn't fmriprep (no parser) or no events have been
+    written yet, ``nipype_status`` is an empty block.
+    """
+    mgr = request.app.state.preproc_manager
+    result = mgr.get_run(run_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+
+    from fmriflow.preproc.nipype_log import parse_nipype_events_file
+
+    jsonl_path = result.get("nipype_jsonl_path")
+    if jsonl_path:
+        block = parse_nipype_events_file(jsonl_path, cap=cap)
+        result["nipype_status"] = block.to_dict()
+    else:
+        result["nipype_status"] = {
+            "counts": {"running": 0, "ok": 0, "failed": 0, "total_seen": 0},
+            "recent_nodes": [],
+        }
+    return result
+
+
 @router.post("/preproc/runs/{run_id}/cancel")
 async def cancel_preproc_run(request: Request, run_id: str):
     """Cancel a running preprocessing job (SIGTERM then SIGKILL)."""

--- a/fmriflow/server/routes/structural_qc.py
+++ b/fmriflow/server/routes/structural_qc.py
@@ -117,6 +117,22 @@ def _build_freeview_command(fs_subject_dir: Path) -> str:
 # ── review CRUD ─────────────────────────────────────────────────────────
 
 
+@router.get("/structural-qc/reviews")
+async def list_reviews(request: Request, dataset: str | None = None):
+    """List all structural-QC reviews across datasets, or filter by one.
+
+    Returns ``[{...review fields...}]`` newest-first (by timestamp).
+    """
+    store = request.app.state.structural_qc_store
+    if dataset:
+        reviews = store.list_for_dataset(dataset)
+    else:
+        reviews = store.list_all()
+    rows = [r.to_dict() for r in reviews]
+    rows.sort(key=lambda r: r.get("timestamp") or "", reverse=True)
+    return rows
+
+
 @router.get("/preproc/subjects/{subject}/structural-qc")
 async def get_review(request: Request, subject: str):
     manifest = _manifest_for(request, subject)

--- a/fmriflow/server/routes/structural_qc.py
+++ b/fmriflow/server/routes/structural_qc.py
@@ -188,9 +188,14 @@ async def get_fs_file(request: Request, subject: str, rel: str):
     if fs_dir is None:
         raise HTTPException(404, "No FreeSurfer subject directory")
 
+    # Validate the suffix from the *requested* rel — the caller controls
+    # this, and we want to allow symlinked targets like
+    # `lh.pial → lh.pial.T1` whose resolved suffix wouldn't pass.
+    rel_suffix = Path(rel).suffix.lower()
+    if rel_suffix not in _FS_ALLOWED_SUFFIXES:
+        raise HTTPException(403, f"Suffix not allowed: {rel_suffix}")
+
     target = _safe_join(fs_dir, rel)
     if not target.is_file():
         raise HTTPException(404, f"File not found: {rel}")
-    if target.suffix.lower() not in _FS_ALLOWED_SUFFIXES:
-        raise HTTPException(403, f"Suffix not allowed: {target.suffix}")
     return FileResponse(target, media_type="application/octet-stream")

--- a/fmriflow/server/routes/structural_qc.py
+++ b/fmriflow/server/routes/structural_qc.py
@@ -31,6 +31,29 @@ _FS_ALLOWED_SUFFIXES = {
     ".png", ".svg",
 }
 
+# Files we'll serve from the fmriprep output dir to satisfy the
+# report HTML's relative URLs (figures, embedded svg, etc.).
+_OUT_ALLOWED_SUFFIXES = {
+    ".svg", ".png", ".jpg", ".jpeg", ".gif",
+    ".html", ".htm", ".css", ".js", ".json",
+    ".tsv", ".txt", ".nii", ".gz",
+}
+
+_MEDIA_TYPES = {
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".html": "text/html",
+    ".htm": "text/html",
+    ".css": "text/css",
+    ".js": "application/javascript",
+    ".json": "application/json",
+    ".tsv": "text/tab-separated-values",
+    ".txt": "text/plain",
+}
+
 
 class ReviewBody(BaseModel):
     status: str
@@ -215,3 +238,36 @@ async def get_fs_file(request: Request, subject: str, rel: str):
     if not target.is_file():
         raise HTTPException(404, f"File not found: {rel}")
     return FileResponse(target, media_type="application/octet-stream")
+
+
+# Declared LAST on purpose: this catch-all serves the fmriprep report's
+# relative asset URLs (e.g. `sub-AN/figures/foo.svg`). FastAPI matches
+# routes in declaration order, so the dedicated `/report`,
+# `/freeview-command`, and `/fs-file` endpoints above win first.
+@router.get("/preproc/subjects/{subject}/structural-qc/{rest:path}")
+async def get_report_asset(request: Request, subject: str, rest: str):
+    """Serve any file under the manifest's ``output_dir`` so the report
+    HTML's relative figure URLs resolve.
+
+    The report iframe sits at
+    ``/api/preproc/subjects/{subject}/structural-qc/report`` so the
+    browser resolves ``sub-AN/figures/foo.svg`` against
+    ``/api/preproc/subjects/AN/structural-qc/sub-AN/figures/foo.svg`` —
+    that path lands here. Suffix-whitelisted, with a safe-join check
+    against ``output_dir``.
+    """
+    manifest = _manifest_for(request, subject)
+    out = Path(manifest.get("output_dir", ""))
+    if not out.is_dir():
+        raise HTTPException(404, "Manifest output_dir does not exist")
+
+    suffix = Path(rest).suffix.lower()
+    if suffix not in _OUT_ALLOWED_SUFFIXES:
+        raise HTTPException(403, f"Suffix not allowed: {suffix}")
+
+    target = _safe_join(out, rest)
+    if not target.is_file():
+        raise HTTPException(404, f"File not found: {rest}")
+
+    media_type = _MEDIA_TYPES.get(suffix, "application/octet-stream")
+    return FileResponse(target, media_type=media_type)

--- a/fmriflow/server/routes/structural_qc.py
+++ b/fmriflow/server/routes/structural_qc.py
@@ -1,0 +1,196 @@
+"""Structural-preprocessing QC review endpoints.
+
+Endpoints:
+  GET  /preproc/subjects/{subject}/structural-qc
+  POST /preproc/subjects/{subject}/structural-qc
+  GET  /preproc/subjects/{subject}/structural-qc/freeview-command
+  GET  /preproc/subjects/{subject}/structural-qc/report
+  GET  /preproc/subjects/{subject}/structural-qc/fs-file?rel=<path>
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from fmriflow.qc.structural_review import StructuralQCReview, QC_STATUSES
+
+router = APIRouter(tags=["structural-qc"])
+logger = logging.getLogger(__name__)
+
+
+# Files we'll serve from the FS subject dir for in-browser viewing.
+_FS_ALLOWED_SUFFIXES = {
+    ".nii", ".gz", ".mgz",
+    ".pial", ".white", ".inflated", ".smoothwm",
+    ".png", ".svg",
+}
+
+
+class ReviewBody(BaseModel):
+    status: str
+    reviewer: str = ""
+    notes: str = ""
+    freeview_command_used: str | None = None
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+def _manifest_for(request: Request, subject: str) -> dict[str, Any]:
+    mgr = request.app.state.preproc_manager
+    m = mgr.get_manifest(subject)
+    if m is None:
+        raise HTTPException(404, f"No manifest for subject '{subject}'")
+    return m
+
+
+def _safe_join(root: Path, rel: str) -> Path:
+    """Resolve `root / rel` and refuse to leave `root`."""
+    target = (root / rel).resolve()
+    root_resolved = root.resolve()
+    if not str(target).startswith(str(root_resolved) + "/") and target != root_resolved:
+        raise HTTPException(403, "Path escapes root")
+    return target
+
+
+def _fs_subject_dir(manifest: dict[str, Any]) -> Path | None:
+    """Locate the FreeSurfer subject directory for the manifest, if any."""
+    fs_dir = manifest.get("freesurfer_subjects_dir")
+    subject = manifest["subject"]
+    if fs_dir:
+        cand = Path(fs_dir) / f"sub-{subject}"
+        if cand.is_dir():
+            return cand
+        cand2 = Path(fs_dir) / subject
+        if cand2.is_dir():
+            return cand2
+    # Fallback: common fmriprep layouts under output_dir
+    out = Path(manifest.get("output_dir", ""))
+    for base in (
+        out / "sourcedata" / "freesurfer",
+        out / "freesurfer",
+        out.parent / "freesurfer",
+    ):
+        for name in (f"sub-{subject}", subject):
+            cand = base / name
+            if cand.is_dir():
+                return cand
+    return None
+
+
+def _build_freeview_command(fs_subject_dir: Path) -> str:
+    """Build a freeview command using the files that actually exist."""
+    parts: list[str] = ["freeview"]
+    mri = fs_subject_dir / "mri"
+    surf = fs_subject_dir / "surf"
+
+    volumes = [
+        ("T1.mgz", ""),
+        ("brainmask.mgz", ":colormap=heat:opacity=0.3"),
+        ("aseg.mgz", ":colormap=lut:opacity=0.3"),
+    ]
+    for name, opts in volumes:
+        p = mri / name
+        if p.is_file():
+            parts.append(f"-v {p}{opts}")
+
+    surfaces = [
+        ("lh.pial", ":edgecolor=red"),
+        ("rh.pial", ":edgecolor=red"),
+        ("lh.white", ":edgecolor=yellow"),
+        ("rh.white", ":edgecolor=yellow"),
+    ]
+    for name, opts in surfaces:
+        p = surf / name
+        if p.is_file():
+            parts.append(f"-f {p}{opts}")
+
+    return " \\\n  ".join(parts)
+
+
+# ── review CRUD ─────────────────────────────────────────────────────────
+
+
+@router.get("/preproc/subjects/{subject}/structural-qc")
+async def get_review(request: Request, subject: str):
+    manifest = _manifest_for(request, subject)
+    store = request.app.state.structural_qc_store
+    review = store.get(manifest["dataset"], subject)
+    if review is None:
+        # Default "pending" record (not persisted)
+        review = StructuralQCReview(
+            dataset=manifest["dataset"], subject=subject, status="pending"
+        )
+    return review.to_dict()
+
+
+@router.post("/preproc/subjects/{subject}/structural-qc")
+async def save_review(request: Request, subject: str, body: ReviewBody):
+    if body.status not in QC_STATUSES:
+        raise HTTPException(400, f"status must be one of {QC_STATUSES}")
+    manifest = _manifest_for(request, subject)
+    review = StructuralQCReview(
+        dataset=manifest["dataset"],
+        subject=subject,
+        status=body.status,
+        reviewer=body.reviewer,
+        notes=body.notes,
+        freeview_command_used=body.freeview_command_used,
+    )
+    store = request.app.state.structural_qc_store
+    path = store.save(review)
+    return {"saved": True, "path": str(path), "review": review.to_dict()}
+
+
+# ── freeview command ────────────────────────────────────────────────────
+
+
+@router.get("/preproc/subjects/{subject}/structural-qc/freeview-command")
+async def freeview_command(request: Request, subject: str):
+    manifest = _manifest_for(request, subject)
+    fs_dir = _fs_subject_dir(manifest)
+    if fs_dir is None:
+        raise HTTPException(
+            404,
+            "Could not locate a FreeSurfer subject directory for this manifest.",
+        )
+    return {"command": _build_freeview_command(fs_dir), "fs_subject_dir": str(fs_dir)}
+
+
+# ── file serving (fmriprep report + FS files for niivue) ────────────────
+
+
+@router.get("/preproc/subjects/{subject}/structural-qc/report")
+async def get_report(request: Request, subject: str):
+    manifest = _manifest_for(request, subject)
+    out = Path(manifest.get("output_dir", ""))
+    if not out.is_dir():
+        raise HTTPException(404, "Manifest output_dir does not exist")
+    # fmriprep writes <subject>.html at the root of output_dir
+    candidates = sorted(out.glob(f"sub-{subject}*.html"))
+    if not candidates:
+        candidates = sorted(out.glob(f"{subject}*.html"))
+    if not candidates:
+        raise HTTPException(404, "No fmriprep HTML report found")
+    return FileResponse(candidates[0], media_type="text/html")
+
+
+@router.get("/preproc/subjects/{subject}/structural-qc/fs-file")
+async def get_fs_file(request: Request, subject: str, rel: str):
+    manifest = _manifest_for(request, subject)
+    fs_dir = _fs_subject_dir(manifest)
+    if fs_dir is None:
+        raise HTTPException(404, "No FreeSurfer subject directory")
+
+    target = _safe_join(fs_dir, rel)
+    if not target.is_file():
+        raise HTTPException(404, f"File not found: {rel}")
+    if target.suffix.lower() not in _FS_ALLOWED_SUFFIXES:
+        raise HTTPException(403, f"Suffix not allowed: {target.suffix}")
+    return FileResponse(target, media_type="application/octet-stream")

--- a/fmriflow/server/services/post_preproc_manager.py
+++ b/fmriflow/server/services/post_preproc_manager.py
@@ -35,6 +35,19 @@ class PostPreprocManager:
     def __init__(self):
         self._runs: dict[str, PostPreprocRunHandle] = {}
         self._lock = threading.Lock()
+        # Late-bound by app.py so `start_run_from_config_file` can build
+        # a runnable config without the caller passing them in.
+        self._registry = None
+        self._workflow_store = None
+
+    def bind_dependencies(self, *, registry, workflow_store) -> None:
+        self._registry = registry
+        self._workflow_store = workflow_store
+
+    @property
+    def active_runs(self) -> dict[str, PostPreprocRunHandle]:
+        """WorkflowManager polls this attribute on every stage manager."""
+        return self._runs
 
     def start(
         self,
@@ -93,3 +106,107 @@ class PostPreprocManager:
     def list(self) -> list[PostPreprocRunHandle]:
         with self._lock:
             return list(self._runs.values())
+
+    # ── workflow-stage entrypoint ──────────────────────────────────
+
+    def start_run_from_config_file(self, config_path: str) -> str:
+        """Run a post-preproc graph described by a stage YAML.
+
+        YAML schema::
+
+            graph: <saved-workflow-name>
+            subject: <subject-id>
+            source_manifest_path: <path-to-PreprocManifest.json>
+            output_dir: <where-to-write>
+            bindings:                       # optional
+              <wf_input_name>:
+                source_run: <run_name>      # take this run's output_file
+                # or: path: /abs/path.nii.gz
+
+        Bindings translate the workflow's exposed ``inputs:`` ports into
+        concrete files: each key looks up the workflow's declared
+        ``inputs[K] = {from: <inner_id>.<inner_handle>}`` and injects a
+        literal ``_inputs`` value on that inner node so the runner can
+        find the file.
+        """
+        import copy
+
+        import yaml
+
+        path = Path(config_path)
+        if not path.is_file():
+            raise FileNotFoundError(f"Post-preproc config not found: {path}")
+        data = yaml.safe_load(path.read_text()) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"Bad post-preproc config at {path}")
+
+        if self._registry is None or self._workflow_store is None:
+            raise RuntimeError(
+                "PostPreprocManager.bind_dependencies() not called yet"
+            )
+
+        graph_name = data.get("graph")
+        if not graph_name:
+            raise ValueError(f"{path}: 'graph' is required")
+        wf = self._workflow_store.get(graph_name)
+        if wf is None:
+            raise ValueError(
+                f"{path}: saved post-preproc workflow {graph_name!r} not found"
+            )
+
+        # Apply bindings into a copy of the inner graph.
+        inner_graph = copy.deepcopy(wf.get("graph") or {"nodes": [], "edges": []})
+        declared_inputs = wf.get("inputs") or {}
+        bindings = data.get("bindings") or {}
+        if bindings:
+            from fmriflow.preproc.manifest import PreprocManifest
+            src_manifest = PreprocManifest.from_json(data["source_manifest_path"])
+            for wf_input, binding in bindings.items():
+                decl = declared_inputs.get(wf_input)
+                if not decl:
+                    raise ValueError(
+                        f"binding {wf_input!r} not declared by workflow "
+                        f"{graph_name!r} (declared: {list(declared_inputs)})"
+                    )
+                from_str = decl.get("from") if isinstance(decl, dict) else str(decl)
+                if not from_str or "." not in from_str:
+                    raise ValueError(
+                        f"workflow {graph_name!r} input {wf_input!r} has bad "
+                        f"target {decl!r}"
+                    )
+                inner_id, inner_handle = from_str.split(".", 1)
+                file_path = self._resolve_binding(binding, src_manifest)
+                for node in inner_graph.get("nodes", []):
+                    if node.get("id") == inner_id:
+                        params = node.setdefault("data", {}).setdefault("params", {})
+                        inputs_map = params.setdefault("_inputs", {})
+                        inputs_map[inner_handle] = file_path
+                        break
+
+        config = PostPreprocConfig(
+            subject=data.get("subject", ""),
+            source_manifest_path=data["source_manifest_path"],
+            graph=inner_graph,
+            output_dir=data["output_dir"],
+            name=graph_name,
+        )
+        handle = self.start(
+            config, self._registry, workflow_store=self._workflow_store,
+        )
+        return handle.run_id
+
+    @staticmethod
+    def _resolve_binding(binding: dict, src_manifest) -> str:
+        if not isinstance(binding, dict):
+            raise ValueError(f"binding must be a mapping, got {binding!r}")
+        if "path" in binding:
+            return str(binding["path"])
+        if "source_run" in binding:
+            run_name = binding["source_run"]
+            for r in src_manifest.runs:
+                if r.run_name == run_name:
+                    return str(Path(src_manifest.output_dir) / r.output_file)
+            raise ValueError(
+                f"binding source_run={run_name!r} not in source manifest"
+            )
+        raise ValueError(f"binding requires 'path' or 'source_run', got {binding!r}")

--- a/fmriflow/server/services/post_preproc_manager.py
+++ b/fmriflow/server/services/post_preproc_manager.py
@@ -176,12 +176,19 @@ class PostPreprocManager:
                     )
                 inner_id, inner_handle = from_str.split(".", 1)
                 file_path = self._resolve_binding(binding, src_manifest)
+                found_inner_node = False
                 for node in inner_graph.get("nodes", []):
                     if node.get("id") == inner_id:
                         params = node.setdefault("data", {}).setdefault("params", {})
                         inputs_map = params.setdefault("_inputs", {})
                         inputs_map[inner_handle] = file_path
+                        found_inner_node = True
                         break
+                if not found_inner_node:
+                    raise ValueError(
+                        f"workflow {graph_name!r} input {wf_input!r} targets "
+                        f"missing inner node/handle {inner_id}.{inner_handle}"
+                    )
 
         config = PostPreprocConfig(
             subject=data.get("subject", ""),

--- a/fmriflow/server/services/post_preproc_manager.py
+++ b/fmriflow/server/services/post_preproc_manager.py
@@ -36,7 +36,12 @@ class PostPreprocManager:
         self._runs: dict[str, PostPreprocRunHandle] = {}
         self._lock = threading.Lock()
 
-    def start(self, config: PostPreprocConfig, registry) -> PostPreprocRunHandle:
+    def start(
+        self,
+        config: PostPreprocConfig,
+        registry,
+        workflow_store=None,
+    ) -> PostPreprocRunHandle:
         run_id = uuid.uuid4().hex[:12]
         handle = PostPreprocRunHandle(
             run_id=run_id,
@@ -56,16 +61,20 @@ class PostPreprocManager:
         )
 
         thread = threading.Thread(
-            target=self._run, args=(run_id, cfg_with_run, registry), daemon=True
+            target=self._run,
+            args=(run_id, cfg_with_run, registry, workflow_store),
+            daemon=True,
         )
         thread.start()
         return handle
 
-    def _run(self, run_id: str, config: PostPreprocConfig, registry) -> None:
+    def _run(self, run_id: str, config: PostPreprocConfig, registry, workflow_store) -> None:
         with self._lock:
             self._runs[run_id].status = "running"
         try:
-            manifest = run_post_preproc(config, registry=registry)
+            manifest = run_post_preproc(
+                config, registry=registry, workflow_store=workflow_store,
+            )
             with self._lock:
                 handle = self._runs[run_id]
                 handle.status = "done"

--- a/fmriflow/server/services/post_preproc_manager.py
+++ b/fmriflow/server/services/post_preproc_manager.py
@@ -1,0 +1,86 @@
+"""Threaded post-preproc run manager.
+
+v1 runs each graph in a background thread and tracks status in memory.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import traceback
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from fmriflow.post_preproc.manifest import PostPreprocConfig
+from fmriflow.post_preproc.runner import run_post_preproc
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PostPreprocRunHandle:
+    run_id: str
+    status: str = "pending"  # pending | running | done | failed
+    error: str | None = None
+    output_dir: str = ""
+    manifest: dict[str, Any] | None = None
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+class PostPreprocManager:
+    """In-memory tracker for post-preproc runs."""
+
+    def __init__(self):
+        self._runs: dict[str, PostPreprocRunHandle] = {}
+        self._lock = threading.Lock()
+
+    def start(self, config: PostPreprocConfig, registry) -> PostPreprocRunHandle:
+        run_id = uuid.uuid4().hex[:12]
+        handle = PostPreprocRunHandle(
+            run_id=run_id,
+            status="pending",
+            output_dir=str(Path(config.output_dir) / run_id),
+            config=config.__dict__,
+        )
+        with self._lock:
+            self._runs[run_id] = handle
+
+        cfg_with_run = PostPreprocConfig(
+            subject=config.subject,
+            source_manifest_path=config.source_manifest_path,
+            graph=config.graph,
+            output_dir=handle.output_dir,
+            name=config.name,
+        )
+
+        thread = threading.Thread(
+            target=self._run, args=(run_id, cfg_with_run, registry), daemon=True
+        )
+        thread.start()
+        return handle
+
+    def _run(self, run_id: str, config: PostPreprocConfig, registry) -> None:
+        with self._lock:
+            self._runs[run_id].status = "running"
+        try:
+            manifest = run_post_preproc(config, registry=registry)
+            with self._lock:
+                handle = self._runs[run_id]
+                handle.status = "done"
+                handle.manifest = manifest.to_dict()
+        except Exception as e:
+            logger.exception("post-preproc run %s failed", run_id)
+            with self._lock:
+                handle = self._runs[run_id]
+                handle.status = "failed"
+                handle.error = f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
+
+    def get(self, run_id: str) -> PostPreprocRunHandle | None:
+        with self._lock:
+            return self._runs.get(run_id)
+
+    def list(self) -> list[PostPreprocRunHandle]:
+        with self._lock:
+            return list(self._runs.values())

--- a/fmriflow/server/services/post_preproc_workflow_store.py
+++ b/fmriflow/server/services/post_preproc_workflow_store.py
@@ -1,0 +1,116 @@
+"""Disk-backed registry of saved post-preproc workflows.
+
+Each workflow is one YAML file at::
+
+    {root}/<name>.yaml
+
+Default root is ``~/.fmriflow/post_preproc_workflows/``. The YAML wraps
+the existing ReactFlow-shape graph::
+
+    name: smooth_then_mask
+    description: Optional one-liner.
+    inputs:
+      in_file: { from: smo.in_file }
+    outputs:
+      out_file: { from: msk.out_file }
+    graph:
+      nodes: [...]
+      edges: [...]
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _safe(name: str) -> str:
+    if not name or not _SAFE_NAME.match(name):
+        raise ValueError(f"Unsafe workflow name: {name!r}")
+    return name
+
+
+class PostPreprocWorkflowStore:
+    """List/get/save/delete YAML workflows on disk."""
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+
+    def _path(self, name: str) -> Path:
+        return self.root / f"{_safe(name)}.yaml"
+
+    def list(self) -> list[dict[str, Any]]:
+        if not self.root.is_dir():
+            return []
+        out: list[dict[str, Any]] = []
+        for p in sorted(self.root.glob("*.yaml")):
+            try:
+                data = yaml.safe_load(p.read_text()) or {}
+            except yaml.YAMLError as e:
+                logger.warning("Bad workflow YAML %s: %s", p, e)
+                continue
+            if not isinstance(data, dict):
+                continue
+            out.append({
+                "name": data.get("name", p.stem),
+                "description": data.get("description", ""),
+                "inputs": list((data.get("inputs") or {}).keys()),
+                "outputs": list((data.get("outputs") or {}).keys()),
+                "n_nodes": len(((data.get("graph") or {}).get("nodes") or [])),
+            })
+        return out
+
+    def get(self, name: str) -> dict[str, Any] | None:
+        p = self._path(name)
+        if not p.is_file():
+            return None
+        try:
+            data = yaml.safe_load(p.read_text()) or {}
+        except yaml.YAMLError as e:
+            logger.warning("Bad workflow YAML %s: %s", p, e)
+            return None
+        if not isinstance(data, dict):
+            return None
+        # Normalize.
+        data.setdefault("name", name)
+        data.setdefault("description", "")
+        data.setdefault("inputs", {})
+        data.setdefault("outputs", {})
+        data.setdefault("graph", {"nodes": [], "edges": []})
+        return data
+
+    def save(
+        self,
+        name: str,
+        graph: dict[str, Any],
+        *,
+        description: str = "",
+        inputs: dict[str, Any] | None = None,
+        outputs: dict[str, Any] | None = None,
+    ) -> Path:
+        p = self._path(name)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        body = {
+            "name": _safe(name),
+            "description": description,
+            "inputs": inputs or {},
+            "outputs": outputs or {},
+            "graph": graph,
+        }
+        p.write_text(yaml.safe_dump(body, sort_keys=False))
+        return p
+
+    def delete(self, name: str) -> bool:
+        p = self._path(name)
+        if not p.is_file():
+            return False
+        p.unlink()
+        return True

--- a/fmriflow/server/services/preproc_manager.py
+++ b/fmriflow/server/services/preproc_manager.py
@@ -62,6 +62,9 @@ class PreprocRunHandle:
     is_reattached: bool = False
     config_path: str | None = None
     params: dict = field(default_factory=dict)
+    # JSONL of parsed nipype-node events, populated by _LogTailer when the
+    # backend is fmriprep. Used by /api/preproc/runs/{run_id}/live.
+    nipype_jsonl_path: str | None = None
 
     def push_event(self, event: dict) -> None:
         event.setdefault("timestamp", time.time())
@@ -89,6 +92,7 @@ class PreprocRunHandle:
             "error": self.error,
             "config_path": self.config_path,
             "log_path": self.log_path,
+            "nipype_jsonl_path": self.nipype_jsonl_path,
         }
 
 
@@ -250,6 +254,11 @@ class PreprocManager:
         )
         self.registry.register(state)
         handle.log_path = state.stdout_log
+        # Sibling JSONL for parsed nipype-node events (only fmriprep populates it).
+        if params.get("backend") == "fmriprep":
+            handle.nipype_jsonl_path = str(
+                Path(state.stdout_log).parent / "nipype_events.jsonl"
+            )
 
         self.active_runs[run_id] = handle
 
@@ -363,10 +372,14 @@ class PreprocManager:
                         exc_info=True,
                     )
 
+            nipype_jsonl_path = (
+                Path(handle.nipype_jsonl_path) if handle.nipype_jsonl_path else None
+            )
             tailer = _LogTailer(
                 log_path, handle,
                 stop_when=lambda: proc.poll() is not None,
                 on_fatal_line=_sigterm_proc_group,
+                nipype_jsonl_path=nipype_jsonl_path,
             )
             tailer.start()
 
@@ -532,6 +545,10 @@ class PreprocManager:
                 config_path=state.config_path,
                 params=state.params,
             )
+            if state.backend == "fmriprep" and state.stdout_log:
+                handle.nipype_jsonl_path = str(
+                    Path(state.stdout_log).parent / "nipype_events.jsonl"
+                )
             self.active_runs[state.run_id] = handle
 
             monitor = _ReattachedMonitor(handle, self, state)
@@ -816,6 +833,7 @@ class _LogTailer(threading.Thread):
         stop_when,
         poll_interval: float = 0.5,
         on_fatal_line=None,
+        nipype_jsonl_path: Path | None = None,
     ):
         super().__init__(daemon=True, name=f"tail-{handle.run_id}")
         self.log_path = log_path
@@ -825,6 +843,13 @@ class _LogTailer(threading.Thread):
         self._stop_flag = threading.Event()
         self._on_fatal_line = on_fatal_line
         self._fatal_fired = False
+        # Optional nipype log parsing (only meaningful for fmriprep stdout).
+        self._nipype_jsonl_path = nipype_jsonl_path
+        if nipype_jsonl_path is not None:
+            from fmriflow.preproc.nipype_log import NipypeLogParser
+            self._nipype_parser: object | None = NipypeLogParser()
+        else:
+            self._nipype_parser = None
 
     def run(self) -> None:
         # Wait briefly for the file to exist
@@ -856,6 +881,20 @@ class _LogTailer(threading.Thread):
 
     def _emit(self, line: str) -> None:
         self.handle.push_event({"event": "log", "message": line})
+
+        # Parse nipype lines (cheap; one regex check per line) and persist.
+        if self._nipype_parser is not None and self._nipype_jsonl_path is not None:
+            try:
+                from fmriflow.preproc.nipype_log import append_jsonl
+                for ev in self._nipype_parser.feed(line):
+                    append_jsonl(self._nipype_jsonl_path, ev)
+                    # Also push to in-memory event queue for any live consumers.
+                    self.handle.push_event(ev)
+            except Exception:
+                # Never let log parsing kill the tailer.
+                logger.debug(
+                    "nipype log parser raised", exc_info=True,
+                )
 
         if not self._fatal_fired and self._on_fatal_line is not None:
             for marker in self._FATAL_MARKERS:
@@ -926,10 +965,15 @@ class _ReattachedMonitor:
 
         tailer = None
         if log_path and log_path.is_file():
+            nipype_jsonl_path = (
+                Path(self.handle.nipype_jsonl_path)
+                if self.handle.nipype_jsonl_path else None
+            )
             tailer = _LogTailer(
                 log_path, self.handle,
                 stop_when=stop_when,
                 on_fatal_line=_sigterm_proc_group,
+                nipype_jsonl_path=nipype_jsonl_path,
             )
             tailer.start()
 

--- a/fmriflow/server/services/preproc_manager.py
+++ b/fmriflow/server/services/preproc_manager.py
@@ -651,6 +651,13 @@ class PreprocManager:
             }
         log_path = summary.get("log_path")
         summary["log_tail"] = _read_tail(log_path, n=200) if log_path else ""
+        # Derive nipype_jsonl_path from the log path on the registry-fallback
+        # branch — it's not persisted in state.json, but the JSONL always
+        # lives next to stdout.log when fmriprep wrote one.
+        if not summary.get("nipype_jsonl_path") and log_path:
+            candidate = Path(log_path).parent / "nipype_events.jsonl"
+            if candidate.is_file():
+                summary["nipype_jsonl_path"] = str(candidate)
         return summary
 
     def delete_run(self, run_id: str) -> dict:

--- a/fmriflow/server/services/preproc_manager.py
+++ b/fmriflow/server/services/preproc_manager.py
@@ -123,33 +123,70 @@ class PreprocManager:
     # ── Manifest scanning ────────────────────────────────────────
 
     def scan_manifests(self) -> list[dict]:
-        """Scan derivatives dir for preproc_manifest.json files."""
+        """Scan for ``preproc_manifest.json`` files.
+
+        Two sources, deduplicated by absolute path:
+
+        1. The configured ``derivatives_dir`` (default ``./derivatives``)
+           — recursive glob.
+        2. The output_dir of every completed preproc run on the run
+           registry. Catches manifests written outside the configured
+           derivatives root (e.g. under ``./testing/<study>/...``).
+        """
         now = time.time()
         if self._manifests_cache is not None and (now - self._cache_time) < self._cache_ttl:
             return self._manifests_cache
 
-        manifests = []
-        if not self.derivatives_dir.is_dir():
-            self._manifests_cache = []
-            self._cache_time = now
-            return []
+        from fmriflow.preproc.manifest import PreprocManifest
 
-        for mf in sorted(self.derivatives_dir.rglob("preproc_manifest.json")):
+        seen: set[str] = set()
+        manifests: list[dict] = []
+
+        def _add(mf: Path) -> None:
+            ap = str(mf.resolve())
+            if ap in seen:
+                return
+            seen.add(ap)
             try:
-                from fmriflow.preproc.manifest import PreprocManifest
                 m = PreprocManifest.from_json(mf)
-                manifests.append({
-                    "subject": m.subject,
-                    "path": str(mf),
-                    "backend": m.backend,
-                    "backend_version": m.backend_version,
-                    "space": m.space,
-                    "n_runs": len(m.runs),
-                    "created": m.created,
-                    "dataset": m.dataset,
-                })
             except Exception:
                 logger.warning("Could not read manifest: %s", mf, exc_info=True)
+                return
+            manifests.append({
+                "subject": m.subject,
+                "path": ap,
+                "backend": m.backend,
+                "backend_version": m.backend_version,
+                "space": m.space,
+                "n_runs": len(m.runs),
+                "created": m.created,
+                "dataset": m.dataset,
+            })
+
+        if self.derivatives_dir.is_dir():
+            for mf in sorted(self.derivatives_dir.rglob("preproc_manifest.json")):
+                _add(mf)
+
+        # Also pick up manifests recorded by the run registry — covers
+        # output_dirs outside the configured derivatives root.
+        try:
+            for state in self.registry.list_all():
+                if state.kind != "preproc" or state.status != "done":
+                    continue
+                # First preference: explicit manifest_path on the state.
+                if state.manifest_path:
+                    p = Path(state.manifest_path)
+                    if p.is_file():
+                        _add(p)
+                        continue
+                # Fallback: derive from output_dir + subject.
+                out = (state.params or {}).get("output_dir") if state.params else None
+                if out:
+                    p = Path(out) / f"sub-{state.subject}" / "preproc_manifest.json"
+                    if p.is_file():
+                        _add(p)
+        except Exception:
+            logger.warning("Could not scan run registry for manifests", exc_info=True)
 
         self._manifests_cache = manifests
         self._cache_time = now

--- a/fmriflow/server/services/preproc_manager.py
+++ b/fmriflow/server/services/preproc_manager.py
@@ -93,6 +93,8 @@ class PreprocRunHandle:
             "config_path": self.config_path,
             "log_path": self.log_path,
             "nipype_jsonl_path": self.nipype_jsonl_path,
+            "work_dir": (self.params or {}).get("work_dir"),
+            "output_dir": (self.params or {}).get("output_dir"),
         }
 
 
@@ -648,6 +650,8 @@ class PreprocManager:
                 "error": state.error,
                 "config_path": state.config_path,
                 "log_path": state.stdout_log,
+                "work_dir": (state.params or {}).get("work_dir"),
+                "output_dir": (state.params or {}).get("output_dir"),
             }
         log_path = summary.get("log_path")
         summary["log_tail"] = _read_tail(log_path, n=200) if log_path else ""

--- a/fmriflow/server/services/structural_qc_store.py
+++ b/fmriflow/server/services/structural_qc_store.py
@@ -70,6 +70,21 @@ class StructuralQCStore:
                 logger.warning("Skipping QC review %s: %s", p, e)
         return out
 
+    def list_all(self) -> list[StructuralQCReview]:
+        """Return every review across every dataset under ``root``."""
+        out: list[StructuralQCReview] = []
+        if not self.root.is_dir():
+            return out
+        for d in sorted(self.root.iterdir()):
+            if not d.is_dir():
+                continue
+            try:
+                _safe(d.name)
+            except ValueError:
+                continue  # skip stray dirs that aren't valid dataset names
+            out.extend(self.list_for_dataset(d.name))
+        return out
+
     # ── writes ──────────────────────────────────────────────────────
 
     def save(self, review: StructuralQCReview) -> Path:

--- a/fmriflow/server/services/structural_qc_store.py
+++ b/fmriflow/server/services/structural_qc_store.py
@@ -1,0 +1,80 @@
+"""StructuralQCStore — persists structural-QC reviews to disk.
+
+Reviews live at::
+
+    {root}/<dataset>/<subject>.yaml
+
+Default root is ``~/.fmriflow/structural_qc/``. One YAML per (dataset, subject).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from fmriflow.qc.structural_review import StructuralQCReview, now_iso
+
+logger = logging.getLogger(__name__)
+
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _safe(name: str) -> str:
+    """Reject names with path separators or other unsafe chars."""
+    if not name or not _SAFE_NAME.match(name):
+        raise ValueError(f"Unsafe name: {name!r}")
+    return name
+
+
+class StructuralQCStore:
+    """Disk-backed registry of structural-QC reviews."""
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+
+    # ── path helpers ────────────────────────────────────────────────
+
+    def _path(self, dataset: str, subject: str) -> Path:
+        return self.root / _safe(dataset) / f"{_safe(subject)}.yaml"
+
+    # ── reads ───────────────────────────────────────────────────────
+
+    def get(self, dataset: str, subject: str) -> StructuralQCReview | None:
+        p = self._path(dataset, subject)
+        if not p.is_file():
+            return None
+        try:
+            data = yaml.safe_load(p.read_text()) or {}
+        except yaml.YAMLError as e:
+            logger.warning("Bad QC review YAML at %s: %s", p, e)
+            return None
+        if not isinstance(data, dict):
+            return None
+        return StructuralQCReview.from_dict(data)
+
+    def list_for_dataset(self, dataset: str) -> list[StructuralQCReview]:
+        d = self.root / _safe(dataset)
+        if not d.is_dir():
+            return []
+        out: list[StructuralQCReview] = []
+        for p in sorted(d.glob("*.yaml")):
+            try:
+                data = yaml.safe_load(p.read_text()) or {}
+                if isinstance(data, dict):
+                    out.append(StructuralQCReview.from_dict(data))
+            except (yaml.YAMLError, ValueError) as e:
+                logger.warning("Skipping QC review %s: %s", p, e)
+        return out
+
+    # ── writes ──────────────────────────────────────────────────────
+
+    def save(self, review: StructuralQCReview) -> Path:
+        review.timestamp = now_iso()
+        p = self._path(review.dataset, review.subject)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(yaml.safe_dump(review.to_dict(), sort_keys=False))
+        return p

--- a/fmriflow/server/services/templates.py
+++ b/fmriflow/server/services/templates.py
@@ -201,6 +201,41 @@ class {class_name}:
         return []
 ''',
 
+    'nipype_nodes': '''\
+"""Custom post-fmriprep node: {name}."""
+
+from pathlib import Path
+from typing import Any
+
+from fmriflow.modules._decorators import nipype_node
+
+
+@nipype_node("{name}")
+class {class_name}:
+    """Short description of what this node does."""
+
+    INPUTS = ["in_file"]
+    OUTPUTS = ["out_file"]
+
+    PARAM_SCHEMA: dict[str, Any] = {{
+        # "fwhm": {{"type": "float", "default": 5.0, "description": "..."}},
+    }}
+
+    def run(
+        self,
+        inputs: dict[str, Path],
+        out_dir: Path,
+        params: dict[str, Any],
+    ) -> dict[str, Path]:
+        in_file = Path(inputs["in_file"])
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        # YOUR LOGIC HERE — produce one file per OUTPUTS handle.
+        out_path = out_dir / f"{{in_file.stem}}_{name}.nii.gz"
+
+        return {{"out_file": out_path}}
+''',
+
     'models': '''\
 """Custom model: {name}."""
 

--- a/fmriflow/server/services/workflow_manager.py
+++ b/fmriflow/server/services/workflow_manager.py
@@ -37,7 +37,9 @@ from fmriflow.server.services.workflow_config_store import (
 logger = logging.getLogger(__name__)
 
 
-STAGE_KEYS: tuple[str, ...] = ("convert", "preproc", "autoflatten", "analysis")
+STAGE_KEYS: tuple[str, ...] = (
+    "convert", "preproc", "autoflatten", "post_preproc", "analysis",
+)
 
 
 @dataclass
@@ -414,6 +416,8 @@ class WorkflowManager:
         elif stage.stage == "preproc":
             return mgr.start_run_from_config_file(stage.config)
         elif stage.stage == "autoflatten":
+            return mgr.start_run_from_config_file(stage.config)
+        elif stage.stage == "post_preproc":
             return mgr.start_run_from_config_file(stage.config)
         elif stage.stage == "analysis":
             return mgr.start_run_from_config(stage.config)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.0",
         "@monaco-editor/react": "^4.7.0",
+        "@niivue/niivue": "^0.45.0",
         "@xyflow/react": "^12.10.2",
         "dagre": "^0.8.5",
         "js-yaml": "^4.1.0",
@@ -803,6 +804,27 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@monaco-editor/loader": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
@@ -824,6 +846,25 @@
         "monaco-editor": ">= 0.25.0 < 1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@niivue/niivue": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@niivue/niivue/-/niivue-0.45.1.tgz",
+      "integrity": "sha512-1KfuiIbdJr0fi9Odv/Wjrej580B295q+fE+PAIW9L5ZrJhCmsMzYgxYecJGcj67tu8mcwQkKjbLaO6VxdVS3+g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.1",
+        "@ungap/structured-clone": "^1.2.0",
+        "array-equal": "^1.0.2",
+        "daikon": "^1.2.46",
+        "fflate": "^0.8.2",
+        "gl-matrix": "^3.4.3",
+        "nifti-reader-js": "^0.6.8",
+        "rxjs": "^7.8.1"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.18.1"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1060,7 +1101,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1292,6 +1332,12 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1310,6 +1356,15 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@wearemothership/dicom-character-set": {
+      "version": "1.0.4-opt.1",
+      "resolved": "https://registry.npmjs.org/@wearemothership/dicom-character-set/-/dicom-character-set-1.0.4-opt.1.tgz",
+      "integrity": "sha512-stqhnpawYHY2UZKj4RHTF71ab3q3z8S1SO9ToQKjsHQwowUdFVo6YFea93psFux3yqNbRlQjwoCdPjHcD0YQzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@xyflow/react": {
@@ -1376,6 +1431,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/array-equal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.2.tgz",
+      "integrity": "sha512-gUHx76KtnhEgB3HOuFYiCm3FIdEs6ocM2asHvNTkfu/Y09qQVrrVVaOKENmS2KkSaGoxgXNqC+ZVtR/n0MOkSA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
@@ -1448,6 +1512,12 @@
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1465,6 +1535,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1587,6 +1663,19 @@
         "lodash": "^4.17.15"
       }
     },
+    "node_modules/daikon": {
+      "version": "1.2.46",
+      "resolved": "https://registry.npmjs.org/daikon/-/daikon-1.2.46.tgz",
+      "integrity": "sha512-S8dTTlsWYTH3LQztjTW9KnNvxDeL2mr2cau0auLdYMJe4TrocYP1PmidHizO3rXUs+gXpBWI1PQ2qvB4b21QFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@wearemothership/dicom-character-set": "^1.0.4-opt.1",
+        "fflate": "*",
+        "jpeg-lossless-decoder-js": "2.0.7",
+        "pako": "^2.1",
+        "xss": "1.0.14"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1687,6 +1776,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1710,6 +1805,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/graphlib": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
@@ -1718,6 +1819,12 @@
       "dependencies": {
         "lodash": "^4.17.15"
       }
+    },
+    "node_modules/jpeg-lossless-decoder-js": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/jpeg-lossless-decoder-js/-/jpeg-lossless-decoder-js-2.0.7.tgz",
+      "integrity": "sha512-tbZlhFkKmx+JaqVMkq47SKWGuXLkIaV8fTbnhO39dYEnQrSShLGuLCGb0n6ntXjtmk6oAWGiIriWOLwj9od0yQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -1823,11 +1930,26 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nifti-reader-js": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/nifti-reader-js/-/nifti-reader-js-0.6.9.tgz",
+      "integrity": "sha512-oEC35cuYFR0i+KeXhaK0hJz4oSj511Vo7LmO/6iqbxzwek6XWnBi77VURlk4jsnJ86tlJNpYv6ujmSDpPP46Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "*"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1981,6 +2103,15 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/scheduler": {
@@ -2162,6 +2293,22 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xss": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
+      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/yallist": {
@@ -2649,6 +2796,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="
+    },
+    "@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "requires": {
+        "@lukeed/csprng": "^1.1.0"
+      }
+    },
     "@monaco-editor/loader": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
@@ -2663,6 +2823,22 @@
       "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
       "requires": {
         "@monaco-editor/loader": "^1.5.0"
+      }
+    },
+    "@niivue/niivue": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@niivue/niivue/-/niivue-0.45.1.tgz",
+      "integrity": "sha512-1KfuiIbdJr0fi9Odv/Wjrej580B295q+fE+PAIW9L5ZrJhCmsMzYgxYecJGcj67tu8mcwQkKjbLaO6VxdVS3+g==",
+      "requires": {
+        "@lukeed/uuid": "^2.0.1",
+        "@rollup/rollup-linux-x64-gnu": "^4.18.1",
+        "@ungap/structured-clone": "^1.2.0",
+        "array-equal": "^1.0.2",
+        "daikon": "^1.2.46",
+        "fflate": "^0.8.2",
+        "gl-matrix": "^3.4.3",
+        "nifti-reader-js": "^0.6.8",
+        "rxjs": "^7.8.1"
       }
     },
     "@rolldown/pluginutils": {
@@ -2794,7 +2970,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
       "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-x64-musl": {
@@ -2971,6 +3146,11 @@
       "optional": true,
       "peer": true
     },
+    "@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
+    },
     "@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2984,6 +3164,11 @@
         "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.17.0"
       }
+    },
+    "@wearemothership/dicom-character-set": {
+      "version": "1.0.4-opt.1",
+      "resolved": "https://registry.npmjs.org/@wearemothership/dicom-character-set/-/dicom-character-set-1.0.4-opt.1.tgz",
+      "integrity": "sha512-stqhnpawYHY2UZKj4RHTF71ab3q3z8S1SO9ToQKjsHQwowUdFVo6YFea93psFux3yqNbRlQjwoCdPjHcD0YQzw=="
     },
     "@xyflow/react": {
       "version": "12.10.2",
@@ -3026,6 +3211,11 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
+    "array-equal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.2.tgz",
+      "integrity": "sha512-gUHx76KtnhEgB3HOuFYiCm3FIdEs6ocM2asHvNTkfu/Y09qQVrrVVaOKENmS2KkSaGoxgXNqC+ZVtR/n0MOkSA=="
+    },
     "baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -3056,6 +3246,11 @@
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3066,6 +3261,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="
+    },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "csstype": {
       "version": "3.2.3",
@@ -3148,6 +3348,18 @@
         "lodash": "^4.17.15"
       }
     },
+    "daikon": {
+      "version": "1.2.46",
+      "resolved": "https://registry.npmjs.org/daikon/-/daikon-1.2.46.tgz",
+      "integrity": "sha512-S8dTTlsWYTH3LQztjTW9KnNvxDeL2mr2cau0auLdYMJe4TrocYP1PmidHizO3rXUs+gXpBWI1PQ2qvB4b21QFw==",
+      "requires": {
+        "@wearemothership/dicom-character-set": "^1.0.4-opt.1",
+        "fflate": "*",
+        "jpeg-lossless-decoder-js": "2.0.7",
+        "pako": "^2.1",
+        "xss": "1.0.14"
+      }
+    },
     "debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3219,6 +3431,11 @@
       "dev": true,
       "requires": {}
     },
+    "fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    },
     "fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3232,6 +3449,11 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
+    "gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="
+    },
     "graphlib": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
@@ -3239,6 +3461,11 @@
       "requires": {
         "lodash": "^4.17.15"
       }
+    },
+    "jpeg-lossless-decoder-js": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/jpeg-lossless-decoder-js/-/jpeg-lossless-decoder-js-2.0.7.tgz",
+      "integrity": "sha512-tbZlhFkKmx+JaqVMkq47SKWGuXLkIaV8fTbnhO39dYEnQrSShLGuLCGb0n6ntXjtmk6oAWGiIriWOLwj9od0yQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -3308,11 +3535,24 @@
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true
     },
+    "nifti-reader-js": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/nifti-reader-js/-/nifti-reader-js-0.6.9.tgz",
+      "integrity": "sha512-oEC35cuYFR0i+KeXhaK0hJz4oSj511Vo7LmO/6iqbxzwek6XWnBi77VURlk4jsnJ86tlJNpYv6ujmSDpPP46Tw==",
+      "requires": {
+        "fflate": "*"
+      }
+    },
     "node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true
+    },
+    "pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "picocolors": {
       "version": "1.1.1",
@@ -3408,6 +3648,14 @@
         "fsevents": "~2.3.2"
       }
     },
+    "rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3485,6 +3733,15 @@
         "postcss": "^8.5.3",
         "rollup": "^4.34.9",
         "tinyglobby": "^0.2.13"
+      }
+    },
+    "xss": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
+      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
+      "requires": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
       }
     },
     "yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.0",
     "@monaco-editor/react": "^4.7.0",
+    "@niivue/niivue": "^0.45.0",
     "@xyflow/react": "^12.10.2",
     "dagre": "^0.8.5",
     "js-yaml": "^4.1.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,9 +13,10 @@ import { AutoflattenManager } from './views/AutoflattenManager'
 import { PipelineGraph } from './views/PipelineGraph'
 import { WorkflowsView } from './views/WorkflowsView'
 import { PostPreprocBuilder } from './views/PostPreprocBuilder'
+import { QCReviews } from './views/QCReviews'
 import { useModuleStore } from './stores/module-store'
 
-type Route = 'modules' | 'composer' | 'runs' | 'editor' | 'dashboard' | 'preproc' | 'convert' | 'autoflatten' | 'graph' | 'errors' | 'workflows' | 'post-preproc'
+type Route = 'modules' | 'composer' | 'runs' | 'editor' | 'dashboard' | 'preproc' | 'convert' | 'autoflatten' | 'graph' | 'errors' | 'workflows' | 'post-preproc' | 'qc-reviews'
 
 function getRoute(): Route {
   const hash = window.location.hash.replace('#', '').replace('/', '')
@@ -31,6 +32,7 @@ function getRoute(): Route {
   if (hash === 'errors') return 'errors'
   if (hash === 'workflows') return 'workflows'
   if (hash === 'post-preproc') return 'post-preproc'
+  if (hash === 'qc-reviews') return 'qc-reviews'
   return 'dashboard'
 }
 
@@ -132,6 +134,7 @@ export function App() {
         {route === 'errors' && <ErrorBrowser />}
         {route === 'workflows' && <WorkflowsView />}
         {route === 'post-preproc' && <PostPreprocBuilder />}
+        {route === 'qc-reviews' && <QCReviews />}
       </div>
     </div>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,9 +12,10 @@ import { ErrorBrowser } from './views/ErrorBrowser'
 import { AutoflattenManager } from './views/AutoflattenManager'
 import { PipelineGraph } from './views/PipelineGraph'
 import { WorkflowsView } from './views/WorkflowsView'
+import { PostPreprocBuilder } from './views/PostPreprocBuilder'
 import { useModuleStore } from './stores/module-store'
 
-type Route = 'modules' | 'composer' | 'runs' | 'editor' | 'dashboard' | 'preproc' | 'convert' | 'autoflatten' | 'graph' | 'errors' | 'workflows'
+type Route = 'modules' | 'composer' | 'runs' | 'editor' | 'dashboard' | 'preproc' | 'convert' | 'autoflatten' | 'graph' | 'errors' | 'workflows' | 'post-preproc'
 
 function getRoute(): Route {
   const hash = window.location.hash.replace('#', '').replace('/', '')
@@ -29,6 +30,7 @@ function getRoute(): Route {
   if (hash === 'graph') return 'graph'
   if (hash === 'errors') return 'errors'
   if (hash === 'workflows') return 'workflows'
+  if (hash === 'post-preproc') return 'post-preproc'
   return 'dashboard'
 }
 
@@ -129,6 +131,7 @@ export function App() {
         {route === 'graph' && <PipelineGraph />}
         {route === 'errors' && <ErrorBrowser />}
         {route === 'workflows' && <WorkflowsView />}
+        {route === 'post-preproc' && <PostPreprocBuilder />}
       </div>
     </div>
   )

--- a/frontend/src/api/__tests__/preproc-live.test.ts
+++ b/frontend/src/api/__tests__/preproc-live.test.ts
@@ -1,0 +1,266 @@
+/** API client coverage for the new endpoints landed on this branch:
+ *  - GET /preproc/runs/{id}/live  (live nipype-node monitoring)
+ *  - Post-preproc CRUD            (saved nipype workflows)
+ *  - Structural-QC review         (in-browser structural sign-off)
+ */
+
+import { describe, it, expect } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/mocks/server'
+import { fetchPreprocRunLive } from '../client'
+import {
+  fetchNipypeNodes,
+  fetchWorkflows,
+  fetchWorkflow,
+  saveWorkflow,
+  deleteWorkflow,
+  validateGraph,
+  startRun,
+  getRun,
+} from '../post-preproc'
+import {
+  fetchReview,
+  saveReview,
+  fetchFreeviewCommand,
+  reportUrl,
+  fsFileUrl,
+} from '../structural-qc'
+
+
+describe('preproc /live endpoint', () => {
+  it('fetches a live status block', async () => {
+    server.use(
+      http.get('/api/preproc/runs/abc/live', ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('cap')).toBe('200')
+        return HttpResponse.json({
+          run_id: 'abc',
+          subject: 'sub01',
+          backend: 'fmriprep',
+          status: 'running',
+          pid: 1234,
+          started_at: 0,
+          finished_at: 0,
+          is_reattached: false,
+          manifest_path: null,
+          error: null,
+          config_path: null,
+          log_path: null,
+          nipype_status: {
+            counts: { running: 2, ok: 5, failed: 1, total_seen: 8 },
+            recent_nodes: [],
+          },
+        })
+      }),
+    )
+    const r = await fetchPreprocRunLive('abc')
+    expect(r.nipype_status.counts.ok).toBe(5)
+    expect(r.nipype_status.counts.failed).toBe(1)
+  })
+
+  it('passes a custom cap as query param', async () => {
+    let observedCap: string | null = null
+    server.use(
+      http.get('/api/preproc/runs/xyz/live', ({ request }) => {
+        observedCap = new URL(request.url).searchParams.get('cap')
+        return HttpResponse.json({
+          run_id: 'xyz', subject: 's', backend: 'fmriprep',
+          status: 'done', pid: null, started_at: 0, finished_at: 0,
+          is_reattached: false, manifest_path: null, error: null,
+          config_path: null, log_path: null,
+          nipype_status: { counts: { running: 0, ok: 0, failed: 0, total_seen: 0 }, recent_nodes: [] },
+        })
+      }),
+    )
+    await fetchPreprocRunLive('xyz', 50)
+    expect(observedCap).toBe('50')
+  })
+
+  it('throws on a 404', async () => {
+    server.use(
+      http.get('/api/preproc/runs/missing/live',
+        () => new HttpResponse('not found', { status: 404 }),
+      ),
+    )
+    await expect(fetchPreprocRunLive('missing')).rejects.toThrow(/404/)
+  })
+})
+
+
+describe('post-preproc API client', () => {
+  it('fetches the registered nipype-node palette', async () => {
+    server.use(
+      http.get('/api/post-preproc/nodes', () =>
+        HttpResponse.json([
+          { name: 'smooth', docstring: '', inputs: ['in_file'], outputs: ['out_file'], params: {} },
+          { name: 'mask_apply', docstring: '', inputs: ['in_file', 'mask_file'], outputs: ['out_file'], params: {} },
+        ])),
+    )
+    const nodes = await fetchNipypeNodes()
+    expect(nodes.map((n) => n.name)).toEqual(['smooth', 'mask_apply'])
+  })
+
+  it('lists saved workflows', async () => {
+    server.use(
+      http.get('/api/post-preproc/workflows', () =>
+        HttpResponse.json([
+          { name: 'smooth_only', description: '', inputs: ['in_file'], outputs: ['out_file'], n_nodes: 1 },
+        ])),
+    )
+    const wfs = await fetchWorkflows()
+    expect(wfs).toHaveLength(1)
+    expect(wfs[0].name).toBe('smooth_only')
+  })
+
+  it('fetches a workflow by name (URL-encoded)', async () => {
+    let observed = ''
+    server.use(
+      http.get('/api/post-preproc/workflows/:name', ({ params }) => {
+        observed = String(params.name)
+        return HttpResponse.json({
+          name: observed,
+          description: '',
+          inputs: { in_file: { from: 'smo.in_file' } },
+          outputs: { out_file: { from: 'smo.out_file' } },
+          graph: { nodes: [], edges: [] },
+        })
+      }),
+    )
+    await fetchWorkflow('smooth/only')
+    expect(observed).toBe('smooth/only')
+  })
+
+  it('saves a workflow with the right body', async () => {
+    let captured: any = null
+    server.use(
+      http.post('/api/post-preproc/workflows', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json({ saved: true, path: '/tmp/wf.yaml', name: 'wf' })
+      }),
+    )
+    const result = await saveWorkflow({
+      name: 'wf',
+      description: 'd',
+      graph: { nodes: [], edges: [] },
+      inputs: { in_file: { from: 'a.in_file' } },
+      outputs: {},
+    })
+    expect(result.saved).toBe(true)
+    expect(captured.name).toBe('wf')
+    expect(captured.description).toBe('d')
+    expect(captured.inputs.in_file.from).toBe('a.in_file')
+  })
+
+  it('deletes a workflow', async () => {
+    server.use(
+      http.delete('/api/post-preproc/workflows/wf', () =>
+        HttpResponse.json({ deleted: true, name: 'wf' }),
+      ),
+    )
+    const r = await deleteWorkflow('wf')
+    expect(r.deleted).toBe(true)
+  })
+
+  it('validates a graph', async () => {
+    server.use(
+      http.post('/api/post-preproc/graphs/validate', () =>
+        HttpResponse.json({ valid: false, errors: ['Cycle detected'] })),
+    )
+    const result = await validateGraph({ nodes: [], edges: [] })
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain('Cycle detected')
+  })
+
+  it('starts a run', async () => {
+    server.use(
+      http.post('/api/post-preproc/run', () =>
+        HttpResponse.json({
+          run_id: 'r1',
+          status: 'pending',
+          output_dir: '/tmp/out/r1',
+        })),
+    )
+    const handle = await startRun({
+      subject: 'sub01',
+      source_manifest_path: '/m.json',
+      graph: { nodes: [], edges: [] },
+      output_dir: '/tmp/out',
+    })
+    expect(handle.run_id).toBe('r1')
+    expect(handle.status).toBe('pending')
+  })
+
+  it('gets a run', async () => {
+    server.use(
+      http.get('/api/post-preproc/runs/r1', () =>
+        HttpResponse.json({
+          run_id: 'r1', status: 'done', output_dir: '/tmp/out/r1',
+          error: null, manifest: null,
+        })),
+    )
+    const r = await getRun('r1')
+    expect(r.status).toBe('done')
+  })
+})
+
+
+describe('structural-qc API client', () => {
+  it('fetches a review', async () => {
+    server.use(
+      http.get('/api/preproc/subjects/sub01/structural-qc', () =>
+        HttpResponse.json({
+          dataset: 'ds', subject: 'sub01', status: 'approved',
+          reviewer: 'omar', timestamp: '2026-05-04', notes: '',
+          freeview_command_used: null,
+        })),
+    )
+    const r = await fetchReview('sub01')
+    expect(r.status).toBe('approved')
+    expect(r.reviewer).toBe('omar')
+  })
+
+  it('saves a review with the right body', async () => {
+    let captured: any = null
+    server.use(
+      http.post('/api/preproc/subjects/sub01/structural-qc', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json({
+          saved: true,
+          path: '/tmp/r.yaml',
+          review: {
+            dataset: 'ds', subject: 'sub01', status: captured.status,
+            reviewer: captured.reviewer, timestamp: '2026-05-04',
+            notes: captured.notes ?? '', freeview_command_used: null,
+          },
+        })
+      }),
+    )
+    const r = await saveReview('sub01', {
+      status: 'needs_edits', reviewer: 'omar', notes: 'fix the pial',
+    })
+    expect(r.saved).toBe(true)
+    expect(captured.status).toBe('needs_edits')
+    expect(captured.notes).toBe('fix the pial')
+  })
+
+  it('fetches a freeview command', async () => {
+    server.use(
+      http.get('/api/preproc/subjects/sub01/structural-qc/freeview-command', () =>
+        HttpResponse.json({
+          command: 'freeview -v T1.mgz',
+          fs_subject_dir: '/fs/sub01',
+        })),
+    )
+    const r = await fetchFreeviewCommand('sub01')
+    expect(r.command).toContain('freeview')
+  })
+
+  it('builds a report URL', () => {
+    expect(reportUrl('sub01')).toBe('/api/preproc/subjects/sub01/structural-qc/report')
+  })
+
+  it('builds an FS-file URL with encoded rel param', () => {
+    expect(fsFileUrl('sub01', 'mri/T1.mgz'))
+      .toBe('/api/preproc/subjects/sub01/structural-qc/fs-file?rel=mri%2FT1.mgz')
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -487,6 +487,14 @@ export async function fetchPreprocRun(runId: string): Promise<PreprocRunSummary>
   return json(`${BASE}/preproc/runs/${encodeURIComponent(runId)}`)
 }
 
+export async function fetchPreprocRunLive(
+  runId: string, cap: number = 200,
+): Promise<import('./types').PreprocRunLive> {
+  return json(
+    `${BASE}/preproc/runs/${encodeURIComponent(runId)}/live?cap=${cap}`,
+  )
+}
+
 export async function cancelPreprocRun(runId: string): Promise<{ cancelled: boolean }> {
   return json(`${BASE}/preproc/runs/${encodeURIComponent(runId)}/cancel`, {
     method: 'POST',

--- a/frontend/src/api/node-outputs.ts
+++ b/frontend/src/api/node-outputs.ts
@@ -1,6 +1,6 @@
 /** Per-node fmriprep output endpoints. */
 
-import type { NodeOutputsList, NodePickleResponse } from './types'
+import type { NipypeWorkTree, NodeOutputsList, NodePickleResponse } from './types'
 
 const BASE = '/api'
 
@@ -28,6 +28,14 @@ export async function fetchNodePickle(
 ): Promise<NodePickleResponse> {
   const res = await fetch(
     `${BASE}/preproc/runs/${encodeURIComponent(runId)}/node/${nodePath(node)}/pickle?rel=${encodeURIComponent(rel)}`,
+  )
+  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
+  return res.json()
+}
+
+export async function fetchWorkTree(runId: string): Promise<NipypeWorkTree> {
+  const res = await fetch(
+    `${BASE}/preproc/runs/${encodeURIComponent(runId)}/work_tree`,
   )
   if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
   return res.json()

--- a/frontend/src/api/node-outputs.ts
+++ b/frontend/src/api/node-outputs.ts
@@ -1,0 +1,42 @@
+/** Per-node fmriprep output endpoints. */
+
+import type { NodeOutputsList, NodePickleResponse } from './types'
+
+const BASE = '/api'
+
+function nodePath(p: string): string {
+  // FastAPI's :path converter accepts the dotted node path verbatim;
+  // we still encode segments to be safe (no slashes in node leaves).
+  return encodeURI(p)
+}
+
+export async function fetchNodeOutputs(
+  runId: string,
+  node: string,
+): Promise<NodeOutputsList> {
+  const res = await fetch(
+    `${BASE}/preproc/runs/${encodeURIComponent(runId)}/node/${nodePath(node)}/files`,
+  )
+  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
+  return res.json()
+}
+
+export async function fetchNodePickle(
+  runId: string,
+  node: string,
+  rel: string,
+): Promise<NodePickleResponse> {
+  const res = await fetch(
+    `${BASE}/preproc/runs/${encodeURIComponent(runId)}/node/${nodePath(node)}/pickle?rel=${encodeURIComponent(rel)}`,
+  )
+  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
+  return res.json()
+}
+
+export function nodeFileUrl(
+  runId: string,
+  node: string,
+  rel: string,
+): string {
+  return `${BASE}/preproc/runs/${encodeURIComponent(runId)}/node/${nodePath(node)}/file?rel=${encodeURIComponent(rel)}`
+}

--- a/frontend/src/api/post-preproc.ts
+++ b/frontend/src/api/post-preproc.ts
@@ -48,3 +48,38 @@ export async function getRun(runId: string): Promise<
 > {
   return json(`${BASE}/post-preproc/runs/${runId}`)
 }
+
+// ── Saved workflows ──────────────────────────────────────────────
+
+import type {
+  PostPreprocWorkflow,
+  PostPreprocWorkflowSummary,
+} from './types'
+
+export async function fetchWorkflows(): Promise<PostPreprocWorkflowSummary[]> {
+  return json(`${BASE}/post-preproc/workflows`)
+}
+
+export async function fetchWorkflow(name: string): Promise<PostPreprocWorkflow> {
+  return json(`${BASE}/post-preproc/workflows/${encodeURIComponent(name)}`)
+}
+
+export async function saveWorkflow(body: {
+  name: string
+  description?: string
+  graph: PostPreprocGraph
+  inputs?: Record<string, { from: string }>
+  outputs?: Record<string, { from: string }>
+}): Promise<{ saved: boolean; path: string; name: string }> {
+  return json(`${BASE}/post-preproc/workflows`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+export async function deleteWorkflow(name: string): Promise<{ deleted: boolean; name: string }> {
+  return json(`${BASE}/post-preproc/workflows/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  })
+}

--- a/frontend/src/api/post-preproc.ts
+++ b/frontend/src/api/post-preproc.ts
@@ -1,0 +1,50 @@
+/** Post-preproc API client. */
+
+import type {
+  NipypeNodeMeta,
+  PostPreprocGraph,
+  PostPreprocRunHandle,
+  PostPreprocManifest,
+} from './types'
+
+const BASE = '/api'
+
+async function json<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init)
+  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
+  return res.json()
+}
+
+export async function fetchNipypeNodes(): Promise<NipypeNodeMeta[]> {
+  return json(`${BASE}/post-preproc/nodes`)
+}
+
+export async function validateGraph(
+  graph: PostPreprocGraph,
+): Promise<{ valid: boolean; errors: string[] }> {
+  return json(`${BASE}/post-preproc/graphs/validate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ graph }),
+  })
+}
+
+export async function startRun(body: {
+  subject: string
+  source_manifest_path: string
+  graph: PostPreprocGraph
+  output_dir: string
+  name?: string | null
+}): Promise<PostPreprocRunHandle> {
+  return json(`${BASE}/post-preproc/run`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+export async function getRun(runId: string): Promise<
+  PostPreprocRunHandle & { error: string | null; manifest: PostPreprocManifest | null }
+> {
+  return json(`${BASE}/post-preproc/runs/${runId}`)
+}

--- a/frontend/src/api/structural-qc.ts
+++ b/frontend/src/api/structural-qc.ts
@@ -1,0 +1,47 @@
+/** Structural-QC API client. */
+
+import type { StructuralQCReview, StructuralQCStatus } from './types'
+
+const BASE = '/api'
+
+export async function fetchReview(subject: string): Promise<StructuralQCReview> {
+  const res = await fetch(`${BASE}/preproc/subjects/${subject}/structural-qc`)
+  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
+  return res.json()
+}
+
+export async function saveReview(
+  subject: string,
+  body: {
+    status: StructuralQCStatus
+    reviewer?: string
+    notes?: string
+    freeview_command_used?: string | null
+  },
+): Promise<{ saved: boolean; review: StructuralQCReview }> {
+  const res = await fetch(`${BASE}/preproc/subjects/${subject}/structural-qc`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
+  return res.json()
+}
+
+export async function fetchFreeviewCommand(
+  subject: string,
+): Promise<{ command: string; fs_subject_dir: string }> {
+  const res = await fetch(
+    `${BASE}/preproc/subjects/${subject}/structural-qc/freeview-command`,
+  )
+  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
+  return res.json()
+}
+
+export function reportUrl(subject: string): string {
+  return `${BASE}/preproc/subjects/${subject}/structural-qc/report`
+}
+
+export function fsFileUrl(subject: string, rel: string): string {
+  return `${BASE}/preproc/subjects/${subject}/structural-qc/fs-file?rel=${encodeURIComponent(rel)}`
+}

--- a/frontend/src/api/structural-qc.ts
+++ b/frontend/src/api/structural-qc.ts
@@ -4,6 +4,13 @@ import type { StructuralQCReview, StructuralQCStatus } from './types'
 
 const BASE = '/api'
 
+export async function fetchAllReviews(dataset?: string): Promise<StructuralQCReview[]> {
+  const qs = dataset ? `?dataset=${encodeURIComponent(dataset)}` : ''
+  const res = await fetch(`${BASE}/structural-qc/reviews${qs}`)
+  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
+  return res.json()
+}
+
 export async function fetchReview(subject: string): Promise<StructuralQCReview> {
   const res = await fetch(`${BASE}/preproc/subjects/${subject}/structural-qc`)
   if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -667,7 +667,8 @@ export interface NewErrorFromCaptureResult {
 
 // ── Live nipype-node monitoring ───────────────────────────────────
 
-export type NipypeNodeStatusKind = 'running' | 'ok' | 'failed'
+export type NipypeNodeStatusKind =
+  | 'running' | 'ok' | 'failed' | 'completed_assumed'
 
 export interface NipypeNodeStatus {
   node: string        // full dotted path
@@ -685,6 +686,7 @@ export interface NipypeStatusCounts {
   running: number
   ok: number
   failed: number
+  completed_assumed: number
   total_seen: number
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -786,3 +786,34 @@ export interface PostPreprocWorkflow {
   outputs: Record<string, { from: string }>
   graph: PostPreprocGraph
 }
+
+// ── Per-node fmriprep outputs ────────────────────────────────────
+
+export interface NodeOutputFile {
+  name: string
+  rel: string
+  suffix: string
+  size: number
+  kind: 'view' | 'pickle' | 'link'
+}
+
+export interface NodeOutputCrash {
+  name: string
+  path: string
+  size: number
+}
+
+export interface NodeOutputsList {
+  node: string
+  leaf_dir: string
+  exists: boolean
+  files: NodeOutputFile[]
+  crashes: NodeOutputCrash[]
+}
+
+export interface NodePickleResponse {
+  name: string
+  type?: string
+  value?: unknown
+  error?: string
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -346,6 +346,9 @@ export interface WorkflowStageStatus {
   // inner-stage progression (stimuli / responses / features / prepare /
   // model / analyze / report).
   inner_stages?: AnalysisInnerStage[]
+  // Populated client-side for the preproc stage when fmriprep is the
+  // backend; the parent view polls /preproc/runs/{run_id}/live.
+  nipype_status?: NipypeStatusBlock
 }
 
 export interface WorkflowRunSummary {
@@ -660,4 +663,36 @@ export interface NewErrorFromCaptureResult {
   filename: string
   path: string
   proposed_dir: string
+}
+
+// ── Live nipype-node monitoring ───────────────────────────────────
+
+export type NipypeNodeStatusKind = 'running' | 'ok' | 'failed'
+
+export interface NipypeNodeStatus {
+  node: string        // full dotted path
+  leaf: string        // last segment
+  workflow: string    // parent workflow path
+  status: NipypeNodeStatusKind
+  started_at: number
+  finished_at: number
+  elapsed: number
+  crash_file: string | null
+  level: string
+}
+
+export interface NipypeStatusCounts {
+  running: number
+  ok: number
+  failed: number
+  total_seen: number
+}
+
+export interface NipypeStatusBlock {
+  counts: NipypeStatusCounts
+  recent_nodes: NipypeNodeStatus[]
+}
+
+export interface PreprocRunLive extends PreprocRunSummary {
+  nipype_status: NipypeStatusBlock
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -668,7 +668,12 @@ export interface NewErrorFromCaptureResult {
 // ── Live nipype-node monitoring ───────────────────────────────────
 
 export type NipypeNodeStatusKind =
-  | 'running' | 'ok' | 'failed' | 'completed_assumed'
+  | 'running' | 'ok' | 'failed' | 'completed_assumed' | 'cached'
+
+export interface NipypeWorkTree {
+  work_dir: string | null
+  leaves: string[]
+}
 
 export interface NipypeNodeStatus {
   node: string        // full dotted path

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -661,3 +661,16 @@ export interface NewErrorFromCaptureResult {
   path: string
   proposed_dir: string
 }
+
+export type StructuralQCStatus = "pending" | "approved" | "needs_edits" | "rejected"
+
+export interface StructuralQCReview {
+  dataset: string
+  subject: string
+  status: StructuralQCStatus
+  reviewer: string
+  timestamp: string
+  notes: string
+  freeview_command_used: string | null
+}
+

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -729,3 +729,21 @@ export interface PostPreprocManifest {
   created: string
   manifest_version: number
 }
+
+// ── Post-preproc workflows (saved YAML) ───────────────────────────
+
+export interface PostPreprocWorkflowSummary {
+  name: string
+  description: string
+  inputs: string[]
+  outputs: string[]
+  n_nodes: number
+}
+
+export interface PostPreprocWorkflow {
+  name: string
+  description: string
+  inputs: Record<string, { from: string }>
+  outputs: Record<string, { from: string }>
+  graph: PostPreprocGraph
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -661,3 +661,59 @@ export interface NewErrorFromCaptureResult {
   path: string
   proposed_dir: string
 }
+
+// ── Post-preproc ─────────────────────────────────────────────────
+
+export interface NipypeNodeMeta {
+  name: string
+  docstring: string
+  inputs: string[]
+  outputs: string[]
+  params: ParamSchema
+}
+
+export interface PostPreprocGraphNode {
+  id: string
+  type: string
+  data: { params: Record<string, unknown> }
+  position: { x: number; y: number }
+}
+
+export interface PostPreprocGraphEdge {
+  id: string
+  source: string
+  target: string
+  sourceHandle?: string
+  targetHandle?: string
+}
+
+export interface PostPreprocGraph {
+  nodes: PostPreprocGraphNode[]
+  edges: PostPreprocGraphEdge[]
+}
+
+export interface PostPreprocRunHandle {
+  run_id: string
+  status: 'pending' | 'running' | 'done' | 'failed'
+  output_dir: string
+  error?: string | null
+  manifest?: PostPreprocManifest | null
+}
+
+export interface PostPreprocManifest {
+  subject: string
+  dataset: string
+  source_manifest_path: string
+  graph: PostPreprocGraph
+  nodes_run: Array<{
+    node_id: string
+    node_type: string
+    params: Record<string, unknown>
+    inputs: Record<string, string>
+    outputs: Record<string, string>
+    duration_s: number | null
+  }>
+  output_dir: string
+  created: string
+  manifest_version: number
+}

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -92,6 +92,7 @@ const groups = [
       { key: 'preproc', label: 'Preproc', hash: '#preproc' },
       { key: 'autoflatten', label: 'Autoflatten', hash: '#autoflatten' },
       { key: 'post-preproc', label: 'Post-preproc (nipype)', hash: '#post-preproc' },
+      { key: 'qc-reviews', label: 'QC Reviews', hash: '#qc-reviews' },
     ],
   },
   {

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -91,6 +91,7 @@ const groups = [
       { key: 'convert', label: 'DICOM \u2192 BIDS', hash: '#convert' },
       { key: 'preproc', label: 'Preproc', hash: '#preproc' },
       { key: 'autoflatten', label: 'Autoflatten', hash: '#autoflatten' },
+      { key: 'post-preproc', label: 'Post-preproc (nipype)', hash: '#post-preproc' },
     ],
   },
   {

--- a/frontend/src/components/post_preproc/NipypeNode.tsx
+++ b/frontend/src/components/post_preproc/NipypeNode.tsx
@@ -1,0 +1,125 @@
+/** Custom XYFlow node for the post-preproc builder.
+ *
+ * Renders one labelled handle per declared INPUT (left) and OUTPUT
+ * (right), so wires land unambiguously on the right port.
+ */
+
+import { memo } from 'react'
+import type { CSSProperties } from 'react'
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+
+const COLOR = '#10b981' // matches preproc stage color in WorkflowGraph
+
+export interface NipypeNodeData {
+  label: string
+  nodeType: string
+  inputs: string[]
+  outputs: string[]
+  iterating?: boolean
+}
+
+const handleStyle: CSSProperties = {
+  width: 10,
+  height: 10,
+  backgroundColor: COLOR,
+  border: '2px solid #1a1a2e',
+}
+
+const handleLabel = (side: 'left' | 'right'): CSSProperties => ({
+  position: 'absolute',
+  fontSize: 9,
+  color: 'var(--text-secondary)',
+  pointerEvents: 'none',
+  whiteSpace: 'nowrap',
+  [side === 'left' ? 'left' : 'right']: 14,
+  top: -1,
+  transform: 'translateY(-50%)',
+})
+
+function NipypeNodeInner({ data, selected }: NodeProps & { data: NipypeNodeData }) {
+  const inputs = data.inputs ?? []
+  const outputs = data.outputs ?? []
+  const rows = Math.max(inputs.length, outputs.length, 1)
+  const rowHeight = 22
+  const headerHeight = 30
+  const height = headerHeight + rows * rowHeight + 6
+
+  const containerStyle: CSSProperties = {
+    background: `${COLOR}22`,
+    border: selected ? `2px solid ${COLOR}` : `1px solid ${COLOR}aa`,
+    borderRadius: 6,
+    minWidth: 170,
+    color: 'var(--text-primary)',
+    fontSize: 12,
+    fontWeight: 600,
+    position: 'relative',
+    height,
+    boxShadow: selected ? `0 0 10px ${COLOR}55` : undefined,
+  }
+
+  return (
+    <div style={containerStyle}>
+      <div
+        style={{
+          padding: '6px 10px',
+          borderBottom: `1px solid ${COLOR}55`,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+        }}
+      >
+        <span style={{ color: COLOR }}>{data.nodeType}</span>
+        <span style={{ flex: 1 }} />
+        {data.iterating && (
+          <span
+            style={{
+              fontSize: 9,
+              padding: '1px 5px',
+              borderRadius: 8,
+              background: '#ffd60022',
+              color: 'var(--accent-yellow)',
+              border: '1px solid #ffd60055',
+            }}
+            title="Iterates over a list"
+          >
+            map
+          </span>
+        )}
+      </div>
+
+      {/* input handles, stacked */}
+      {inputs.map((name, i) => {
+        const top = headerHeight + i * rowHeight + rowHeight / 2
+        return (
+          <div key={`in-${name}`}>
+            <Handle
+              type="target"
+              position={Position.Left}
+              id={name}
+              style={{ ...handleStyle, top }}
+            />
+            <span style={{ ...handleLabel('left'), top }}>{name}</span>
+          </div>
+        )
+      })}
+
+      {/* output handles, stacked */}
+      {outputs.map((name, i) => {
+        const top = headerHeight + i * rowHeight + rowHeight / 2
+        return (
+          <div key={`out-${name}`}>
+            <Handle
+              type="source"
+              position={Position.Right}
+              id={name}
+              style={{ ...handleStyle, top }}
+            />
+            <span style={{ ...handleLabel('right'), top }}>{name}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export const NipypeNode = memo(NipypeNodeInner)

--- a/frontend/src/components/post_preproc/__tests__/NipypeNode.test.tsx
+++ b/frontend/src/components/post_preproc/__tests__/NipypeNode.test.tsx
@@ -1,0 +1,81 @@
+/** Render the post-preproc canvas's custom node renderer. */
+
+import { describe, it, expect } from 'vitest'
+import { ReactFlowProvider } from '@xyflow/react'
+import { renderWithProviders, screen } from '../../../test/render'
+import { NipypeNode } from '../NipypeNode'
+import type { NipypeNodeData } from '../NipypeNode'
+
+
+function buildData(overrides: Partial<NipypeNodeData> = {}): NipypeNodeData {
+  return {
+    label: 'smooth (n1)',
+    nodeType: 'smooth',
+    inputs: ['in_file'],
+    outputs: ['out_file'],
+    iterating: false,
+    ...overrides,
+  }
+}
+
+
+function renderNode(data: NipypeNodeData) {
+  // XYFlow's <Handle> requires a ReactFlow context to mount.
+  return renderWithProviders(
+    <ReactFlowProvider>
+      <NipypeNode
+        id="n1"
+        type="nipype"
+        data={data as any}
+        dragging={false}
+        selectable={false}
+        deletable={false}
+        draggable={false}
+        selected={false}
+        isConnectable={false}
+        positionAbsoluteX={0}
+        positionAbsoluteY={0}
+        zIndex={0}
+      />
+    </ReactFlowProvider>,
+  )
+}
+
+
+describe('<NipypeNode />', () => {
+  it('renders the nodeType label', () => {
+    renderNode(buildData({ nodeType: 'smooth' }))
+    expect(screen.getByText('smooth')).toBeInTheDocument()
+  })
+
+  it('renders one labelled input handle per declared INPUT', () => {
+    renderNode(buildData({
+      nodeType: 'mask_apply',
+      inputs: ['in_file', 'mask_file'],
+      outputs: ['out_file'],
+    }))
+    expect(screen.getByText('in_file')).toBeInTheDocument()
+    expect(screen.getByText('mask_file')).toBeInTheDocument()
+    expect(screen.getByText('out_file')).toBeInTheDocument()
+  })
+
+  it('renders the map badge when iterating is true', () => {
+    renderNode(buildData({ iterating: true }))
+    expect(screen.getByText('map')).toBeInTheDocument()
+  })
+
+  it('omits the map badge by default', () => {
+    renderNode(buildData({ iterating: false }))
+    expect(screen.queryByText('map')).not.toBeInTheDocument()
+  })
+
+  it('handles a node with no inputs (source-only)', () => {
+    renderNode(buildData({
+      nodeType: 'preproc_run',
+      inputs: [],
+      outputs: ['out_file'],
+    }))
+    expect(screen.getByText('preproc_run')).toBeInTheDocument()
+    expect(screen.getByText('out_file')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/preproc/ManifestBrowser.tsx
+++ b/frontend/src/components/preproc/ManifestBrowser.tsx
@@ -3,6 +3,44 @@ import { useEffect, useState } from 'react'
 import type { CSSProperties } from 'react'
 import { usePreprocStore } from '../../stores/preproc-store'
 import { ManifestDetail } from './ManifestDetail'
+import { fetchAllReviews } from '../../api/structural-qc'
+import type { StructuralQCReview, StructuralQCStatus } from '../../api/types'
+
+const QC_STATUS_COLOR: Record<StructuralQCStatus, string> = {
+  pending: 'var(--text-secondary)',
+  approved: 'var(--accent-green)',
+  needs_edits: 'var(--accent-yellow)',
+  rejected: 'var(--accent-red)',
+}
+
+const QC_STATUS_LABEL: Record<StructuralQCStatus, string> = {
+  pending: 'pending',
+  approved: 'approved',
+  needs_edits: 'needs edits',
+  rejected: 'rejected',
+}
+
+function QcPill({ status }: { status: StructuralQCStatus }) {
+  const color = QC_STATUS_COLOR[status]
+  return (
+    <span
+      style={{
+        fontSize: 9,
+        padding: '1px 6px',
+        borderRadius: 8,
+        background: status === 'pending' ? 'transparent' : `${color}22`,
+        color,
+        border: `1px solid ${color}66`,
+        textTransform: 'uppercase',
+        letterSpacing: 0.4,
+        fontWeight: 700,
+      }}
+      title={`structural QC: ${QC_STATUS_LABEL[status]}`}
+    >
+      {QC_STATUS_LABEL[status]}
+    </span>
+  )
+}
 
 const containerStyle: CSSProperties = {
   display: 'flex',
@@ -86,8 +124,26 @@ export function ManifestBrowser() {
     manifests, manifestsLoading, selectedSubject, selectedManifest,
     loadManifests, rescan, selectManifest,
   } = usePreprocStore()
+  const [reviews, setReviews] = useState<Map<string, StructuralQCReview>>(
+    new Map(),
+  )
 
   useEffect(() => { loadManifests() }, [])
+
+  // Reviews are fetched once per manifest list refresh and indexed by
+  // `dataset|subject` so we can stamp a status pill on each row.
+  useEffect(() => {
+    let cancelled = false
+    fetchAllReviews()
+      .then((rs) => {
+        if (cancelled) return
+        const map = new Map<string, StructuralQCReview>()
+        for (const r of rs) map.set(`${r.dataset}|${r.subject}`, r)
+        setReviews(map)
+      })
+      .catch(() => { /* ignore — pill simply won't show */ })
+    return () => { cancelled = true }
+  }, [manifests.length])
 
   return (
     <div style={containerStyle}>
@@ -99,20 +155,34 @@ export function ManifestBrowser() {
           </button>
         </div>
         <div style={listStyle}>
-          {manifests.map((m) => (
-            <div
-              key={m.subject}
-              style={itemStyle(selectedSubject === m.subject)}
-              onClick={() => selectManifest(m.subject)}
-            >
-              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>
-                sub-{m.subject}
+          {manifests.map((m) => {
+            const review = reviews.get(`${m.dataset}|${m.subject}`)
+            return (
+              <div
+                key={m.subject}
+                style={itemStyle(selectedSubject === m.subject)}
+                onClick={() => selectManifest(m.subject)}
+              >
+                <div
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: 'var(--text-primary)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                  }}
+                >
+                  <span>sub-{m.subject}</span>
+                  <span style={{ flex: 1 }} />
+                  {review && <QcPill status={review.status} />}
+                </div>
+                <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginTop: 2 }}>
+                  {m.backend} {m.backend_version} &middot; {m.n_runs} runs
+                </div>
               </div>
-              <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginTop: 2 }}>
-                {m.backend} {m.backend_version} &middot; {m.n_runs} runs
-              </div>
-            </div>
-          ))}
+            )
+          })}
           {manifests.length === 0 && !manifestsLoading && (
             <div style={{ padding: 16, fontSize: 11, color: 'var(--text-secondary)' }}>
               No manifests found. Use the Collect tab to create one, or check --derivatives-dir.

--- a/frontend/src/components/preproc/ManifestDetail.tsx
+++ b/frontend/src/components/preproc/ManifestDetail.tsx
@@ -4,6 +4,7 @@ import type { CSSProperties } from 'react'
 import type { ManifestDetail as ManifestDetailType } from '../../api/types'
 import { usePreprocStore } from '../../stores/preproc-store'
 import { QcBadge } from './QcBadge'
+import { StructuralQCPanel } from './StructuralQCPanel'
 
 interface Props {
   manifest: ManifestDetailType
@@ -186,6 +187,9 @@ export function ManifestDetail({ manifest }: Props) {
           </tbody>
         </table>
       </div>
+
+      {/* Structural QC */}
+      <StructuralQCPanel subject={manifest.subject} />
 
       {/* Validation */}
       <div style={sectionLabel}>Validation</div>

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -81,9 +81,11 @@ export function StructuralQCPanel({ subject }: Props) {
   // niivue sliceType: 0=axial 1=coronal 2=sagittal 3=multiplanar 4=render(3D)
   const [sliceType, setSliceType] = useState<number>(3)
   const [volumeVisible, setVolumeVisible] = useState<boolean>(true)
-  // Per-mesh opacity (0..1). Default 0.55 so an inner surface peeks
-  // through an outer one in 3D — same trick freeview uses.
-  const [surfaceAlpha, setSurfaceAlpha] = useState<number>(0.55)
+  // Per-surface alpha (0..1) so an outer mesh can be made transparent
+  // enough to see an inner one. Default 0.55 = freeview-ish translucency.
+  const [surfaceAlphas, setSurfaceAlphas] = useState<Record<SurfaceKind, number>>(
+    { pial: 0.55, white: 1.0, inflated: 1.0 },
+  )
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const nvRef = useRef<Niivue | null>(null)
 
@@ -140,26 +142,35 @@ export function StructuralQCPanel({ subject }: Props) {
     }
   }, [sliceType])
 
-  // Apply mesh opacity live whenever the slider moves or meshes reload.
+  // Apply per-mesh opacity live whenever a slider moves or meshes
+  // reload. Also enable the meshXRay second pass so the inner surface
+  // is actually visible through the outer one in 3D — without this,
+  // niivue's depth-test draws the outer mesh fully opaque.
   useEffect(() => {
     const nv = nvRef.current as unknown as {
-      meshes?: Array<{ id: string }>
+      meshes?: Array<{ id: string; name?: string }>
       setMeshProperty?: (id: string, key: string, val: number) => void
+      opts?: { meshXRay: number }
       drawScene?: () => void
-      updateGLVolume?: () => void
     } | null
-    if (!nv || !nv.setMeshProperty) return
+    if (!nv) return
+    if (nv.opts) nv.opts.meshXRay = 0.5
     const ms = nv.meshes ?? []
-    if (ms.length === 0) return
+    if (!nv.setMeshProperty || ms.length === 0) {
+      nv.drawScene?.()
+      return
+    }
     try {
       for (const m of ms) {
-        nv.setMeshProperty(m.id, 'opacity', surfaceAlpha)
+        const kind = (Object.keys(SURFACE_COLORS) as SurfaceKind[])
+          .find((k) => (m.name ?? '').endsWith(`.${k}`)) ?? 'pial'
+        nv.setMeshProperty(m.id, 'opacity', surfaceAlphas[kind] ?? 1)
       }
       nv.drawScene?.()
     } catch (e) {
       console.warn('niivue setMeshProperty failed', e)
     }
-  }, [surfaceAlpha, surfaces, showViewer])
+  }, [surfaceAlphas, surfaces, showViewer])
 
   // Toggle volume opacity (0 = invisible, 1 = full). Lets the user
   // hide the T1 "skull" in 3D mode so the cortex meshes are unobstructed.
@@ -374,27 +385,66 @@ export function StructuralQCPanel({ subject }: Props) {
                 const on = surfaces.has(k)
                 const color = `rgb(${SURFACE_COLORS[k].slice(0, 3).join(',')})`
                 return (
-                  <button
+                  <span
                     key={k}
                     style={{
-                      ...btn,
-                      padding: '2px 8px',
-                      fontSize: 11,
-                      background: on ? color : btn.background,
-                      color: on ? '#000' : 'var(--text-primary)',
-                      borderColor: on ? color : 'var(--border)',
-                    }}
-                    onClick={() => {
-                      setSurfaces((prev) => {
-                        const next = new Set(prev)
-                        if (next.has(k)) next.delete(k)
-                        else next.add(k)
-                        return next
-                      })
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 4,
+                      padding: '2px 6px',
+                      borderRadius: 4,
+                      border: `1px solid ${on ? color : 'var(--border)'}`,
+                      background: on ? `${color}` : 'transparent',
                     }}
                   >
-                    {k}
-                  </button>
+                    <button
+                      type="button"
+                      style={{
+                        ...btn,
+                        padding: '0 6px',
+                        fontSize: 11,
+                        background: 'transparent',
+                        color: on ? '#000' : 'var(--text-primary)',
+                        border: 'none',
+                      }}
+                      onClick={() => {
+                        setSurfaces((prev) => {
+                          const next = new Set(prev)
+                          if (next.has(k)) next.delete(k)
+                          else next.add(k)
+                          return next
+                        })
+                      }}
+                    >
+                      {k}
+                    </button>
+                    <input
+                      type="range"
+                      min={0}
+                      max={1}
+                      step={0.05}
+                      value={surfaceAlphas[k]}
+                      disabled={!on}
+                      onChange={(e) =>
+                        setSurfaceAlphas((prev) => ({
+                          ...prev,
+                          [k]: parseFloat(e.target.value),
+                        }))
+                      }
+                      style={{ width: 60, opacity: on ? 1 : 0.4 }}
+                      title={`${k} opacity (lower = more transparent)`}
+                    />
+                    <span
+                      style={{
+                        fontSize: 9,
+                        fontVariantNumeric: 'tabular-nums',
+                        color: on ? '#000' : 'var(--text-secondary)',
+                        minWidth: 22,
+                      }}
+                    >
+                      {surfaceAlphas[k].toFixed(2)}
+                    </span>
+                  </span>
                 )
               })}
               <button
@@ -404,35 +454,6 @@ export function StructuralQCPanel({ subject }: Props) {
               >
                 clear
               </button>
-              <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 6,
-                  marginLeft: 6,
-                }}
-              >
-                <span style={{ color: 'var(--text-secondary)' }}>α</span>
-                <input
-                  type="range"
-                  min={0}
-                  max={1}
-                  step={0.05}
-                  value={surfaceAlpha}
-                  onChange={(e) => setSurfaceAlpha(parseFloat(e.target.value))}
-                  style={{ width: 90 }}
-                  title="Surface opacity (lower = more transparent)"
-                />
-                <span
-                  style={{
-                    fontVariantNumeric: 'tabular-nums',
-                    color: 'var(--text-secondary)',
-                    minWidth: 28,
-                  }}
-                >
-                  {surfaceAlpha.toFixed(2)}
-                </span>
-              </span>
               <span style={{ flex: 1 }} />
               <button
                 style={{ ...btn, padding: '2px 8px', fontSize: 11 }}

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -18,9 +18,10 @@ interface Props {
 
 type SurfaceKind = 'pial' | 'white' | 'inflated'
 
+// Match FreeSurfer's freeview palette: pial = green, white = red.
 const SURFACE_COLORS: Record<SurfaceKind, [number, number, number, number]> = {
-  pial:     [255,  80,  80, 255],   // red
-  white:    [255, 220,  60, 255],   // yellow
+  pial:     [ 60, 220,  90, 255],   // green
+  white:    [255,  80,  80, 255],   // red
   inflated: [ 80, 160, 255, 255],   // blue
 }
 

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -81,11 +81,11 @@ export function StructuralQCPanel({ subject }: Props) {
   // niivue sliceType: 0=axial 1=coronal 2=sagittal 3=multiplanar 4=render(3D)
   const [sliceType, setSliceType] = useState<number>(3)
   const [volumeVisible, setVolumeVisible] = useState<boolean>(true)
-  // Per-surface alpha (0..1) so an outer mesh can be made transparent
-  // enough to see an inner one. Default 0.55 = freeview-ish translucency.
-  const [surfaceAlphas, setSurfaceAlphas] = useState<Record<SurfaceKind, number>>(
-    { pial: 0.55, white: 1.0, inflated: 1.0 },
-  )
+  // niivue exposes mesh transparency only as a single GLOBAL "X-ray"
+  // pass — there's no per-mesh opacity uniform in `drawMesh3D`.
+  // 0 = opaque (depth-test wins, outer mesh hides inner), 1 = pure
+  // see-through pass at full opacity. ~0.6 lets the inner one peek.
+  const [meshXRay, setMeshXRay] = useState<number>(0.6)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const nvRef = useRef<Niivue | null>(null)
 
@@ -142,35 +142,19 @@ export function StructuralQCPanel({ subject }: Props) {
     }
   }, [sliceType])
 
-  // Apply per-mesh opacity live whenever a slider moves or meshes
-  // reload. Also enable the meshXRay second pass so the inner surface
-  // is actually visible through the outer one in 3D — without this,
-  // niivue's depth-test draws the outer mesh fully opaque.
+  // Drive the global X-ray pass — only knob niivue gives for mesh
+  // transparency in 3D. nv.opts.meshXRay > 0 enables a second
+  // depth-test-off pass at the given alpha, blending all meshes
+  // together so inner ones show through outer ones.
   useEffect(() => {
     const nv = nvRef.current as unknown as {
-      meshes?: Array<{ id: string; name?: string }>
-      setMeshProperty?: (id: string, key: string, val: number) => void
       opts?: { meshXRay: number }
       drawScene?: () => void
     } | null
-    if (!nv) return
-    if (nv.opts) nv.opts.meshXRay = 0.5
-    const ms = nv.meshes ?? []
-    if (!nv.setMeshProperty || ms.length === 0) {
-      nv.drawScene?.()
-      return
-    }
-    try {
-      for (const m of ms) {
-        const kind = (Object.keys(SURFACE_COLORS) as SurfaceKind[])
-          .find((k) => (m.name ?? '').endsWith(`.${k}`)) ?? 'pial'
-        nv.setMeshProperty(m.id, 'opacity', surfaceAlphas[kind] ?? 1)
-      }
-      nv.drawScene?.()
-    } catch (e) {
-      console.warn('niivue setMeshProperty failed', e)
-    }
-  }, [surfaceAlphas, surfaces, showViewer])
+    if (!nv?.opts) return
+    nv.opts.meshXRay = meshXRay
+    nv.drawScene?.()
+  }, [meshXRay, surfaces, showViewer])
 
   // Toggle volume opacity (0 = invisible, 1 = full). Lets the user
   // hide the T1 "skull" in 3D mode so the cortex meshes are unobstructed.
@@ -385,66 +369,27 @@ export function StructuralQCPanel({ subject }: Props) {
                 const on = surfaces.has(k)
                 const color = `rgb(${SURFACE_COLORS[k].slice(0, 3).join(',')})`
                 return (
-                  <span
+                  <button
                     key={k}
                     style={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: 4,
-                      padding: '2px 6px',
-                      borderRadius: 4,
-                      border: `1px solid ${on ? color : 'var(--border)'}`,
-                      background: on ? `${color}` : 'transparent',
+                      ...btn,
+                      padding: '2px 8px',
+                      fontSize: 11,
+                      background: on ? color : btn.background,
+                      color: on ? '#000' : 'var(--text-primary)',
+                      borderColor: on ? color : 'var(--border)',
+                    }}
+                    onClick={() => {
+                      setSurfaces((prev) => {
+                        const next = new Set(prev)
+                        if (next.has(k)) next.delete(k)
+                        else next.add(k)
+                        return next
+                      })
                     }}
                   >
-                    <button
-                      type="button"
-                      style={{
-                        ...btn,
-                        padding: '0 6px',
-                        fontSize: 11,
-                        background: 'transparent',
-                        color: on ? '#000' : 'var(--text-primary)',
-                        border: 'none',
-                      }}
-                      onClick={() => {
-                        setSurfaces((prev) => {
-                          const next = new Set(prev)
-                          if (next.has(k)) next.delete(k)
-                          else next.add(k)
-                          return next
-                        })
-                      }}
-                    >
-                      {k}
-                    </button>
-                    <input
-                      type="range"
-                      min={0}
-                      max={1}
-                      step={0.05}
-                      value={surfaceAlphas[k]}
-                      disabled={!on}
-                      onChange={(e) =>
-                        setSurfaceAlphas((prev) => ({
-                          ...prev,
-                          [k]: parseFloat(e.target.value),
-                        }))
-                      }
-                      style={{ width: 60, opacity: on ? 1 : 0.4 }}
-                      title={`${k} opacity (lower = more transparent)`}
-                    />
-                    <span
-                      style={{
-                        fontSize: 9,
-                        fontVariantNumeric: 'tabular-nums',
-                        color: on ? '#000' : 'var(--text-secondary)',
-                        minWidth: 22,
-                      }}
-                    >
-                      {surfaceAlphas[k].toFixed(2)}
-                    </span>
-                  </span>
+                    {k}
+                  </button>
                 )
               })}
               <button
@@ -454,6 +399,35 @@ export function StructuralQCPanel({ subject }: Props) {
               >
                 clear
               </button>
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  marginLeft: 6,
+                }}
+                title="X-ray pass — 0 = opaque (outer hides inner), 1 = full see-through. Affects all surfaces."
+              >
+                <span style={{ color: 'var(--text-secondary)' }}>X-ray</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  value={meshXRay}
+                  onChange={(e) => setMeshXRay(parseFloat(e.target.value))}
+                  style={{ width: 90 }}
+                />
+                <span
+                  style={{
+                    fontVariantNumeric: 'tabular-nums',
+                    color: 'var(--text-secondary)',
+                    minWidth: 28,
+                  }}
+                >
+                  {meshXRay.toFixed(2)}
+                </span>
+              </span>
               <span style={{ flex: 1 }} />
               <button
                 style={{ ...btn, padding: '2px 8px', fontSize: 11 }}

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -81,6 +81,9 @@ export function StructuralQCPanel({ subject }: Props) {
   // niivue sliceType: 0=axial 1=coronal 2=sagittal 3=multiplanar 4=render(3D)
   const [sliceType, setSliceType] = useState<number>(3)
   const [volumeVisible, setVolumeVisible] = useState<boolean>(true)
+  // Per-mesh opacity (0..1). Default 0.55 so an inner surface peeks
+  // through an outer one in 3D — same trick freeview uses.
+  const [surfaceAlpha, setSurfaceAlpha] = useState<number>(0.55)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const nvRef = useRef<Niivue | null>(null)
 
@@ -136,6 +139,27 @@ export function StructuralQCPanel({ subject }: Props) {
       console.warn('niivue setSliceType failed', e)
     }
   }, [sliceType])
+
+  // Apply mesh opacity live whenever the slider moves or meshes reload.
+  useEffect(() => {
+    const nv = nvRef.current as unknown as {
+      meshes?: Array<{ id: string }>
+      setMeshProperty?: (id: string, key: string, val: number) => void
+      drawScene?: () => void
+      updateGLVolume?: () => void
+    } | null
+    if (!nv || !nv.setMeshProperty) return
+    const ms = nv.meshes ?? []
+    if (ms.length === 0) return
+    try {
+      for (const m of ms) {
+        nv.setMeshProperty(m.id, 'opacity', surfaceAlpha)
+      }
+      nv.drawScene?.()
+    } catch (e) {
+      console.warn('niivue setMeshProperty failed', e)
+    }
+  }, [surfaceAlpha, surfaces, showViewer])
 
   // Toggle volume opacity (0 = invisible, 1 = full). Lets the user
   // hide the T1 "skull" in 3D mode so the cortex meshes are unobstructed.
@@ -380,6 +404,35 @@ export function StructuralQCPanel({ subject }: Props) {
               >
                 clear
               </button>
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  marginLeft: 6,
+                }}
+              >
+                <span style={{ color: 'var(--text-secondary)' }}>α</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  value={surfaceAlpha}
+                  onChange={(e) => setSurfaceAlpha(parseFloat(e.target.value))}
+                  style={{ width: 90 }}
+                  title="Surface opacity (lower = more transparent)"
+                />
+                <span
+                  style={{
+                    fontVariantNumeric: 'tabular-nums',
+                    color: 'var(--text-secondary)',
+                    minWidth: 28,
+                  }}
+                >
+                  {surfaceAlpha.toFixed(2)}
+                </span>
+              </span>
               <span style={{ flex: 1 }} />
               <button
                 style={{ ...btn, padding: '2px 8px', fontSize: 11 }}

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -66,6 +66,7 @@ export function StructuralQCPanel({ subject }: Props) {
     useState<'pial' | 'white' | 'inflated' | 'none'>('pial')
   // niivue sliceType: 0=axial 1=coronal 2=sagittal 3=multiplanar 4=render(3D)
   const [sliceType, setSliceType] = useState<number>(3)
+  const [volumeVisible, setVolumeVisible] = useState<boolean>(true)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const nvRef = useRef<Niivue | null>(null)
 
@@ -121,6 +122,27 @@ export function StructuralQCPanel({ subject }: Props) {
       console.warn('niivue setSliceType failed', e)
     }
   }, [sliceType])
+
+  // Toggle volume opacity (0 = invisible, 1 = full). Lets the user
+  // hide the T1 "skull" in 3D mode so the cortex meshes are unobstructed.
+  useEffect(() => {
+    const nv = nvRef.current as unknown as {
+      volumes?: Array<unknown>
+      setOpacity?: (idx: number, opacity: number) => void
+      updateGLVolume?: () => void
+    } | null
+    if (!nv) return
+    const vols = nv.volumes ?? []
+    if (vols.length === 0 || !nv.setOpacity) return
+    try {
+      for (let i = 0; i < vols.length; i++) {
+        nv.setOpacity(i, volumeVisible ? 1 : 0)
+      }
+      nv.updateGLVolume?.()
+    } catch (e) {
+      console.warn('niivue setOpacity failed', e)
+    }
+  }, [volumeVisible, surfaceKind, sliceType, showViewer])
 
   // Reload meshes when surface kind changes.
   useEffect(() => {
@@ -285,6 +307,24 @@ export function StructuralQCPanel({ subject }: Props) {
                   {opt.label}
                 </button>
               ))}
+              <span style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)' }} />
+              <span style={{ color: 'var(--text-secondary)' }}>Volume:</span>
+              <button
+                style={{
+                  ...btn,
+                  padding: '2px 8px',
+                  fontSize: 11,
+                  background: volumeVisible ? 'var(--accent-cyan)' : btn.background,
+                  color: volumeVisible ? '#000' : 'var(--text-primary)',
+                  borderColor: volumeVisible ? 'var(--accent-cyan)' : 'var(--border)',
+                }}
+                onClick={() => setVolumeVisible((v) => !v)}
+                title={volumeVisible
+                  ? 'Hide the T1 — useful in 3D mode so the cortex meshes are unobstructed'
+                  : 'Show the T1 volume'}
+              >
+                {volumeVisible ? 'on' : 'off'}
+              </button>
               <span style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)' }} />
               <span style={{ color: 'var(--text-secondary)' }}>Surface:</span>
               {(['pial', 'white', 'inflated', 'none'] as const).map((k) => (

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -1,0 +1,319 @@
+/** Structural-QC review panel: fmriprep report + niivue viewer + decision form. */
+
+import { useEffect, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
+import { Niivue } from '@niivue/niivue'
+import {
+  fetchReview,
+  saveReview,
+  fetchFreeviewCommand,
+  reportUrl,
+  fsFileUrl,
+} from '../../api/structural-qc'
+import type { StructuralQCReview, StructuralQCStatus } from '../../api/types'
+
+interface Props {
+  subject: string
+}
+
+const STATUSES: { value: StructuralQCStatus; label: string; color: string }[] = [
+  { value: 'pending', label: 'Pending', color: 'var(--text-secondary)' },
+  { value: 'approved', label: 'Approve', color: 'var(--accent-green)' },
+  { value: 'needs_edits', label: 'Needs edits', color: 'var(--accent-yellow)' },
+  { value: 'rejected', label: 'Rejected', color: 'var(--accent-red)' },
+]
+
+const sectionLabel: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  color: 'var(--text-secondary)',
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  marginTop: 16,
+  marginBottom: 8,
+}
+
+const btn: CSSProperties = {
+  padding: '6px 12px',
+  fontSize: 12,
+  fontWeight: 600,
+  borderRadius: 4,
+  border: '1px solid var(--border)',
+  background: 'var(--bg-secondary)',
+  color: 'var(--text-primary)',
+  cursor: 'pointer',
+}
+
+const primaryBtn: CSSProperties = {
+  ...btn,
+  background: 'var(--accent-cyan)',
+  color: '#000',
+  border: 'none',
+}
+
+export function StructuralQCPanel({ subject }: Props) {
+  const [review, setReview] = useState<StructuralQCReview | null>(null)
+  const [status, setStatus] = useState<StructuralQCStatus>('pending')
+  const [reviewer, setReviewer] = useState('')
+  const [notes, setNotes] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [savedAt, setSavedAt] = useState<string | null>(null)
+  const [freeviewCmd, setFreeviewCmd] = useState<string | null>(null)
+  const [freeviewErr, setFreeviewErr] = useState<string | null>(null)
+  const [showReport, setShowReport] = useState(false)
+  const [showViewer, setShowViewer] = useState(false)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const nvRef = useRef<Niivue | null>(null)
+
+  // Load existing review
+  useEffect(() => {
+    let cancelled = false
+    fetchReview(subject)
+      .then((r) => {
+        if (cancelled) return
+        setReview(r)
+        setStatus(r.status)
+        setReviewer(r.reviewer)
+        setNotes(r.notes)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [subject])
+
+  // Initialize niivue when viewer is opened
+  useEffect(() => {
+    if (!showViewer || !canvasRef.current) return
+    const nv = new Niivue({ show3Dcrosshair: true, backColor: [0, 0, 0, 1] })
+    nvRef.current = nv
+    nv.attachToCanvas(canvasRef.current)
+
+    nv.loadVolumes([{ url: fsFileUrl(subject, 'mri/T1.mgz'), name: 'T1' }])
+      .then(() => {
+        return nv.loadMeshes([
+          {
+            url: fsFileUrl(subject, 'surf/lh.pial'),
+            name: 'lh.pial',
+            rgba255: [255, 0, 0, 255],
+          },
+          {
+            url: fsFileUrl(subject, 'surf/rh.pial'),
+            name: 'rh.pial',
+            rgba255: [255, 0, 0, 255],
+          },
+        ])
+      })
+      .catch((e) => console.warn('niivue load failed', e))
+
+    return () => {
+      nvRef.current = null
+    }
+  }, [showViewer, subject])
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      const result = await saveReview(subject, {
+        status,
+        reviewer,
+        notes,
+        freeview_command_used: freeviewCmd,
+      })
+      setReview(result.review)
+      setSavedAt(new Date().toLocaleTimeString())
+    } catch (e) {
+      console.error('Save failed', e)
+      alert(`Save failed: ${e}`)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleCopyFreeview() {
+    setFreeviewErr(null)
+    try {
+      const { command } = await fetchFreeviewCommand(subject)
+      await navigator.clipboard.writeText(command)
+      setFreeviewCmd(command)
+    } catch (e) {
+      setFreeviewErr(String(e))
+    }
+  }
+
+  const currentStatus = STATUSES.find((s) => s.value === status) ?? STATUSES[0]
+
+  return (
+    <div>
+      <div style={sectionLabel}>
+        Structural QC{' '}
+        <span style={{ marginLeft: 6, color: currentStatus.color }}>
+          ● {currentStatus.label}
+        </span>
+        {review?.timestamp && (
+          <span
+            style={{
+              marginLeft: 8,
+              fontSize: 10,
+              color: 'var(--text-secondary)',
+              fontWeight: 400,
+              textTransform: 'none',
+              letterSpacing: 0,
+            }}
+          >
+            last saved {new Date(review.timestamp).toLocaleString()}
+          </span>
+        )}
+      </div>
+
+      {/* Report toggle + iframe */}
+      <div style={{ marginBottom: 12 }}>
+        <button style={btn} onClick={() => setShowReport((v) => !v)}>
+          {showReport ? 'Hide' : 'Show'} fmriprep report
+        </button>
+        {showReport && (
+          <iframe
+            src={reportUrl(subject)}
+            title="fmriprep report"
+            style={{
+              width: '100%',
+              height: 600,
+              marginTop: 8,
+              border: '1px solid var(--border)',
+              borderRadius: 4,
+            }}
+          />
+        )}
+      </div>
+
+      {/* Niivue toggle + canvas */}
+      <div style={{ marginBottom: 12 }}>
+        <button style={btn} onClick={() => setShowViewer((v) => !v)}>
+          {showViewer ? 'Hide' : 'Show'} 3D viewer (T1 + pial)
+        </button>
+        {showViewer && (
+          <div
+            style={{
+              marginTop: 8,
+              border: '1px solid var(--border)',
+              borderRadius: 4,
+              background: '#000',
+              overflow: 'hidden',
+            }}
+          >
+            <canvas
+              ref={canvasRef}
+              style={{ width: '100%', height: 500, display: 'block' }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Decision panel */}
+      <div
+        style={{
+          padding: 12,
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border)',
+          borderRadius: 6,
+        }}
+      >
+        <div style={{ display: 'flex', gap: 6, marginBottom: 10, flexWrap: 'wrap' }}>
+          {STATUSES.map((s) => (
+            <button
+              key={s.value}
+              onClick={() => setStatus(s.value)}
+              style={{
+                ...btn,
+                borderColor: status === s.value ? s.color : 'var(--border)',
+                background:
+                  status === s.value ? s.color : 'var(--bg-secondary)',
+                color: status === s.value ? '#000' : 'var(--text-primary)',
+              }}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+          <input
+            placeholder="reviewer (e.g. omar)"
+            value={reviewer}
+            onChange={(e) => setReviewer(e.target.value)}
+            style={{
+              flex: 1,
+              padding: '6px 8px',
+              fontSize: 12,
+              border: '1px solid var(--border)',
+              borderRadius: 4,
+              background: 'var(--bg-secondary)',
+              color: 'var(--text-primary)',
+            }}
+          />
+        </div>
+        <textarea
+          placeholder="notes (optional)"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={3}
+          style={{
+            width: '100%',
+            padding: 8,
+            fontSize: 12,
+            border: '1px solid var(--border)',
+            borderRadius: 4,
+            background: 'var(--bg-secondary)',
+            color: 'var(--text-primary)',
+            resize: 'vertical',
+            marginBottom: 8,
+            boxSizing: 'border-box',
+          }}
+        />
+
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <button style={primaryBtn} onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving…' : 'Save review'}
+          </button>
+          {status === 'needs_edits' && (
+            <button style={btn} onClick={handleCopyFreeview}>
+              Copy freeview command
+            </button>
+          )}
+          {savedAt && (
+            <span style={{ fontSize: 11, color: 'var(--accent-green)' }}>
+              ✓ saved {savedAt}
+            </span>
+          )}
+          {freeviewCmd && (
+            <span style={{ fontSize: 11, color: 'var(--accent-cyan)' }}>
+              ✓ freeview command copied
+            </span>
+          )}
+          {freeviewErr && (
+            <span style={{ fontSize: 11, color: 'var(--accent-red)' }}>
+              {freeviewErr}
+            </span>
+          )}
+        </div>
+
+        {freeviewCmd && (
+          <pre
+            style={{
+              marginTop: 8,
+              padding: 8,
+              fontSize: 11,
+              background: 'var(--bg-secondary)',
+              border: '1px solid var(--border)',
+              borderRadius: 4,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all',
+            }}
+          >
+            {freeviewCmd}
+          </pre>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -89,7 +89,10 @@ export function StructuralQCPanel({ subject }: Props) {
     nvRef.current = nv
     nv.attachToCanvas(canvasRef.current)
 
-    nv.loadVolumes([{ url: fsFileUrl(subject, 'mri/T1.mgz'), name: 'T1' }])
+    // niivue derives the file format from `name` (preferring it over `url`),
+    // so the name MUST keep its extension or `getFileExt` blows up with
+    // "Cannot read properties of undefined (reading 'toUpperCase')".
+    nv.loadVolumes([{ url: fsFileUrl(subject, 'mri/T1.mgz'), name: 'T1.mgz' }])
       .then(() => {
         return nv.loadMeshes([
           {

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -73,7 +73,6 @@ export function StructuralQCPanel({ subject }: Props) {
   const [freeviewErr, setFreeviewErr] = useState<string | null>(null)
   const [showReport, setShowReport] = useState(false)
   const [showViewer, setShowViewer] = useState(false)
-  const [fullscreen, setFullscreen] = useState(false)
   // Multiple surfaces can be shown at once. Each renders in its own colour.
   const [surfaces, setSurfaces] = useState<Set<SurfaceKind>>(
     () => new Set<SurfaceKind>(['pial']),
@@ -297,7 +296,7 @@ export function StructuralQCPanel({ subject }: Props) {
         </button>
         {showViewer && (
           <div
-            style={fullscreen ? {
+            style={{
               position: 'fixed',
               inset: 0,
               zIndex: 1000,
@@ -305,7 +304,7 @@ export function StructuralQCPanel({ subject }: Props) {
               padding: 12,
               display: 'flex',
               flexDirection: 'column',
-            } : { marginTop: 8 }}
+            }}
           >
             {/* Toolbar — view + surface pickers */}
             <div
@@ -431,10 +430,10 @@ export function StructuralQCPanel({ subject }: Props) {
               <span style={{ flex: 1 }} />
               <button
                 style={{ ...btn, padding: '2px 8px', fontSize: 11 }}
-                onClick={() => setFullscreen((v) => !v)}
-                title="Pop out to fullscreen"
+                onClick={() => setShowViewer(false)}
+                title="Close 3D viewer"
               >
-                {fullscreen ? '⤢ Exit fullscreen' : '⤢ Fullscreen'}
+                ✕ Close
               </button>
             </div>
             <div
@@ -445,7 +444,7 @@ export function StructuralQCPanel({ subject }: Props) {
                 borderBottomRightRadius: 4,
                 background: '#000',
                 overflow: 'hidden',
-                flex: fullscreen ? 1 : undefined,
+                flex: 1,
                 minHeight: 0,
               }}
             >
@@ -453,7 +452,7 @@ export function StructuralQCPanel({ subject }: Props) {
                 ref={canvasRef}
                 style={{
                   width: '100%',
-                  height: fullscreen ? '100%' : '70vh',
+                  height: '100%',
                   display: 'block',
                 }}
               />

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -16,6 +16,16 @@ interface Props {
   subject: string
 }
 
+type SurfaceKind = 'pial' | 'white' | 'inflated'
+
+const SURFACE_COLORS: Record<SurfaceKind, [number, number, number, number]> = {
+  pial:     [255,  80,  80, 255],   // red
+  white:    [255, 220,  60, 255],   // yellow
+  inflated: [ 80, 160, 255, 255],   // blue
+}
+
+const ALL_SURFACES: SurfaceKind[] = ['pial', 'white', 'inflated']
+
 const STATUSES: { value: StructuralQCStatus; label: string; color: string }[] = [
   { value: 'pending', label: 'Pending', color: 'var(--text-secondary)' },
   { value: 'approved', label: 'Approve', color: 'var(--accent-green)' },
@@ -62,8 +72,11 @@ export function StructuralQCPanel({ subject }: Props) {
   const [freeviewErr, setFreeviewErr] = useState<string | null>(null)
   const [showReport, setShowReport] = useState(false)
   const [showViewer, setShowViewer] = useState(false)
-  const [surfaceKind, setSurfaceKind] =
-    useState<'pial' | 'white' | 'inflated' | 'none'>('pial')
+  const [fullscreen, setFullscreen] = useState(false)
+  // Multiple surfaces can be shown at once. Each renders in its own colour.
+  const [surfaces, setSurfaces] = useState<Set<SurfaceKind>>(
+    () => new Set<SurfaceKind>(['pial']),
+  )
   // niivue sliceType: 0=axial 1=coronal 2=sagittal 3=multiplanar 4=render(3D)
   const [sliceType, setSliceType] = useState<number>(3)
   const [volumeVisible, setVolumeVisible] = useState<boolean>(true)
@@ -142,9 +155,10 @@ export function StructuralQCPanel({ subject }: Props) {
     } catch (e) {
       console.warn('niivue setOpacity failed', e)
     }
-  }, [volumeVisible, surfaceKind, sliceType, showViewer])
+  }, [volumeVisible, surfaces, sliceType, showViewer])
 
-  // Reload meshes when surface kind changes.
+  // Reload meshes when the surface set changes — supports multiple
+  // surfaces simultaneously, colour-coded per kind.
   useEffect(() => {
     const nv = nvRef.current
     if (!nv || !showViewer) return
@@ -158,24 +172,19 @@ export function StructuralQCPanel({ subject }: Props) {
             (inst as unknown as { removeMesh?: (m: unknown) => void }).removeMesh?.(m)
           } catch { /* niivue versions differ — best-effort */ }
         }
-        if (cancelled) return
-        if (surfaceKind === 'none') {
+        if (cancelled || surfaces.size === 0) {
           inst.updateGLVolume()
           return
         }
-        const fname = surfaceKind
-        await inst.loadMeshes([
-          {
-            url: fsFileUrl(subject, `surf/lh.${fname}`),
-            name: `lh.${fname}`,
-            rgba255: [255, 80, 80, 255],
-          },
-          {
-            url: fsFileUrl(subject, `surf/rh.${fname}`),
-            name: `rh.${fname}`,
-            rgba255: [255, 80, 80, 255],
-          },
-        ])
+        const specs = []
+        for (const kind of surfaces) {
+          const rgba = SURFACE_COLORS[kind]
+          specs.push(
+            { url: fsFileUrl(subject, `surf/lh.${kind}`), name: `lh.${kind}`, rgba255: rgba },
+            { url: fsFileUrl(subject, `surf/rh.${kind}`), name: `rh.${kind}`, rgba255: rgba },
+          )
+        }
+        await inst.loadMeshes(specs)
       } catch (e) {
         console.warn('niivue mesh reload failed', e)
       }
@@ -184,7 +193,7 @@ export function StructuralQCPanel({ subject }: Props) {
     return () => {
       cancelled = true
     }
-  }, [surfaceKind, showViewer, subject])
+  }, [surfaces, showViewer, subject])
 
   async function handleSave() {
     setSaving(true)
@@ -267,7 +276,17 @@ export function StructuralQCPanel({ subject }: Props) {
           {showViewer ? 'Hide' : 'Show'} 3D viewer
         </button>
         {showViewer && (
-          <>
+          <div
+            style={fullscreen ? {
+              position: 'fixed',
+              inset: 0,
+              zIndex: 1000,
+              background: '#000',
+              padding: 12,
+              display: 'flex',
+              flexDirection: 'column',
+            } : { marginTop: 8 }}
+          >
             {/* Toolbar — view + surface pickers */}
             <div
               style={{
@@ -275,7 +294,6 @@ export function StructuralQCPanel({ subject }: Props) {
                 flexWrap: 'wrap',
                 gap: 12,
                 alignItems: 'center',
-                marginTop: 8,
                 padding: 8,
                 border: '1px solid var(--border)',
                 borderTopLeftRadius: 4,
@@ -326,23 +344,49 @@ export function StructuralQCPanel({ subject }: Props) {
                 {volumeVisible ? 'on' : 'off'}
               </button>
               <span style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)' }} />
-              <span style={{ color: 'var(--text-secondary)' }}>Surface:</span>
-              {(['pial', 'white', 'inflated', 'none'] as const).map((k) => (
-                <button
-                  key={k}
-                  style={{
-                    ...btn,
-                    padding: '2px 8px',
-                    fontSize: 11,
-                    background: surfaceKind === k ? 'var(--accent-cyan)' : btn.background,
-                    color: surfaceKind === k ? '#000' : 'var(--text-primary)',
-                    borderColor: surfaceKind === k ? 'var(--accent-cyan)' : 'var(--border)',
-                  }}
-                  onClick={() => setSurfaceKind(k)}
-                >
-                  {k}
-                </button>
-              ))}
+              <span style={{ color: 'var(--text-secondary)' }}>Surfaces:</span>
+              {ALL_SURFACES.map((k) => {
+                const on = surfaces.has(k)
+                const color = `rgb(${SURFACE_COLORS[k].slice(0, 3).join(',')})`
+                return (
+                  <button
+                    key={k}
+                    style={{
+                      ...btn,
+                      padding: '2px 8px',
+                      fontSize: 11,
+                      background: on ? color : btn.background,
+                      color: on ? '#000' : 'var(--text-primary)',
+                      borderColor: on ? color : 'var(--border)',
+                    }}
+                    onClick={() => {
+                      setSurfaces((prev) => {
+                        const next = new Set(prev)
+                        if (next.has(k)) next.delete(k)
+                        else next.add(k)
+                        return next
+                      })
+                    }}
+                  >
+                    {k}
+                  </button>
+                )
+              })}
+              <button
+                style={{ ...btn, padding: '2px 8px', fontSize: 11 }}
+                onClick={() => setSurfaces(new Set())}
+                title="Hide all surfaces"
+              >
+                clear
+              </button>
+              <span style={{ flex: 1 }} />
+              <button
+                style={{ ...btn, padding: '2px 8px', fontSize: 11 }}
+                onClick={() => setFullscreen((v) => !v)}
+                title="Pop out to fullscreen"
+              >
+                {fullscreen ? '⤢ Exit fullscreen' : '⤢ Fullscreen'}
+              </button>
             </div>
             <div
               style={{
@@ -352,14 +396,20 @@ export function StructuralQCPanel({ subject }: Props) {
                 borderBottomRightRadius: 4,
                 background: '#000',
                 overflow: 'hidden',
+                flex: fullscreen ? 1 : undefined,
+                minHeight: 0,
               }}
             >
               <canvas
                 ref={canvasRef}
-                style={{ width: '100%', height: '70vh', display: 'block' }}
+                style={{
+                  width: '100%',
+                  height: fullscreen ? '100%' : '70vh',
+                  display: 'block',
+                }}
               />
             </div>
-          </>
+          </div>
         )}
       </div>
 

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -62,6 +62,10 @@ export function StructuralQCPanel({ subject }: Props) {
   const [freeviewErr, setFreeviewErr] = useState<string | null>(null)
   const [showReport, setShowReport] = useState(false)
   const [showViewer, setShowViewer] = useState(false)
+  const [surfaceKind, setSurfaceKind] =
+    useState<'pial' | 'white' | 'inflated' | 'none'>('pial')
+  // niivue sliceType: 0=axial 1=coronal 2=sagittal 3=multiplanar 4=render(3D)
+  const [sliceType, setSliceType] = useState<number>(3)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const nvRef = useRef<Niivue | null>(null)
 
@@ -82,7 +86,8 @@ export function StructuralQCPanel({ subject }: Props) {
     }
   }, [subject])
 
-  // Initialize niivue when viewer is opened
+  // Initialize niivue when viewer is opened. Surface kind / slice type
+  // changes go through their own effects so we don't reload the volume.
   useEffect(() => {
     if (!showViewer || !canvasRef.current) return
     const nv = new Niivue({ show3Dcrosshair: true, backColor: [0, 0, 0, 1] })
@@ -94,25 +99,70 @@ export function StructuralQCPanel({ subject }: Props) {
     // "Cannot read properties of undefined (reading 'toUpperCase')".
     nv.loadVolumes([{ url: fsFileUrl(subject, 'mri/T1.mgz'), name: 'T1.mgz' }])
       .then(() => {
-        return nv.loadMeshes([
-          {
-            url: fsFileUrl(subject, 'surf/lh.pial'),
-            name: 'lh.pial',
-            rgba255: [255, 0, 0, 255],
-          },
-          {
-            url: fsFileUrl(subject, 'surf/rh.pial'),
-            name: 'rh.pial',
-            rgba255: [255, 0, 0, 255],
-          },
-        ])
+        nv.setSliceType(sliceType)
       })
       .catch((e) => console.warn('niivue load failed', e))
 
     return () => {
       nvRef.current = null
     }
+    // We *don't* depend on sliceType / surfaceKind here — those are
+    // applied incrementally below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showViewer, subject])
+
+  // Apply slice-type changes without recreating the niivue instance.
+  useEffect(() => {
+    const nv = nvRef.current
+    if (!nv) return
+    try {
+      nv.setSliceType(sliceType)
+    } catch (e) {
+      console.warn('niivue setSliceType failed', e)
+    }
+  }, [sliceType])
+
+  // Reload meshes when surface kind changes.
+  useEffect(() => {
+    const nv = nvRef.current
+    if (!nv || !showViewer) return
+    const inst = nv
+    let cancelled = false
+    async function reload() {
+      try {
+        const meshes = (inst as unknown as { meshes?: Array<unknown> }).meshes ?? []
+        for (const m of [...meshes]) {
+          try {
+            (inst as unknown as { removeMesh?: (m: unknown) => void }).removeMesh?.(m)
+          } catch { /* niivue versions differ — best-effort */ }
+        }
+        if (cancelled) return
+        if (surfaceKind === 'none') {
+          inst.updateGLVolume()
+          return
+        }
+        const fname = surfaceKind
+        await inst.loadMeshes([
+          {
+            url: fsFileUrl(subject, `surf/lh.${fname}`),
+            name: `lh.${fname}`,
+            rgba255: [255, 80, 80, 255],
+          },
+          {
+            url: fsFileUrl(subject, `surf/rh.${fname}`),
+            name: `rh.${fname}`,
+            rgba255: [255, 80, 80, 255],
+          },
+        ])
+      } catch (e) {
+        console.warn('niivue mesh reload failed', e)
+      }
+    }
+    reload()
+    return () => {
+      cancelled = true
+    }
+  }, [surfaceKind, showViewer, subject])
 
   async function handleSave() {
     setSaving(true)
@@ -192,23 +242,84 @@ export function StructuralQCPanel({ subject }: Props) {
       {/* Niivue toggle + canvas */}
       <div style={{ marginBottom: 12 }}>
         <button style={btn} onClick={() => setShowViewer((v) => !v)}>
-          {showViewer ? 'Hide' : 'Show'} 3D viewer (T1 + pial)
+          {showViewer ? 'Hide' : 'Show'} 3D viewer
         </button>
         {showViewer && (
-          <div
-            style={{
-              marginTop: 8,
-              border: '1px solid var(--border)',
-              borderRadius: 4,
-              background: '#000',
-              overflow: 'hidden',
-            }}
-          >
-            <canvas
-              ref={canvasRef}
-              style={{ width: '100%', height: 500, display: 'block' }}
-            />
-          </div>
+          <>
+            {/* Toolbar — view + surface pickers */}
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 12,
+                alignItems: 'center',
+                marginTop: 8,
+                padding: 8,
+                border: '1px solid var(--border)',
+                borderTopLeftRadius: 4,
+                borderTopRightRadius: 4,
+                background: 'var(--bg-secondary)',
+                fontSize: 11,
+              }}
+            >
+              <span style={{ color: 'var(--text-secondary)' }}>View:</span>
+              {[
+                { v: 3, label: 'Multi' },
+                { v: 0, label: 'Axial' },
+                { v: 1, label: 'Coronal' },
+                { v: 2, label: 'Sagittal' },
+                { v: 4, label: '3D' },
+              ].map((opt) => (
+                <button
+                  key={opt.v}
+                  style={{
+                    ...btn,
+                    padding: '2px 8px',
+                    fontSize: 11,
+                    background: sliceType === opt.v ? 'var(--accent-cyan)' : btn.background,
+                    color: sliceType === opt.v ? '#000' : 'var(--text-primary)',
+                    borderColor: sliceType === opt.v ? 'var(--accent-cyan)' : 'var(--border)',
+                  }}
+                  onClick={() => setSliceType(opt.v)}
+                >
+                  {opt.label}
+                </button>
+              ))}
+              <span style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)' }} />
+              <span style={{ color: 'var(--text-secondary)' }}>Surface:</span>
+              {(['pial', 'white', 'inflated', 'none'] as const).map((k) => (
+                <button
+                  key={k}
+                  style={{
+                    ...btn,
+                    padding: '2px 8px',
+                    fontSize: 11,
+                    background: surfaceKind === k ? 'var(--accent-cyan)' : btn.background,
+                    color: surfaceKind === k ? '#000' : 'var(--text-primary)',
+                    borderColor: surfaceKind === k ? 'var(--accent-cyan)' : 'var(--border)',
+                  }}
+                  onClick={() => setSurfaceKind(k)}
+                >
+                  {k}
+                </button>
+              ))}
+            </div>
+            <div
+              style={{
+                border: '1px solid var(--border)',
+                borderTop: 'none',
+                borderBottomLeftRadius: 4,
+                borderBottomRightRadius: 4,
+                background: '#000',
+                overflow: 'hidden',
+              }}
+            >
+              <canvas
+                ref={canvasRef}
+                style={{ width: '100%', height: '70vh', display: 'block' }}
+              />
+            </div>
+          </>
         )}
       </div>
 

--- a/frontend/src/components/preproc/__tests__/StructuralQCPanel.test.tsx
+++ b/frontend/src/components/preproc/__tests__/StructuralQCPanel.test.tsx
@@ -1,0 +1,117 @@
+/** Reviewer flow: load existing review, change status, save, copy command. */
+
+import { describe, it, expect, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../../test/mocks/server'
+import { renderWithProviders, screen, waitFor } from '../../../test/render'
+import { StructuralQCPanel } from '../StructuralQCPanel'
+
+
+// niivue is heavy and DOM-WebGL — stub it so the panel mounts cleanly.
+vi.mock('@niivue/niivue', () => {
+  return {
+    Niivue: vi.fn().mockImplementation(() => ({
+      attachToCanvas: vi.fn(),
+      loadVolumes: vi.fn().mockResolvedValue(undefined),
+      loadMeshes: vi.fn().mockResolvedValue(undefined),
+    })),
+  }
+})
+
+
+function mockReview(status = 'pending', reviewer = '', notes = '') {
+  server.use(
+    http.get('/api/preproc/subjects/sub01/structural-qc', () =>
+      HttpResponse.json({
+        dataset: 'ds-test',
+        subject: 'sub01',
+        status,
+        reviewer,
+        timestamp: '2026-05-04T00:00:00Z',
+        notes,
+        freeview_command_used: null,
+      }),
+    ),
+  )
+}
+
+
+describe('<StructuralQCPanel />', () => {
+  it('loads and displays an existing review', async () => {
+    mockReview('approved', 'omar', 'looks good')
+    renderWithProviders(<StructuralQCPanel subject="sub01" />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('omar')).toBeInTheDocument()
+    })
+    expect(screen.getByDisplayValue('looks good')).toBeInTheDocument()
+    // Header dot reflects the loaded status (rendered as `● Approve`).
+    expect(screen.getByText(/●\s*Approve/)).toBeInTheDocument()
+  })
+
+  it('saves a status change with reviewer + notes', async () => {
+    mockReview('pending', '', '')
+    let captured: any = null
+    server.use(
+      http.post('/api/preproc/subjects/sub01/structural-qc', async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json({
+          saved: true,
+          path: '/r.yaml',
+          review: {
+            dataset: 'ds-test', subject: 'sub01',
+            status: captured.status, reviewer: captured.reviewer,
+            notes: captured.notes, timestamp: '2026-05-04',
+            freeview_command_used: captured.freeview_command_used ?? null,
+          },
+        })
+      }),
+    )
+
+    const { user } = renderWithProviders(<StructuralQCPanel subject="sub01" />)
+    await waitFor(() => expect(screen.getByPlaceholderText(/reviewer/i)).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: /^approve$/i }))
+    await user.type(screen.getByPlaceholderText(/reviewer/i), 'omar')
+    await user.type(screen.getByPlaceholderText(/notes/i), 'all good')
+    await user.click(screen.getByRole('button', { name: /save review/i }))
+
+    await waitFor(() => expect(captured).not.toBeNull())
+    expect(captured.status).toBe('approved')
+    expect(captured.reviewer).toBe('omar')
+    expect(captured.notes).toBe('all good')
+  })
+
+  it('shows the freeview button only when status is needs_edits', async () => {
+    mockReview('approved', 'omar', '')
+    const { user } = renderWithProviders(<StructuralQCPanel subject="sub01" />)
+    await waitFor(() => expect(screen.getByDisplayValue('omar')).toBeInTheDocument())
+
+    expect(screen.queryByRole('button', { name: /copy freeview command/i })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /needs edits/i }))
+    expect(screen.getByRole('button', { name: /copy freeview command/i })).toBeInTheDocument()
+  })
+
+  it('toggles the fmriprep report iframe', async () => {
+    mockReview()
+    const { user } = renderWithProviders(<StructuralQCPanel subject="sub01" />)
+    await waitFor(() => expect(screen.getByPlaceholderText(/reviewer/i)).toBeInTheDocument())
+
+    expect(screen.queryByTitle('fmriprep report')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /show fmriprep report/i }))
+    expect(screen.getByTitle('fmriprep report')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /hide fmriprep report/i }))
+    expect(screen.queryByTitle('fmriprep report')).not.toBeInTheDocument()
+  })
+
+  it('toggles the niivue 3D viewer', async () => {
+    mockReview()
+    const { user } = renderWithProviders(<StructuralQCPanel subject="sub01" />)
+    await waitFor(() => expect(screen.getByPlaceholderText(/reviewer/i)).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: /show 3d viewer/i }))
+    // Toggle button label flips when the viewer is open.
+    expect(screen.getByRole('button', { name: /hide 3d viewer/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/workflow/InnerNodesStrip.tsx
+++ b/frontend/src/components/workflow/InnerNodesStrip.tsx
@@ -1,0 +1,175 @@
+/** Render a strip of nipype-node status pills under a stage block.
+ *
+ * Variable-N siblings, grouped by workflow path so a 200-node fmriprep
+ * graph stays scannable. Default-collapsed; expand on click to see all.
+ */
+
+import { memo, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+import type {
+  NipypeNodeStatus,
+  NipypeStatusCounts,
+  NipypeStatusBlock,
+} from '../../api/types'
+
+const STATUS_COLOR: Record<string, string> = {
+  running: '#00e5ff',
+  ok: '#00e676',
+  failed: '#ff1744',
+  // Anything else falls back to neutral
+}
+
+const containerStyle: CSSProperties = {
+  marginTop: 6,
+  padding: '6px 8px',
+  borderRadius: 6,
+  background: 'rgba(16, 185, 129, 0.08)',
+  border: '1px solid rgba(16, 185, 129, 0.25)',
+  fontSize: 10,
+  color: 'var(--text-primary)',
+}
+
+const headerStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  cursor: 'pointer',
+  userSelect: 'none',
+}
+
+const countPill = (color: string): CSSProperties => ({
+  padding: '1px 6px',
+  borderRadius: 8,
+  background: `${color}22`,
+  color,
+  border: `1px solid ${color}55`,
+  fontSize: 9,
+  fontWeight: 700,
+})
+
+const groupHeader: CSSProperties = {
+  marginTop: 6,
+  marginBottom: 2,
+  fontSize: 9,
+  textTransform: 'uppercase',
+  letterSpacing: 0.5,
+  color: 'var(--text-secondary)',
+  fontWeight: 700,
+}
+
+const pillRow: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 4,
+}
+
+const nodePill = (color: string): CSSProperties => ({
+  padding: '2px 6px',
+  borderRadius: 8,
+  background: `${color}1f`,
+  color,
+  border: `1px solid ${color}55`,
+  fontSize: 9,
+  fontWeight: 600,
+  cursor: 'default',
+  whiteSpace: 'nowrap',
+})
+
+
+function _summarize(counts: NipypeStatusCounts): React.ReactNode {
+  const items: { color: string; label: string }[] = []
+  if (counts.running) items.push({ color: STATUS_COLOR.running, label: `${counts.running} running` })
+  if (counts.ok) items.push({ color: STATUS_COLOR.ok, label: `${counts.ok} done` })
+  if (counts.failed) items.push({ color: STATUS_COLOR.failed, label: `${counts.failed} failed` })
+  if (items.length === 0) {
+    return <span style={{ color: 'var(--text-secondary)' }}>no nodes seen yet</span>
+  }
+  return (
+    <>
+      {items.map((it, i) => (
+        <span key={i} style={countPill(it.color)}>{it.label}</span>
+      ))}
+    </>
+  )
+}
+
+
+function _topGroup(workflow: string): string {
+  // First two dotted segments — keeps fmriprep_wf groups (anatomical /
+  // functional / fieldmap) visible without dragging in 8-deep paths.
+  const parts = workflow.split('.')
+  if (parts.length === 0) return '(root)'
+  if (parts.length === 1) return parts[0]
+  return parts.slice(0, 2).join('.')
+}
+
+
+interface Props {
+  block: NipypeStatusBlock
+  onNodeClick?: (node: NipypeNodeStatus) => void
+}
+
+function InnerNodesStripInner({ block, onNodeClick }: Props) {
+  const [expanded, setExpanded] = useState(false)
+  const grouped = useMemo(() => {
+    const groups = new Map<string, NipypeNodeStatus[]>()
+    for (const n of block.recent_nodes) {
+      const key = _topGroup(n.workflow || '')
+      const arr = groups.get(key)
+      if (arr) arr.push(n)
+      else groups.set(key, [n])
+    }
+    return groups
+  }, [block.recent_nodes])
+
+  const total = block.counts.total_seen
+  return (
+    <div style={containerStyle}>
+      <div style={headerStyle} onClick={() => setExpanded((v) => !v)}>
+        <span style={{ color: 'var(--text-secondary)' }}>
+          {expanded ? '▼' : '▶'}
+        </span>
+        <span style={{ fontWeight: 700 }}>nipype nodes</span>
+        {_summarize(block.counts)}
+        {total > 0 && (
+          <span style={{ marginLeft: 'auto', color: 'var(--text-secondary)' }}>
+            {total} seen
+          </span>
+        )}
+      </div>
+      {expanded && grouped.size > 0 && (
+        <div style={{ marginTop: 4 }}>
+          {Array.from(grouped.entries()).map(([group, nodes]) => (
+            <div key={group}>
+              <div style={groupHeader}>{group}</div>
+              <div style={pillRow}>
+                {nodes.map((n) => {
+                  const color = STATUS_COLOR[n.status] ?? 'var(--text-secondary)'
+                  const elapsed = n.elapsed > 0
+                    ? ` · ${n.elapsed.toFixed(1)}s`
+                    : ''
+                  return (
+                    <span
+                      key={n.node}
+                      style={{
+                        ...nodePill(color),
+                        cursor: onNodeClick ? 'pointer' : 'default',
+                      }}
+                      title={`${n.node} — ${n.status}${elapsed}`}
+                      onClick={onNodeClick ? () => onNodeClick(n) : undefined}
+                    >
+                      {n.leaf}{elapsed}
+                    </span>
+                  )
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+
+export const InnerNodesStrip = memo(InnerNodesStripInner)

--- a/frontend/src/components/workflow/InnerNodesStrip.tsx
+++ b/frontend/src/components/workflow/InnerNodesStrip.tsx
@@ -15,6 +15,8 @@ const STATUS_COLOR: Record<string, string> = {
   running: '#00e5ff',
   ok: '#00e676',
   failed: '#ff1744',
+  // Softer green for inferred-as-finished (no Finished log line seen).
+  completed_assumed: '#52c98f',
   // Anything else falls back to neutral
 }
 
@@ -64,6 +66,11 @@ function _summarize(counts: NipypeStatusCounts): React.ReactNode {
   if (counts.running) items.push({ color: STATUS_COLOR.running, label: `${counts.running} running` })
   if (counts.ok) items.push({ color: STATUS_COLOR.ok, label: `${counts.ok} done` })
   if (counts.failed) items.push({ color: STATUS_COLOR.failed, label: `${counts.failed} failed` })
+  if (counts.completed_assumed)
+    items.push({
+      color: STATUS_COLOR.completed_assumed,
+      label: `${counts.completed_assumed} assumed`,
+    })
   if (items.length === 0) {
     return <span style={{ color: 'var(--text-secondary)' }}>no nodes seen yet</span>
   }

--- a/frontend/src/components/workflow/InnerNodesStrip.tsx
+++ b/frontend/src/components/workflow/InnerNodesStrip.tsx
@@ -4,10 +4,9 @@
  * graph stays scannable. Default-collapsed; expand on click to see all.
  */
 
-import { memo, useMemo, useState } from 'react'
+import { memo } from 'react'
 import type { CSSProperties } from 'react'
 import type {
-  NipypeNodeStatus,
   NipypeStatusCounts,
   NipypeStatusBlock,
 } from '../../api/types'
@@ -33,9 +32,22 @@ const headerStyle: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   gap: 8,
-  cursor: 'pointer',
   userSelect: 'none',
 }
+
+const viewBtn = (color: string): CSSProperties => ({
+  marginLeft: 'auto',
+  padding: '2px 8px',
+  fontSize: 9,
+  fontWeight: 700,
+  letterSpacing: 0.5,
+  borderRadius: 4,
+  background: `${color}33`,
+  color,
+  border: `1px solid ${color}88`,
+  cursor: 'pointer',
+  textTransform: 'uppercase',
+})
 
 const countPill = (color: string): CSSProperties => ({
   padding: '1px 6px',
@@ -46,35 +58,6 @@ const countPill = (color: string): CSSProperties => ({
   fontSize: 9,
   fontWeight: 700,
 })
-
-const groupHeader: CSSProperties = {
-  marginTop: 6,
-  marginBottom: 2,
-  fontSize: 9,
-  textTransform: 'uppercase',
-  letterSpacing: 0.5,
-  color: 'var(--text-secondary)',
-  fontWeight: 700,
-}
-
-const pillRow: CSSProperties = {
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: 4,
-}
-
-const nodePill = (color: string): CSSProperties => ({
-  padding: '2px 6px',
-  borderRadius: 8,
-  background: `${color}1f`,
-  color,
-  border: `1px solid ${color}55`,
-  fontSize: 9,
-  fontWeight: 600,
-  cursor: 'default',
-  whiteSpace: 'nowrap',
-})
-
 
 function _summarize(counts: NipypeStatusCounts): React.ReactNode {
   const items: { color: string; label: string }[] = []
@@ -94,79 +77,40 @@ function _summarize(counts: NipypeStatusCounts): React.ReactNode {
 }
 
 
-function _topGroup(workflow: string): string {
-  // First two dotted segments — keeps fmriprep_wf groups (anatomical /
-  // functional / fieldmap) visible without dragging in 8-deep paths.
-  const parts = workflow.split('.')
-  if (parts.length === 0) return '(root)'
-  if (parts.length === 1) return parts[0]
-  return parts.slice(0, 2).join('.')
-}
-
-
 interface Props {
   block: NipypeStatusBlock
-  onNodeClick?: (node: NipypeNodeStatus) => void
+  onOpenDag?: () => void
 }
 
-function InnerNodesStripInner({ block, onNodeClick }: Props) {
-  const [expanded, setExpanded] = useState(false)
-  const grouped = useMemo(() => {
-    const groups = new Map<string, NipypeNodeStatus[]>()
-    for (const n of block.recent_nodes) {
-      const key = _topGroup(n.workflow || '')
-      const arr = groups.get(key)
-      if (arr) arr.push(n)
-      else groups.set(key, [n])
-    }
-    return groups
-  }, [block.recent_nodes])
-
+function InnerNodesStripInner({ block, onOpenDag }: Props) {
   const total = block.counts.total_seen
+  // Pick the dominant status color for the View DAG button.
+  const btnColor =
+    block.counts.failed > 0 ? STATUS_COLOR.failed
+    : block.counts.running > 0 ? STATUS_COLOR.running
+    : STATUS_COLOR.ok
   return (
     <div style={containerStyle}>
-      <div style={headerStyle} onClick={() => setExpanded((v) => !v)}>
-        <span style={{ color: 'var(--text-secondary)' }}>
-          {expanded ? '▼' : '▶'}
-        </span>
+      <div style={headerStyle}>
         <span style={{ fontWeight: 700 }}>nipype nodes</span>
         {_summarize(block.counts)}
         {total > 0 && (
-          <span style={{ marginLeft: 'auto', color: 'var(--text-secondary)' }}>
-            {total} seen
+          <span style={{ color: 'var(--text-secondary)', marginLeft: 4 }}>
+            ({total} seen)
           </span>
         )}
+        {onOpenDag && total > 0 && (
+          <button
+            style={viewBtn(btnColor)}
+            onClick={(e) => {
+              e.stopPropagation()
+              onOpenDag()
+            }}
+          >
+            View DAG →
+          </button>
+        )}
       </div>
-      {expanded && grouped.size > 0 && (
-        <div style={{ marginTop: 4 }}>
-          {Array.from(grouped.entries()).map(([group, nodes]) => (
-            <div key={group}>
-              <div style={groupHeader}>{group}</div>
-              <div style={pillRow}>
-                {nodes.map((n) => {
-                  const color = STATUS_COLOR[n.status] ?? 'var(--text-secondary)'
-                  const elapsed = n.elapsed > 0
-                    ? ` · ${n.elapsed.toFixed(1)}s`
-                    : ''
-                  return (
-                    <span
-                      key={n.node}
-                      style={{
-                        ...nodePill(color),
-                        cursor: onNodeClick ? 'pointer' : 'default',
-                      }}
-                      title={`${n.node} — ${n.status}${elapsed}`}
-                      onClick={onNodeClick ? () => onNodeClick(n) : undefined}
-                    >
-                      {n.leaf}{elapsed}
-                    </span>
-                  )
-                })}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/components/workflow/NipypeGraphModal.tsx
+++ b/frontend/src/components/workflow/NipypeGraphModal.tsx
@@ -19,6 +19,7 @@ import { fetchPreprocRunLive } from '../../api/client'
 import type { NipypeStatusBlock } from '../../api/types'
 import { buildNipypeTree, type NipypeTreeNode } from './nipype_tree'
 import { NodeOutputsPanel } from './NodeOutputsPanel'
+import { NodeListPanel } from './NodeListPanel'
 
 const STATUS_COLOR: Record<string, string> = {
   running: '#00e5ff',
@@ -290,6 +291,11 @@ function Inner({ runId, isRunning, onClose }: Props) {
         borderRadius: 4, background: 'var(--bg-secondary)',
         overflow: 'hidden',
       }}>
+        <NodeListPanel
+          nodes={block?.recent_nodes ?? []}
+          selected={openNode}
+          onSelect={setOpenNode}
+        />
         <div style={{ flex: 1, minWidth: 0, position: 'relative' }}>
         {error && (
           <div style={{ padding: 12, color: 'var(--accent-red)', fontSize: 12 }}>

--- a/frontend/src/components/workflow/NipypeGraphModal.tsx
+++ b/frontend/src/components/workflow/NipypeGraphModal.tsx
@@ -1,0 +1,307 @@
+/** Modal showing the live nipype DAG (tree-from-paths) for a Preproc run. */
+
+import { memo, useEffect, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  Position,
+  Handle,
+  type Node,
+  type Edge,
+  type NodeProps,
+} from '@xyflow/react'
+import dagre from 'dagre'
+
+import { fetchPreprocRunLive } from '../../api/client'
+import type { NipypeStatusBlock } from '../../api/types'
+import { buildNipypeTree, type NipypeTreeNode } from './nipype_tree'
+
+const STATUS_COLOR: Record<string, string> = {
+  running: '#00e5ff',
+  ok: '#00e676',
+  failed: '#ff1744',
+}
+const NEUTRAL = 'var(--text-secondary)'
+
+
+// ── Custom nodes ────────────────────────────────────────────────────────
+
+
+type LeafData = NipypeTreeNode & { _kind: 'leaf' }
+type WorkflowData = NipypeTreeNode & { _kind: 'workflow' }
+
+
+function _LeafNodeInner({ data }: NodeProps & { data: LeafData }) {
+  const color = STATUS_COLOR[data.status ?? ''] ?? NEUTRAL
+  const elapsed = data.elapsed && data.elapsed > 0
+    ? ` · ${data.elapsed.toFixed(1)}s`
+    : ''
+  return (
+    <div
+      style={{
+        background: `${color}22`,
+        border: `1px solid ${color}aa`,
+        color: 'var(--text-primary)',
+        borderRadius: 5,
+        padding: '4px 8px',
+        fontSize: 11,
+        fontWeight: 600,
+        minWidth: 110,
+        textAlign: 'center',
+        position: 'relative',
+      }}
+      title={`${data.full_node ?? data.id} — ${data.status ?? ''}${elapsed}`}
+    >
+      <Handle type="target" position={Position.Top} style={{ background: color }} />
+      <div>{data.label}</div>
+      <div style={{ fontSize: 9, color }}>
+        {data.status ?? ''}{elapsed}
+      </div>
+      <Handle type="source" position={Position.Bottom} style={{ background: color }} />
+    </div>
+  )
+}
+const LeafNode = memo(_LeafNodeInner)
+
+
+function _WorkflowNodeInner({ data }: NodeProps & { data: WorkflowData }) {
+  const c = data.counts ?? { running: 0, ok: 0, failed: 0, total: 0 }
+  // Dominant color: failed > running > ok > neutral.
+  const color =
+    c.failed > 0 ? STATUS_COLOR.failed
+    : c.running > 0 ? STATUS_COLOR.running
+    : c.ok > 0 ? STATUS_COLOR.ok
+    : NEUTRAL
+  return (
+    <div
+      style={{
+        background: `${color}11`,
+        border: `1px solid ${color}66`,
+        color: 'var(--text-primary)',
+        borderRadius: 6,
+        padding: '6px 10px',
+        fontSize: 11,
+        fontWeight: 700,
+        minWidth: 130,
+        textAlign: 'center',
+        position: 'relative',
+      }}
+      title={data.id}
+    >
+      <Handle type="target" position={Position.Top} style={{ background: color }} />
+      <div>{data.label}</div>
+      <div
+        style={{
+          fontSize: 9,
+          color,
+          marginTop: 2,
+          display: 'flex',
+          gap: 4,
+          justifyContent: 'center',
+        }}
+      >
+        {c.running > 0 && <span>{c.running}▶</span>}
+        {c.ok > 0 && <span style={{ color: STATUS_COLOR.ok }}>{c.ok}✓</span>}
+        {c.failed > 0 && <span style={{ color: STATUS_COLOR.failed }}>{c.failed}✗</span>}
+        {c.total === 0 && <span>—</span>}
+      </div>
+      <Handle type="source" position={Position.Bottom} style={{ background: color }} />
+    </div>
+  )
+}
+const WorkflowNode = memo(_WorkflowNodeInner)
+
+
+const nodeTypes = { nipype_leaf: LeafNode, nipype_workflow: WorkflowNode }
+
+
+// ── Layout ──────────────────────────────────────────────────────────────
+
+
+const NODE_WIDTH = 150
+const NODE_HEIGHT = 56
+
+
+function _layout(
+  nodes: NipypeTreeNode[],
+  edges: { id: string; source: string; target: string }[],
+): { nodes: Node[]; edges: Edge[] } {
+  const g = new dagre.graphlib.Graph()
+  g.setDefaultEdgeLabel(() => ({}))
+  g.setGraph({ rankdir: 'TB', nodesep: 18, ranksep: 36 })
+  for (const n of nodes) {
+    g.setNode(n.id, { width: NODE_WIDTH, height: NODE_HEIGHT })
+  }
+  for (const e of edges) {
+    g.setEdge(e.source, e.target)
+  }
+  dagre.layout(g)
+
+  const flowNodes: Node[] = nodes.map((n) => {
+    const pos = g.node(n.id) ?? { x: 0, y: 0 }
+    return {
+      id: n.id,
+      type: n.kind === 'leaf' ? 'nipype_leaf' : 'nipype_workflow',
+      data: { ...n, _kind: n.kind },
+      position: { x: pos.x - NODE_WIDTH / 2, y: pos.y - NODE_HEIGHT / 2 },
+    }
+  })
+  const flowEdges: Edge[] = edges.map((e) => ({
+    id: e.id,
+    source: e.source,
+    target: e.target,
+    style: { stroke: 'var(--border)' },
+  }))
+  return { nodes: flowNodes, edges: flowEdges }
+}
+
+
+// ── Modal ───────────────────────────────────────────────────────────────
+
+
+const backdrop: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.7)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 999,
+}
+
+const card: CSSProperties = {
+  width: '92vw',
+  height: '88vh',
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  borderRadius: 8,
+  display: 'flex',
+  flexDirection: 'column',
+  padding: 12,
+}
+
+const header: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  marginBottom: 8,
+}
+
+const closeBtn: CSSProperties = {
+  padding: '4px 12px',
+  fontSize: 12,
+  border: '1px solid var(--border)',
+  borderRadius: 4,
+  background: 'var(--bg-secondary)',
+  color: 'var(--text-primary)',
+  cursor: 'pointer',
+  marginLeft: 'auto',
+}
+
+
+interface Props {
+  runId: string
+  isRunning: boolean
+  onClose: () => void
+}
+
+
+export function NipypeGraphModal({ runId, isRunning, onClose }: Props) {
+  return (
+    <div style={backdrop} onClick={onClose}>
+      <div style={card} onClick={(e) => e.stopPropagation()}>
+        <ReactFlowProvider>
+          <Inner runId={runId} isRunning={isRunning} onClose={onClose} />
+        </ReactFlowProvider>
+      </div>
+    </div>
+  )
+}
+
+
+function Inner({ runId, isRunning, onClose }: Props) {
+  const [block, setBlock] = useState<NipypeStatusBlock | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const detail = await fetchPreprocRunLive(runId, 500)
+        if (!cancelled) {
+          setBlock(detail.nipype_status)
+          setError(null)
+        }
+      } catch (e) {
+        if (!cancelled) setError(String(e))
+      }
+    }
+    load()
+    if (!isRunning) return () => { cancelled = true }
+    const id = setInterval(load, 2000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [runId, isRunning])
+
+  const flow = useMemo(() => {
+    if (!block) return { nodes: [] as Node[], edges: [] as Edge[] }
+    const tree = buildNipypeTree(block.recent_nodes)
+    return _layout(tree.nodes, tree.edges)
+  }, [block])
+
+  return (
+    <>
+      <div style={header}>
+        <div style={{ fontSize: 14, fontWeight: 700 }}>nipype DAG</div>
+        <code style={{ fontSize: 11, color: 'var(--text-secondary)' }}>{runId}</code>
+        {block && (
+          <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>
+            {block.counts.running} running · {block.counts.ok} done · {block.counts.failed} failed · {block.counts.total_seen} seen
+          </span>
+        )}
+        {isRunning && (
+          <span style={{
+            fontSize: 10, color: STATUS_COLOR.running, fontWeight: 700,
+            padding: '2px 6px', borderRadius: 8,
+            background: `${STATUS_COLOR.running}22`,
+            border: `1px solid ${STATUS_COLOR.running}55`,
+          }}>
+            LIVE
+          </span>
+        )}
+        <button style={closeBtn} onClick={onClose}>Close</button>
+      </div>
+      <div style={{
+        flex: 1, minHeight: 0, border: '1px solid var(--border)',
+        borderRadius: 4, background: 'var(--bg-secondary)',
+      }}>
+        {error && (
+          <div style={{ padding: 12, color: 'var(--accent-red)', fontSize: 12 }}>
+            {error}
+          </div>
+        )}
+        {!error && flow.nodes.length === 0 && (
+          <div style={{ padding: 12, color: 'var(--text-secondary)', fontSize: 12 }}>
+            No nipype nodes parsed yet — log lines may not have arrived.
+          </div>
+        )}
+        {flow.nodes.length > 0 && (
+          <ReactFlow
+            nodes={flow.nodes}
+            edges={flow.edges}
+            nodeTypes={nodeTypes}
+            fitView
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable={true}
+          >
+            <Background />
+            <Controls />
+          </ReactFlow>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/workflow/NipypeGraphModal.tsx
+++ b/frontend/src/components/workflow/NipypeGraphModal.tsx
@@ -18,6 +18,7 @@ import dagre from 'dagre'
 import { fetchPreprocRunLive } from '../../api/client'
 import type { NipypeStatusBlock } from '../../api/types'
 import { buildNipypeTree, type NipypeTreeNode } from './nipype_tree'
+import { NodeOutputsPanel } from './NodeOutputsPanel'
 
 const STATUS_COLOR: Record<string, string> = {
   running: '#00e5ff',
@@ -234,6 +235,7 @@ export function NipypeGraphModal({ runId, isRunning, onClose }: Props) {
 function Inner({ runId, isRunning, onClose }: Props) {
   const [block, setBlock] = useState<NipypeStatusBlock | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [openNode, setOpenNode] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -283,9 +285,12 @@ function Inner({ runId, isRunning, onClose }: Props) {
         <button style={closeBtn} onClick={onClose}>Close</button>
       </div>
       <div style={{
-        flex: 1, minHeight: 0, border: '1px solid var(--border)',
+        flex: 1, minHeight: 0, display: 'flex',
+        border: '1px solid var(--border)',
         borderRadius: 4, background: 'var(--bg-secondary)',
+        overflow: 'hidden',
       }}>
+        <div style={{ flex: 1, minWidth: 0, position: 'relative' }}>
         {error && (
           <div style={{ padding: 12, color: 'var(--accent-red)', fontSize: 12 }}>
             {error}
@@ -305,10 +310,25 @@ function Inner({ runId, isRunning, onClose }: Props) {
             nodesDraggable={false}
             nodesConnectable={false}
             elementsSelectable={true}
+            onNodeClick={(_e, n) => {
+              const data = n.data as unknown as NipypeTreeNode & { _kind?: string }
+              const kind = data._kind ?? data.kind
+              if (kind === 'leaf') {
+                setOpenNode(data.full_node ?? data.id)
+              }
+            }}
           >
             <Background />
             <Controls />
           </ReactFlow>
+        )}
+        </div>
+        {openNode && (
+          <NodeOutputsPanel
+            runId={runId}
+            node={openNode}
+            onClose={() => setOpenNode(null)}
+          />
         )}
       </div>
     </>

--- a/frontend/src/components/workflow/NipypeGraphModal.tsx
+++ b/frontend/src/components/workflow/NipypeGraphModal.tsx
@@ -23,6 +23,7 @@ const STATUS_COLOR: Record<string, string> = {
   running: '#00e5ff',
   ok: '#00e676',
   failed: '#ff1744',
+  completed_assumed: '#52c98f',
 }
 const NEUTRAL = 'var(--text-secondary)'
 
@@ -69,12 +70,14 @@ const LeafNode = memo(_LeafNodeInner)
 
 function _WorkflowNodeInner({ data }: NodeProps & { data: WorkflowData }) {
   const c = data.counts ?? { running: 0, ok: 0, failed: 0, total: 0 }
-  // Dominant color: failed > running > ok > neutral.
+  // Dominant color: failed > running > ok > completed_assumed > neutral.
   const color =
     c.failed > 0 ? STATUS_COLOR.failed
     : c.running > 0 ? STATUS_COLOR.running
     : c.ok > 0 ? STATUS_COLOR.ok
-    : NEUTRAL
+    : (c as { completed_assumed?: number }).completed_assumed
+      ? STATUS_COLOR.completed_assumed
+      : NEUTRAL
   return (
     <div
       style={{
@@ -106,6 +109,12 @@ function _WorkflowNodeInner({ data }: NodeProps & { data: WorkflowData }) {
         {c.running > 0 && <span>{c.running}▶</span>}
         {c.ok > 0 && <span style={{ color: STATUS_COLOR.ok }}>{c.ok}✓</span>}
         {c.failed > 0 && <span style={{ color: STATUS_COLOR.failed }}>{c.failed}✗</span>}
+        {(() => {
+          const ca = (c as { completed_assumed?: number }).completed_assumed ?? 0
+          return ca > 0 ? (
+            <span style={{ color: STATUS_COLOR.completed_assumed }}>{ca}?</span>
+          ) : null
+        })()}
         {c.total === 0 && <span>—</span>}
       </div>
       <Handle type="source" position={Position.Bottom} style={{ background: color }} />
@@ -258,7 +267,7 @@ function Inner({ runId, isRunning, onClose }: Props) {
         <code style={{ fontSize: 11, color: 'var(--text-secondary)' }}>{runId}</code>
         {block && (
           <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>
-            {block.counts.running} running · {block.counts.ok} done · {block.counts.failed} failed · {block.counts.total_seen} seen
+            {block.counts.running} running · {block.counts.ok} done · {block.counts.failed} failed{block.counts.completed_assumed ? ` · ${block.counts.completed_assumed} assumed` : ''} · {block.counts.total_seen} seen
           </span>
         )}
         {isRunning && (

--- a/frontend/src/components/workflow/NipypeGraphModal.tsx
+++ b/frontend/src/components/workflow/NipypeGraphModal.tsx
@@ -17,7 +17,8 @@ import {
 import dagre from 'dagre'
 
 import { fetchPreprocRunLive } from '../../api/client'
-import type { NipypeStatusBlock } from '../../api/types'
+import { fetchWorkTree } from '../../api/node-outputs'
+import type { NipypeNodeStatus, NipypeStatusBlock } from '../../api/types'
 import { buildNipypeTree, type NipypeTreeNode } from './nipype_tree'
 import { NodeOutputsPanel } from './NodeOutputsPanel'
 import { NodeListPanel } from './NodeListPanel'
@@ -27,6 +28,7 @@ const STATUS_COLOR: Record<string, string> = {
   ok: '#00e676',
   failed: '#ff1744',
   completed_assumed: '#52c98f',
+  cached: '#888',
 }
 const NEUTRAL = 'var(--text-secondary)'
 
@@ -72,15 +74,15 @@ const LeafNode = memo(_LeafNodeInner)
 
 
 function _WorkflowNodeInner({ data }: NodeProps & { data: WorkflowData }) {
-  const c = data.counts ?? { running: 0, ok: 0, failed: 0, total: 0 }
-  // Dominant color: failed > running > ok > completed_assumed > neutral.
+  const c = data.counts ?? { running: 0, ok: 0, failed: 0, completed_assumed: 0, cached: 0, total: 0 }
+  // Dominant color: failed > running > ok > completed_assumed > cached > neutral.
   const color =
     c.failed > 0 ? STATUS_COLOR.failed
     : c.running > 0 ? STATUS_COLOR.running
     : c.ok > 0 ? STATUS_COLOR.ok
-    : (c as { completed_assumed?: number }).completed_assumed
-      ? STATUS_COLOR.completed_assumed
-      : NEUTRAL
+    : c.completed_assumed > 0 ? STATUS_COLOR.completed_assumed
+    : c.cached > 0 ? STATUS_COLOR.cached
+    : NEUTRAL
   return (
     <div
       style={{
@@ -112,12 +114,12 @@ function _WorkflowNodeInner({ data }: NodeProps & { data: WorkflowData }) {
         {c.running > 0 && <span>{c.running}▶</span>}
         {c.ok > 0 && <span style={{ color: STATUS_COLOR.ok }}>{c.ok}✓</span>}
         {c.failed > 0 && <span style={{ color: STATUS_COLOR.failed }}>{c.failed}✗</span>}
-        {(() => {
-          const ca = (c as { completed_assumed?: number }).completed_assumed ?? 0
-          return ca > 0 ? (
-            <span style={{ color: STATUS_COLOR.completed_assumed }}>{ca}?</span>
-          ) : null
-        })()}
+        {c.completed_assumed > 0 && (
+          <span style={{ color: STATUS_COLOR.completed_assumed }}>{c.completed_assumed}?</span>
+        )}
+        {c.cached > 0 && (
+          <span style={{ color: STATUS_COLOR.cached }}>{c.cached}◌</span>
+        )}
         {c.total === 0 && <span>—</span>}
       </div>
       <Handle type="source" position={Position.Bottom} style={{ background: color }} />
@@ -236,6 +238,7 @@ export function NipypeGraphModal({ runId, isRunning, onClose }: Props) {
 
 function Inner({ runId, isRunning, onClose }: Props) {
   const [block, setBlock] = useState<NipypeStatusBlock | null>(null)
+  const [cachedLeaves, setCachedLeaves] = useState<string[]>([])
   const [error, setError] = useState<string | null>(null)
   const [openNode, setOpenNode] = useState<string | null>(null)
   const rf = useReactFlow()
@@ -278,11 +281,43 @@ function Inner({ runId, isRunning, onClose }: Props) {
     return () => { cancelled = true; clearInterval(id) }
   }, [runId, isRunning])
 
+  // One-shot work_dir walk so cached nodes (no events emitted) still
+  // show up in the tree.
+  useEffect(() => {
+    let cancelled = false
+    fetchWorkTree(runId)
+      .then((t) => { if (!cancelled) setCachedLeaves(t.leaves) })
+      .catch(() => { /* non-fatal */ })
+    return () => { cancelled = true }
+  }, [runId])
+
+  const mergedNodes = useMemo<NipypeNodeStatus[]>(() => {
+    const live = block?.recent_nodes ?? []
+    const seen = new Set(live.map((n) => n.node))
+    const synthetic: NipypeNodeStatus[] = []
+    for (const path of cachedLeaves) {
+      if (seen.has(path)) continue
+      const segs = path.split('.')
+      synthetic.push({
+        node: path,
+        leaf: segs[segs.length - 1] ?? path,
+        workflow: segs.slice(0, -1).join('.'),
+        status: 'cached',
+        started_at: 0,
+        finished_at: 0,
+        elapsed: 0,
+        crash_file: null,
+        level: 'INFO',
+      })
+    }
+    return [...live, ...synthetic]
+  }, [block, cachedLeaves])
+
   const flow = useMemo(() => {
-    if (!block) return { nodes: [] as Node[], edges: [] as Edge[] }
-    const tree = buildNipypeTree(block.recent_nodes)
+    if (mergedNodes.length === 0) return { nodes: [] as Node[], edges: [] as Edge[] }
+    const tree = buildNipypeTree(mergedNodes)
     return _layout(tree.nodes, tree.edges)
-  }, [block])
+  }, [mergedNodes])
 
   return (
     <>
@@ -313,7 +348,7 @@ function Inner({ runId, isRunning, onClose }: Props) {
         overflow: 'hidden',
       }}>
         <NodeListPanel
-          nodes={block?.recent_nodes ?? []}
+          nodes={mergedNodes}
           selected={openNode}
           onSelect={setOpenNode}
         />

--- a/frontend/src/components/workflow/NipypeGraphModal.tsx
+++ b/frontend/src/components/workflow/NipypeGraphModal.tsx
@@ -9,6 +9,7 @@ import {
   Controls,
   Position,
   Handle,
+  useReactFlow,
   type Node,
   type Edge,
   type NodeProps,
@@ -237,6 +238,26 @@ function Inner({ runId, isRunning, onClose }: Props) {
   const [block, setBlock] = useState<NipypeStatusBlock | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [openNode, setOpenNode] = useState<string | null>(null)
+  const rf = useReactFlow()
+
+  // Whenever the user picks a node (via list or graph click), pan + zoom
+  // the canvas to centre that node. fitView with a single-node selector
+  // does both at once and animates smoothly.
+  useEffect(() => {
+    if (!openNode) return
+    // Defer one tick so the layout has the node by the time we pan.
+    const t = setTimeout(() => {
+      try {
+        rf.fitView({
+          nodes: [{ id: openNode }],
+          duration: 400,
+          padding: 0.4,
+          maxZoom: 1.5,
+        })
+      } catch { /* node not in graph yet — ignore */ }
+    }, 50)
+    return () => clearTimeout(t)
+  }, [openNode, rf])
 
   useEffect(() => {
     let cancelled = false

--- a/frontend/src/components/workflow/NodeListPanel.tsx
+++ b/frontend/src/components/workflow/NodeListPanel.tsx
@@ -1,7 +1,10 @@
-/** Collapsible, searchable list of nipype nodes for the DAG modal.
+/** Collapsible, searchable, hierarchical list of nipype nodes.
  *
- * Sits on the left edge of the DAG modal. Click a row → opens the
- * outputs drawer (same callback the graph uses on leaf clicks).
+ * The dotted nipype paths form a workflow tree
+ * (`fmriprep_wf.sub_AN_wf.anat_fit_wf.surface_recon_wf.autorecon1`).
+ * We render that tree as nested rows: workflow headers with rolled-up
+ * counts, expandable to reveal their children. Click a leaf → opens
+ * the outputs drawer (same callback the graph uses).
  */
 
 import { useMemo, useState } from 'react'
@@ -10,12 +13,14 @@ import type {
   NipypeNodeStatus,
   NipypeNodeStatusKind,
 } from '../../api/types'
+import { buildNipypeTree, type NipypeTreeNode } from './nipype_tree'
 
 const STATUS_COLOR: Record<string, string> = {
   running: '#00e5ff',
   ok: '#00e676',
   failed: '#ff1744',
   completed_assumed: '#52c98f',
+  cached: '#888',
 }
 
 
@@ -33,8 +38,8 @@ const collapsedRail: CSSProperties = {
 }
 
 const panel: CSSProperties = {
-  width: 260,
-  minWidth: 260,
+  width: 280,
+  minWidth: 280,
   borderRight: '1px solid var(--border)',
   background: 'var(--bg-secondary)',
   display: 'flex',
@@ -53,7 +58,6 @@ const panelHeader: CSSProperties = {
 }
 
 const searchInput: CSSProperties = {
-  width: 'calc(100% - 16px)',
   padding: '4px 8px',
   fontSize: 11,
   border: '1px solid var(--border)',
@@ -85,20 +89,31 @@ const filterChip = (active: boolean, color: string): CSSProperties => ({
   fontWeight: 700,
 })
 
-const list: CSSProperties = {
+const listScroll: CSSProperties = {
   flex: 1,
   overflowY: 'auto',
 }
 
-const row = (active: boolean): CSSProperties => ({
+const leafRow = (active: boolean, depth: number): CSSProperties => ({
   display: 'flex',
   alignItems: 'center',
   gap: 6,
-  padding: '4px 8px',
+  padding: `3px 8px 3px ${8 + depth * 12}px`,
   borderBottom: '1px solid var(--border)',
   cursor: 'pointer',
   background: active ? 'rgba(0, 229, 255, 0.08)' : 'transparent',
   borderLeft: active ? '3px solid var(--accent-cyan)' : '3px solid transparent',
+})
+
+const wfRow = (depth: number): CSSProperties => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  padding: `3px 8px 3px ${4 + depth * 12}px`,
+  borderBottom: '1px solid var(--border)',
+  cursor: 'pointer',
+  background: 'rgba(255,255,255,0.02)',
+  fontWeight: 700,
 })
 
 const dot = (color: string): CSSProperties => ({
@@ -127,6 +142,7 @@ const FILTERS: { value: FilterStatus; label: string }[] = [
   { value: 'ok', label: 'Ok' },
   { value: 'failed', label: 'Fail' },
   { value: 'completed_assumed', label: '?' },
+  { value: 'cached', label: 'Cached' },
 ]
 
 
@@ -137,28 +153,166 @@ interface Props {
 }
 
 
+function _wfColor(c: NonNullable<NipypeTreeNode['counts']>): string {
+  if (c.failed > 0) return STATUS_COLOR.failed
+  if (c.running > 0) return STATUS_COLOR.running
+  if (c.ok > 0) return STATUS_COLOR.ok
+  if (c.completed_assumed > 0) return STATUS_COLOR.completed_assumed
+  if (c.cached > 0) return STATUS_COLOR.cached
+  return 'var(--text-secondary)'
+}
+
+
 export function NodeListPanel({ nodes, selected, onSelect }: Props) {
   const [collapsed, setCollapsed] = useState(false)
   const [query, setQuery] = useState('')
   const [filter, setFilter] = useState<FilterStatus>('all')
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
 
   const counts = useMemo(() => {
     const c: Record<string, number> = {
       all: nodes.length,
-      running: 0, ok: 0, failed: 0, completed_assumed: 0,
+      running: 0, ok: 0, failed: 0, completed_assumed: 0, cached: 0,
     }
     for (const n of nodes) c[n.status] = (c[n.status] ?? 0) + 1
     return c
   }, [nodes])
 
-  const filtered = useMemo(() => {
+  // Build the workflow tree from the same dotted paths the DAG uses.
+  // Then filter leaves by status + search; keep ancestors of any
+  // surviving leaf so the hierarchy is preserved.
+  const { byParent, kept } = useMemo(() => {
+    const tree = buildNipypeTree(nodes)
+    const byId = new Map(tree.nodes.map((n) => [n.id, n]))
+    const byParent = new Map<string | null, NipypeTreeNode[]>()
+    for (const n of tree.nodes) {
+      const list = byParent.get(n.parentId) ?? []
+      list.push(n)
+      byParent.set(n.parentId, list)
+    }
+    // Sort: workflows first, then leaves; alpha within each.
+    for (const list of byParent.values()) {
+      list.sort((a, b) => {
+        if (a.kind !== b.kind) return a.kind === 'workflow' ? -1 : 1
+        return a.label.localeCompare(b.label)
+      })
+    }
+
     const q = query.trim().toLowerCase()
-    return nodes.filter((n) => {
-      if (filter !== 'all' && n.status !== filter) return false
+    const matches = (leaf: NipypeTreeNode): boolean => {
+      if (leaf.kind !== 'leaf') return false
+      if (filter !== 'all' && leaf.status !== filter) return false
       if (!q) return true
-      return n.node.toLowerCase().includes(q) || n.leaf.toLowerCase().includes(q)
-    })
+      return leaf.id.toLowerCase().includes(q)
+        || leaf.label.toLowerCase().includes(q)
+    }
+    const kept = new Set<string>()
+    for (const n of tree.nodes) {
+      if (matches(n)) {
+        let cur: NipypeTreeNode | undefined = n
+        while (cur) {
+          if (kept.has(cur.id)) break
+          kept.add(cur.id)
+          cur = cur.parentId ? byId.get(cur.parentId) : undefined
+        }
+      }
+    }
+    return { byParent, kept }
   }, [nodes, query, filter])
+
+  // When searching/filtering, auto-expand surviving workflows so
+  // matches are visible without clicking through.
+  const isSearching = query.trim() !== '' || filter !== 'all'
+
+  function isOpen(id: string): boolean {
+    // User toggle (if any) always wins, so collapse/expand keeps
+    // working during search. Default: open while searching (so hits
+    // are visible), collapsed by default otherwise so the user sees
+    // the top-level workflows first.
+    if (id in expanded) return expanded[id]
+    if (isSearching) return kept.has(id)
+    return false
+  }
+
+  function toggle(id: string) {
+    setExpanded((prev) => ({
+      ...prev,
+      [id]: !isOpen(id),
+    }))
+  }
+
+  function renderChildren(parentId: string | null, depth: number): React.ReactNode {
+    const children = byParent.get(parentId) ?? []
+    return children.map((n) => {
+      if (!kept.has(n.id) && isSearching) return null
+      if (n.kind === 'workflow') {
+        const open = isOpen(n.id)
+        const c = n.counts ?? {
+          running: 0, ok: 0, failed: 0, completed_assumed: 0, cached: 0, total: 0,
+        }
+        const color = _wfColor(c)
+        return (
+          <div key={n.id}>
+            <div
+              style={wfRow(depth)}
+              onClick={() => toggle(n.id)}
+              title={n.id}
+            >
+              <span style={{ width: 10, fontSize: 9, color: 'var(--text-secondary)' }}>
+                {open ? '▼' : '▶'}
+              </span>
+              <span style={dot(color)} />
+              <span style={{
+                fontSize: 11, flex: 1, overflow: 'hidden',
+                textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}>
+                {n.label}
+              </span>
+              <span style={{
+                fontSize: 9, color: 'var(--text-secondary)', fontWeight: 400,
+              }}>
+                {c.running > 0 && <span style={{ color: STATUS_COLOR.running }}>{c.running}▶ </span>}
+                {c.ok > 0 && <span style={{ color: STATUS_COLOR.ok }}>{c.ok}✓ </span>}
+                {c.failed > 0 && <span style={{ color: STATUS_COLOR.failed }}>{c.failed}✗ </span>}
+                {c.completed_assumed > 0 && (
+                  <span style={{ color: STATUS_COLOR.completed_assumed }}>{c.completed_assumed}? </span>
+                )}
+                {c.cached > 0 && (
+                  <span style={{ color: STATUS_COLOR.cached }}>{c.cached}◌ </span>
+                )}
+                {c.total === 0 && <span>—</span>}
+              </span>
+            </div>
+            {open && renderChildren(n.id, depth + 1)}
+          </div>
+        )
+      }
+      // Leaf
+      const color = STATUS_COLOR[n.status ?? ''] ?? 'var(--text-secondary)'
+      const active = selected === n.id
+      return (
+        <div
+          key={n.id}
+          style={leafRow(active, depth)}
+          onClick={() => onSelect(n.full_node ?? n.id)}
+          title={n.id}
+        >
+          <span style={dot(color)} />
+          <span style={{
+            fontSize: 11, fontWeight: 600, flex: 1,
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>
+            {n.label}
+          </span>
+          {n.elapsed !== undefined && n.elapsed > 0 && (
+            <span style={{ fontSize: 9, color: 'var(--text-secondary)' }}>
+              {n.elapsed.toFixed(1)}s
+            </span>
+          )}
+        </div>
+      )
+    })
+  }
 
   if (collapsed) {
     return (
@@ -174,6 +328,9 @@ export function NodeListPanel({ nodes, selected, onSelect }: Props) {
       </div>
     )
   }
+
+  const roots = byParent.get(null) ?? []
+  const anyVisible = roots.some((n) => !isSearching || kept.has(n.id))
 
   return (
     <div style={panel}>
@@ -211,36 +368,15 @@ export function NodeListPanel({ nodes, selected, onSelect }: Props) {
           )
         })}
       </div>
-      <div style={list}>
-        {filtered.length === 0 && (
+      <div style={listScroll}>
+        {!anyVisible && (
           <div style={{
             padding: 10, fontSize: 11, color: 'var(--text-secondary)',
           }}>
             No matches.
           </div>
         )}
-        {filtered.map((n) => {
-          const color = STATUS_COLOR[n.status] ?? 'var(--text-secondary)'
-          const active = selected === n.node
-          return (
-            <div
-              key={n.node}
-              style={row(active)}
-              onClick={() => onSelect(n.node)}
-              title={n.node}
-            >
-              <span style={dot(color)} />
-              <span style={{ fontSize: 11, fontWeight: 600, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {n.leaf}
-              </span>
-              {n.elapsed > 0 && (
-                <span style={{ fontSize: 9, color: 'var(--text-secondary)' }}>
-                  {n.elapsed.toFixed(1)}s
-                </span>
-              )}
-            </div>
-          )
-        })}
+        {renderChildren(null, 0)}
       </div>
     </div>
   )

--- a/frontend/src/components/workflow/NodeListPanel.tsx
+++ b/frontend/src/components/workflow/NodeListPanel.tsx
@@ -1,0 +1,247 @@
+/** Collapsible, searchable list of nipype nodes for the DAG modal.
+ *
+ * Sits on the left edge of the DAG modal. Click a row → opens the
+ * outputs drawer (same callback the graph uses on leaf clicks).
+ */
+
+import { useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+import type {
+  NipypeNodeStatus,
+  NipypeNodeStatusKind,
+} from '../../api/types'
+
+const STATUS_COLOR: Record<string, string> = {
+  running: '#00e5ff',
+  ok: '#00e676',
+  failed: '#ff1744',
+  completed_assumed: '#52c98f',
+}
+
+
+// ── styles ──────────────────────────────────────────────────────────────
+
+
+const collapsedRail: CSSProperties = {
+  width: 24,
+  borderRight: '1px solid var(--border)',
+  background: 'var(--bg-secondary)',
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+  paddingTop: 6,
+}
+
+const panel: CSSProperties = {
+  width: 260,
+  minWidth: 260,
+  borderRight: '1px solid var(--border)',
+  background: 'var(--bg-secondary)',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+}
+
+const panelHeader: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '6px 8px',
+  borderBottom: '1px solid var(--border)',
+  fontSize: 11,
+  fontWeight: 700,
+}
+
+const searchInput: CSSProperties = {
+  width: 'calc(100% - 16px)',
+  padding: '4px 8px',
+  fontSize: 11,
+  border: '1px solid var(--border)',
+  borderRadius: 3,
+  background: 'var(--bg-card)',
+  color: 'var(--text-primary)',
+  fontFamily: 'inherit',
+  margin: '6px 8px',
+  boxSizing: 'border-box',
+}
+
+const filterRow: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 3,
+  padding: '0 8px 6px 8px',
+}
+
+const filterChip = (active: boolean, color: string): CSSProperties => ({
+  fontSize: 9,
+  padding: '1px 5px',
+  borderRadius: 8,
+  background: active ? `${color}33` : 'transparent',
+  color: active ? color : 'var(--text-secondary)',
+  border: `1px solid ${color}66`,
+  cursor: 'pointer',
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+  fontWeight: 700,
+})
+
+const list: CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+}
+
+const row = (active: boolean): CSSProperties => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '4px 8px',
+  borderBottom: '1px solid var(--border)',
+  cursor: 'pointer',
+  background: active ? 'rgba(0, 229, 255, 0.08)' : 'transparent',
+  borderLeft: active ? '3px solid var(--accent-cyan)' : '3px solid transparent',
+})
+
+const dot = (color: string): CSSProperties => ({
+  width: 7, height: 7, borderRadius: '50%', backgroundColor: color, flexShrink: 0,
+})
+
+const toggleBtn: CSSProperties = {
+  padding: '2px 6px',
+  fontSize: 11,
+  border: '1px solid var(--border)',
+  borderRadius: 3,
+  background: 'var(--bg-card)',
+  color: 'var(--text-primary)',
+  cursor: 'pointer',
+}
+
+
+// ── component ───────────────────────────────────────────────────────────
+
+
+type FilterStatus = NipypeNodeStatusKind | 'all'
+
+const FILTERS: { value: FilterStatus; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'running', label: 'Run' },
+  { value: 'ok', label: 'Ok' },
+  { value: 'failed', label: 'Fail' },
+  { value: 'completed_assumed', label: '?' },
+]
+
+
+interface Props {
+  nodes: NipypeNodeStatus[]
+  selected: string | null
+  onSelect: (node: string) => void
+}
+
+
+export function NodeListPanel({ nodes, selected, onSelect }: Props) {
+  const [collapsed, setCollapsed] = useState(false)
+  const [query, setQuery] = useState('')
+  const [filter, setFilter] = useState<FilterStatus>('all')
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = {
+      all: nodes.length,
+      running: 0, ok: 0, failed: 0, completed_assumed: 0,
+    }
+    for (const n of nodes) c[n.status] = (c[n.status] ?? 0) + 1
+    return c
+  }, [nodes])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return nodes.filter((n) => {
+      if (filter !== 'all' && n.status !== filter) return false
+      if (!q) return true
+      return n.node.toLowerCase().includes(q) || n.leaf.toLowerCase().includes(q)
+    })
+  }, [nodes, query, filter])
+
+  if (collapsed) {
+    return (
+      <div style={collapsedRail}>
+        <button
+          style={toggleBtn}
+          onClick={() => setCollapsed(false)}
+          title="Show node list"
+          aria-label="Show node list"
+        >
+          ☰
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div style={panel}>
+      <div style={panelHeader}>
+        <span>Nodes ({nodes.length})</span>
+        <span style={{ flex: 1 }} />
+        <button
+          style={toggleBtn}
+          onClick={() => setCollapsed(true)}
+          title="Collapse node list"
+          aria-label="Collapse node list"
+        >
+          ←
+        </button>
+      </div>
+      <input
+        style={searchInput}
+        placeholder="Search by leaf or path…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <div style={filterRow}>
+        {FILTERS.map((f) => {
+          const color = f.value === 'all'
+            ? 'var(--text-secondary)'
+            : STATUS_COLOR[f.value as keyof typeof STATUS_COLOR]
+          return (
+            <button
+              key={f.value}
+              style={filterChip(filter === f.value, color)}
+              onClick={() => setFilter(f.value)}
+            >
+              {f.label} {counts[f.value] ?? 0}
+            </button>
+          )
+        })}
+      </div>
+      <div style={list}>
+        {filtered.length === 0 && (
+          <div style={{
+            padding: 10, fontSize: 11, color: 'var(--text-secondary)',
+          }}>
+            No matches.
+          </div>
+        )}
+        {filtered.map((n) => {
+          const color = STATUS_COLOR[n.status] ?? 'var(--text-secondary)'
+          const active = selected === n.node
+          return (
+            <div
+              key={n.node}
+              style={row(active)}
+              onClick={() => onSelect(n.node)}
+              title={n.node}
+            >
+              <span style={dot(color)} />
+              <span style={{ fontSize: 11, fontWeight: 600, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {n.leaf}
+              </span>
+              {n.elapsed > 0 && (
+                <span style={{ fontSize: 9, color: 'var(--text-secondary)' }}>
+                  {n.elapsed.toFixed(1)}s
+                </span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/workflow/NodeOutputsPanel.tsx
+++ b/frontend/src/components/workflow/NodeOutputsPanel.tsx
@@ -1,0 +1,389 @@
+/** Drawer inside the DAG modal: shows files in a node's work_dir.
+ *
+ * Renders each file based on its kind:
+ *   - `view`    inline  (NIfTI → niivue, JSON / TSV / text → <pre>)
+ *   - `pickle`  decoded JSON via /pickle endpoint
+ *   - `link`    "Copy path" + a tool hint
+ *
+ * Crash files are surfaced inline as `<pre>` snippets fetched from the
+ * generic file endpoint (we whitelist .txt).
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
+import { Niivue } from '@niivue/niivue'
+
+import {
+  fetchNodeOutputs,
+  fetchNodePickle,
+  nodeFileUrl,
+} from '../../api/node-outputs'
+import type {
+  NodeOutputFile,
+  NodeOutputsList,
+  NodePickleResponse,
+} from '../../api/types'
+
+const NIFTI_SUFFIXES = new Set(['.nii', '.gz', '.mgz'])
+const TEXTY_SUFFIXES = new Set([
+  '.json', '.tsv', '.csv', '.txt', '.log', '.cfg', '.rst', '.dat',
+])
+const IMAGE_SUFFIXES = new Set(['.svg', '.png', '.jpg', '.jpeg', '.gif'])
+const HTML_SUFFIXES = new Set(['.html', '.htm'])
+
+
+// ── styles ──────────────────────────────────────────────────────────────
+
+
+const drawer: CSSProperties = {
+  width: '40%',
+  minWidth: 360,
+  maxWidth: 560,
+  borderLeft: '1px solid var(--border)',
+  background: 'var(--bg-card)',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+}
+
+const drawerHeader: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 10px',
+  borderBottom: '1px solid var(--border)',
+  background: 'var(--bg-secondary)',
+}
+
+const closeBtn: CSSProperties = {
+  marginLeft: 'auto',
+  padding: '2px 8px',
+  fontSize: 11,
+  border: '1px solid var(--border)',
+  borderRadius: 4,
+  background: 'var(--bg-secondary)',
+  color: 'var(--text-primary)',
+  cursor: 'pointer',
+}
+
+const filesList: CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+  padding: '8px 10px',
+}
+
+const fileCard: CSSProperties = {
+  border: '1px solid var(--border)',
+  borderRadius: 4,
+  marginBottom: 8,
+  overflow: 'hidden',
+  background: 'var(--bg-secondary)',
+}
+
+const fileHeader: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '6px 10px',
+  fontSize: 11,
+  fontWeight: 600,
+  cursor: 'pointer',
+  userSelect: 'none',
+}
+
+const fileBody: CSSProperties = {
+  padding: 8,
+  borderTop: '1px solid var(--border)',
+  background: 'var(--bg-card)',
+  fontSize: 11,
+  maxHeight: 480,
+  overflow: 'auto',
+}
+
+const preStyle: CSSProperties = {
+  margin: 0,
+  fontFamily: '"JetBrains Mono", monospace',
+  fontSize: 11,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+}
+
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+
+function _humanSize(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`
+  return `${(n / 1024 / 1024 / 1024).toFixed(1)} GB`
+}
+
+
+function _isNifti(suffix: string, name: string): boolean {
+  if (suffix === '.nii' || suffix === '.mgz') return true
+  // .gz alone — only count as NIfTI if .nii.gz
+  return suffix === '.gz' && name.toLowerCase().endsWith('.nii.gz')
+}
+
+
+// ── individual file renderers ───────────────────────────────────────────
+
+
+function NiivueFile(
+  { url, name }: { url: string; name: string },
+) {
+  const ref = useRef<HTMLCanvasElement | null>(null)
+  useEffect(() => {
+    if (!ref.current) return
+    const nv = new Niivue({ backColor: [0, 0, 0, 1] })
+    nv.attachToCanvas(ref.current)
+    nv.loadVolumes([{ url, name }]).catch((e) =>
+      console.warn('niivue load failed', e),
+    )
+  }, [url, name])
+  return (
+    <div style={{ height: 320, background: '#000' }}>
+      <canvas ref={ref} style={{ width: '100%', height: '100%' }} />
+    </div>
+  )
+}
+
+
+function TextyFile({ url, name }: { url: string; name: string }) {
+  const [body, setBody] = useState<string>('')
+  const [error, setError] = useState<string | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    fetch(url)
+      .then((r) => r.text())
+      .then((t) => { if (!cancelled) setBody(t) })
+      .catch((e) => { if (!cancelled) setError(String(e)) })
+    return () => { cancelled = true }
+  }, [url])
+  if (error) {
+    return <div style={{ color: 'var(--accent-red)' }}>{error}</div>
+  }
+  // Pretty-print JSON.
+  let display = body
+  if (name.toLowerCase().endsWith('.json')) {
+    try {
+      display = JSON.stringify(JSON.parse(body), null, 2)
+    } catch {
+      /* leave raw */
+    }
+  }
+  return <pre style={preStyle}>{display}</pre>
+}
+
+
+function PickleFile(
+  { runId, node, rel }: { runId: string; node: string; rel: string },
+) {
+  const [data, setData] = useState<NodePickleResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    fetchNodePickle(runId, node, rel)
+      .then((r) => { if (!cancelled) setData(r) })
+      .catch((e) => { if (!cancelled) setError(String(e)) })
+    return () => { cancelled = true }
+  }, [runId, node, rel])
+  if (error) return <div style={{ color: 'var(--accent-red)' }}>{error}</div>
+  if (!data) return <div style={{ color: 'var(--text-secondary)' }}>loading…</div>
+  if (data.error) {
+    return (
+      <div>
+        <div style={{ color: 'var(--accent-yellow)', marginBottom: 6 }}>
+          Could not decode pickle: {data.error}
+        </div>
+        <div style={{ color: 'var(--text-secondary)', fontSize: 10 }}>
+          fmriprep's `result_*.pklz` files often reference paths
+          inside the singularity container that don't exist on the
+          host — that's fine, the file is still on disk.
+        </div>
+      </div>
+    )
+  }
+  return (
+    <pre style={preStyle}>
+      {JSON.stringify(data.value, null, 2)}
+    </pre>
+  )
+}
+
+
+function LinkFile({ path }: { path: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <code style={{ fontSize: 10, flex: 1, wordBreak: 'break-all' }}>{path}</code>
+      <button
+        style={{
+          ...closeBtn,
+          marginLeft: 0,
+        }}
+        onClick={() => {
+          navigator.clipboard.writeText(path)
+            .then(() => { setCopied(true); setTimeout(() => setCopied(false), 1500) })
+            .catch(() => { /* ignore */ })
+        }}
+      >
+        {copied ? 'Copied!' : 'Copy path'}
+      </button>
+    </div>
+  )
+}
+
+
+// ── main panel ──────────────────────────────────────────────────────────
+
+
+function _bestRenderer(
+  file: NodeOutputFile,
+  url: string,
+  fullPath: string,
+  runId: string,
+  node: string,
+): React.ReactNode {
+  if (_isNifti(file.suffix, file.name)) {
+    return <NiivueFile url={url} name={file.name} />
+  }
+  if (TEXTY_SUFFIXES.has(file.suffix)) {
+    return <TextyFile url={url} name={file.name} />
+  }
+  if (IMAGE_SUFFIXES.has(file.suffix)) {
+    return (
+      <img src={url} alt={file.name}
+           style={{ maxWidth: '100%', display: 'block' }} />
+    )
+  }
+  if (HTML_SUFFIXES.has(file.suffix)) {
+    return (
+      <iframe src={url} title={file.name}
+              style={{ width: '100%', height: 360, border: 'none' }} />
+    )
+  }
+  if (file.kind === 'pickle') {
+    return <PickleFile runId={runId} node={node} rel={file.rel} />
+  }
+  return <LinkFile path={fullPath} />
+}
+
+
+interface Props {
+  runId: string
+  node: string | null
+  leafDir?: string
+  onClose: () => void
+}
+
+
+export function NodeOutputsPanel({ runId, node, onClose }: Props) {
+  const [data, setData] = useState<NodeOutputsList | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [openFile, setOpenFile] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!node) return
+    let cancelled = false
+    setData(null)
+    setError(null)
+    setOpenFile(null)
+    fetchNodeOutputs(runId, node)
+      .then((d) => { if (!cancelled) setData(d) })
+      .catch((e) => { if (!cancelled) setError(String(e)) })
+    return () => { cancelled = true }
+  }, [runId, node])
+
+  const files = useMemo(() => data?.files ?? [], [data])
+  const crashes = useMemo(() => data?.crashes ?? [], [data])
+
+  if (!node) return null
+
+  return (
+    <div style={drawer}>
+      <div style={drawerHeader}>
+        <div style={{ fontSize: 12, fontWeight: 700 }}>{node.split('.').pop()}</div>
+        <code style={{ fontSize: 9, color: 'var(--text-secondary)' }}>
+          {node}
+        </code>
+        <button style={closeBtn} onClick={onClose}>Close</button>
+      </div>
+
+      {error && (
+        <div style={{ padding: 10, color: 'var(--accent-red)', fontSize: 11 }}>
+          {error}
+        </div>
+      )}
+
+      {data && !data.exists && (
+        <div style={{ padding: 10, color: 'var(--text-secondary)', fontSize: 11 }}>
+          No work_dir on disk for this node ({data.leaf_dir}).
+          fmriprep may have cached this step from a prior run, or
+          the work tree was deleted.
+        </div>
+      )}
+
+      {data && data.exists && files.length === 0 && crashes.length === 0 && (
+        <div style={{ padding: 10, color: 'var(--text-secondary)', fontSize: 11 }}>
+          The work_dir exists but no whitelisted files were found.
+        </div>
+      )}
+
+      <div style={filesList}>
+        {crashes.length > 0 && (
+          <div style={{ marginBottom: 8 }}>
+            <div style={{
+              fontSize: 10, color: 'var(--accent-red)', fontWeight: 700,
+              textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 6,
+            }}>
+              Crashes ({crashes.length})
+            </div>
+            {crashes.map((c) => (
+              <div key={c.path} style={fileCard}>
+                <div style={{ ...fileHeader, color: 'var(--accent-red)' }}>
+                  {c.name}
+                  <span style={{
+                    flex: 1, color: 'var(--text-secondary)', fontWeight: 400,
+                  }}>
+                    {' '}{_humanSize(c.size)}
+                  </span>
+                </div>
+                <div style={fileBody}>
+                  <LinkFile path={c.path} />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {files.map((f) => {
+          const url = nodeFileUrl(runId, node, f.rel)
+          const fullPath = `${data?.leaf_dir ?? ''}/${f.rel}`
+          const isOpen = openFile === f.rel
+          return (
+            <div key={f.rel} style={fileCard}>
+              <div
+                style={fileHeader}
+                onClick={() => setOpenFile(isOpen ? null : f.rel)}
+              >
+                <span>{isOpen ? '▼' : '▶'}</span>
+                <span>{f.name}</span>
+                <span style={{ flex: 1 }} />
+                <span style={{ color: 'var(--text-secondary)', fontWeight: 400 }}>
+                  {f.suffix} · {_humanSize(f.size)} · {f.kind}
+                </span>
+              </div>
+              {isOpen && (
+                <div style={fileBody}>
+                  {_bestRenderer(f, url, fullPath, runId, node)}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/workflow/NodeOutputsPanel.tsx
+++ b/frontend/src/components/workflow/NodeOutputsPanel.tsx
@@ -304,11 +304,23 @@ export function NodeOutputsPanel({ runId, node, onClose }: Props) {
   return (
     <div style={drawer}>
       <div style={drawerHeader}>
+        <button
+          style={{
+            ...closeBtn,
+            marginLeft: 0,
+            padding: '2px 8px',
+            fontWeight: 700,
+          }}
+          onClick={onClose}
+          title="Hide outputs panel (DAG stays open)"
+          aria-label="Hide outputs panel"
+        >
+          →
+        </button>
         <div style={{ fontSize: 12, fontWeight: 700 }}>{node.split('.').pop()}</div>
         <code style={{ fontSize: 9, color: 'var(--text-secondary)' }}>
           {node}
         </code>
-        <button style={closeBtn} onClick={onClose}>Close</button>
       </div>
 
       {error && (

--- a/frontend/src/components/workflow/StructuralQCModal.tsx
+++ b/frontend/src/components/workflow/StructuralQCModal.tsx
@@ -1,0 +1,74 @@
+/** Full-screen modal wrapping the StructuralQCPanel for a given subject.
+ *
+ * Used from the Workflows view: when a workflow's preproc stage is
+ * `done`, the user clicks "Structural QC" on the Preproc block and
+ * this modal opens with the same panel that lives under the
+ * Preproc-manager manifest detail view.
+ */
+
+import type { CSSProperties } from 'react'
+import { StructuralQCPanel } from '../preproc/StructuralQCPanel'
+
+const backdrop: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.7)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 999,
+}
+
+const card: CSSProperties = {
+  width: '92vw',
+  maxHeight: '92vh',
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  borderRadius: 8,
+  display: 'flex',
+  flexDirection: 'column',
+  padding: 12,
+  overflowY: 'auto',
+}
+
+const header: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  marginBottom: 8,
+}
+
+const closeBtn: CSSProperties = {
+  padding: '4px 12px',
+  fontSize: 12,
+  border: '1px solid var(--border)',
+  borderRadius: 4,
+  background: 'var(--bg-secondary)',
+  color: 'var(--text-primary)',
+  cursor: 'pointer',
+  marginLeft: 'auto',
+}
+
+
+interface Props {
+  subject: string
+  onClose: () => void
+}
+
+
+export function StructuralQCModal({ subject, onClose }: Props) {
+  return (
+    <div style={backdrop} onClick={onClose}>
+      <div style={card} onClick={(e) => e.stopPropagation()}>
+        <div style={header}>
+          <div style={{ fontSize: 14, fontWeight: 700 }}>Structural QC</div>
+          <code style={{ fontSize: 11, color: 'var(--text-secondary)' }}>
+            sub-{subject}
+          </code>
+          <button style={closeBtn} onClick={onClose}>Close</button>
+        </div>
+        <StructuralQCPanel subject={subject} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/workflow/WorkflowGraph.tsx
+++ b/frontend/src/components/workflow/WorkflowGraph.tsx
@@ -19,6 +19,7 @@ const STAGE_META: Record<string, { color: string; icon: string; label: string }>
   convert:     { color: '#3b82f6', icon: '\u{1F504}', label: 'Convert' },
   preproc:     { color: '#10b981', icon: '\u{2699}',  label: 'Preproc' },
   autoflatten: { color: '#14b8a6', icon: '\u{1F9E0}', label: 'Autoflatten' },
+  post_preproc:{ color: '#10b981', icon: '\u{1F300}', label: 'Post-preproc' },
   analysis:    { color: '#ef4444', icon: '\u{1F4CA}', label: 'Analysis' },
 }
 

--- a/frontend/src/components/workflow/WorkflowGraph.tsx
+++ b/frontend/src/components/workflow/WorkflowGraph.tsx
@@ -48,6 +48,7 @@ type StageNodeData = WorkflowStageStatus & {
   isFirst: boolean
   isLast: boolean
   onOpenNipypeDag?: () => void
+  onOpenStructuralQC?: () => void
 }
 
 const nodeBase: CSSProperties = {
@@ -186,6 +187,32 @@ function WorkflowStageNodeInner({ data }: NodeProps & { data: StageNodeData }) {
           />
         )}
 
+      {data.stage === 'preproc' && data.status === 'done' &&
+        data.onOpenStructuralQC && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              data.onOpenStructuralQC?.()
+            }}
+            style={{
+              marginTop: 6,
+              padding: '4px 10px',
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: 0.5,
+              borderRadius: 4,
+              background: `${meta.color}33`,
+              color: meta.color,
+              border: `1px solid ${meta.color}88`,
+              cursor: 'pointer',
+              textTransform: 'uppercase',
+            }}
+          >
+            Structural QC →
+          </button>
+        )}
+
       {clickable && (
         <div style={{
           fontSize: 9, color: meta.color, marginTop: 6,
@@ -298,6 +325,7 @@ const NODE_Y = 40
 function buildGraph(
   stages: WorkflowStageStatus[],
   onOpenNipypeDag?: (stage: WorkflowStageStatus) => void,
+  onOpenStructuralQC?: (stage: WorkflowStageStatus) => void,
 ): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = stages.map((s, i) => ({
     id: `stage-${i}-${s.stage}`,
@@ -311,6 +339,10 @@ function buildGraph(
       onOpenNipypeDag:
         s.stage === 'preproc' && onOpenNipypeDag
           ? () => onOpenNipypeDag(s)
+          : undefined,
+      onOpenStructuralQC:
+        s.stage === 'preproc' && onOpenStructuralQC
+          ? () => onOpenStructuralQC(s)
           : undefined,
     },
     draggable: false,
@@ -349,6 +381,7 @@ interface WorkflowGraphProps {
   onStageClick?: (stage: WorkflowStageStatus) => void
   onStageDoubleClick?: (stage: WorkflowStageStatus) => void
   onOpenNipypeDag?: (stage: WorkflowStageStatus) => void
+  onOpenStructuralQC?: (stage: WorkflowStageStatus) => void
 }
 
 export function WorkflowGraph(
@@ -358,11 +391,12 @@ export function WorkflowGraph(
     onStageClick,
     onStageDoubleClick,
     onOpenNipypeDag,
+    onOpenStructuralQC,
   }: WorkflowGraphProps,
 ) {
   const { nodes, edges } = useMemo(
-    () => buildGraph(stages, onOpenNipypeDag),
-    [stages, onOpenNipypeDag],
+    () => buildGraph(stages, onOpenNipypeDag, onOpenStructuralQC),
+    [stages, onOpenNipypeDag, onOpenStructuralQC],
   )
   if (!stages.length) return null
 

--- a/frontend/src/components/workflow/WorkflowGraph.tsx
+++ b/frontend/src/components/workflow/WorkflowGraph.tsx
@@ -12,6 +12,7 @@ import {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import type { WorkflowStageStatus } from '../../api/types'
+import { InnerNodesStrip } from './InnerNodesStrip'
 
 // ── Stage metadata ──────────────────────────────────────────────────────
 
@@ -174,6 +175,11 @@ function WorkflowStageNodeInner({ data }: NodeProps & { data: StageNodeData }) {
       {data.stage === 'analysis' && data.inner_stages && data.inner_stages.length > 0 && (
         <InnerStagesStrip inner={data.inner_stages} />
       )}
+
+      {data.stage === 'preproc' && data.nipype_status &&
+        data.nipype_status.counts.total_seen > 0 && (
+          <InnerNodesStrip block={data.nipype_status} />
+        )}
 
       {clickable && (
         <div style={{

--- a/frontend/src/components/workflow/WorkflowGraph.tsx
+++ b/frontend/src/components/workflow/WorkflowGraph.tsx
@@ -187,6 +187,12 @@ function WorkflowStageNodeInner({ data }: NodeProps & { data: StageNodeData }) {
           letterSpacing: 0.5, fontWeight: 600,
         }}>
           click for log →
+          {data.stage === 'preproc' && data.nipype_status &&
+            data.nipype_status.counts.total_seen > 0 && (
+              <span style={{ marginLeft: 8, opacity: 0.8 }}>
+                · double-click for DAG
+              </span>
+            )}
         </div>
       )}
 
@@ -335,9 +341,12 @@ interface WorkflowGraphProps {
   stages: WorkflowStageStatus[]
   height?: number
   onStageClick?: (stage: WorkflowStageStatus) => void
+  onStageDoubleClick?: (stage: WorkflowStageStatus) => void
 }
 
-export function WorkflowGraph({ stages, height = 220, onStageClick }: WorkflowGraphProps) {
+export function WorkflowGraph(
+  { stages, height = 220, onStageClick, onStageDoubleClick }: WorkflowGraphProps,
+) {
   const { nodes, edges } = useMemo(() => buildGraph(stages), [stages])
   if (!stages.length) return null
 
@@ -368,6 +377,11 @@ export function WorkflowGraph({ stages, height = 220, onStageClick }: WorkflowGr
             if (!onStageClick) return
             const data = node.data as unknown as StageNodeData
             onStageClick(data)
+          }}
+          onNodeDoubleClick={(_e, node) => {
+            if (!onStageDoubleClick) return
+            const data = node.data as unknown as StageNodeData
+            onStageDoubleClick(data)
           }}
           proOptions={{ hideAttribution: true }}
         />

--- a/frontend/src/components/workflow/WorkflowGraph.tsx
+++ b/frontend/src/components/workflow/WorkflowGraph.tsx
@@ -47,6 +47,7 @@ type StageNodeData = WorkflowStageStatus & {
   index: number
   isFirst: boolean
   isLast: boolean
+  onOpenNipypeDag?: () => void
 }
 
 const nodeBase: CSSProperties = {
@@ -179,7 +180,10 @@ function WorkflowStageNodeInner({ data }: NodeProps & { data: StageNodeData }) {
 
       {data.stage === 'preproc' && data.nipype_status &&
         data.nipype_status.counts.total_seen > 0 && (
-          <InnerNodesStrip block={data.nipype_status} />
+          <InnerNodesStrip
+            block={data.nipype_status}
+            onOpenDag={data.onOpenNipypeDag}
+          />
         )}
 
       {clickable && (
@@ -188,12 +192,6 @@ function WorkflowStageNodeInner({ data }: NodeProps & { data: StageNodeData }) {
           letterSpacing: 0.5, fontWeight: 600,
         }}>
           click for log →
-          {data.stage === 'preproc' && data.nipype_status &&
-            data.nipype_status.counts.total_seen > 0 && (
-              <span style={{ marginLeft: 8, opacity: 0.8 }}>
-                · double-click for DAG
-              </span>
-            )}
         </div>
       )}
 
@@ -297,7 +295,10 @@ const GRAPH_STYLE: CSSProperties = {
 const NODE_SPACING_X = 280
 const NODE_Y = 40
 
-function buildGraph(stages: WorkflowStageStatus[]): { nodes: Node[]; edges: Edge[] } {
+function buildGraph(
+  stages: WorkflowStageStatus[],
+  onOpenNipypeDag?: (stage: WorkflowStageStatus) => void,
+): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = stages.map((s, i) => ({
     id: `stage-${i}-${s.stage}`,
     type: 'workflowStage',
@@ -307,6 +308,10 @@ function buildGraph(stages: WorkflowStageStatus[]): { nodes: Node[]; edges: Edge
       index: i,
       isFirst: i === 0,
       isLast: i === stages.length - 1,
+      onOpenNipypeDag:
+        s.stage === 'preproc' && onOpenNipypeDag
+          ? () => onOpenNipypeDag(s)
+          : undefined,
     },
     draggable: false,
     selectable: false,
@@ -343,12 +348,22 @@ interface WorkflowGraphProps {
   height?: number
   onStageClick?: (stage: WorkflowStageStatus) => void
   onStageDoubleClick?: (stage: WorkflowStageStatus) => void
+  onOpenNipypeDag?: (stage: WorkflowStageStatus) => void
 }
 
 export function WorkflowGraph(
-  { stages, height = 220, onStageClick, onStageDoubleClick }: WorkflowGraphProps,
+  {
+    stages,
+    height = 220,
+    onStageClick,
+    onStageDoubleClick,
+    onOpenNipypeDag,
+  }: WorkflowGraphProps,
 ) {
-  const { nodes, edges } = useMemo(() => buildGraph(stages), [stages])
+  const { nodes, edges } = useMemo(
+    () => buildGraph(stages, onOpenNipypeDag),
+    [stages, onOpenNipypeDag],
+  )
   if (!stages.length) return null
 
   return (

--- a/frontend/src/components/workflow/WorkflowGraph.tsx
+++ b/frontend/src/components/workflow/WorkflowGraph.tsx
@@ -188,29 +188,55 @@ function WorkflowStageNodeInner({ data }: NodeProps & { data: StageNodeData }) {
         )}
 
       {data.stage === 'preproc' && data.status === 'done' &&
-        data.onOpenStructuralQC && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation()
-              data.onOpenStructuralQC?.()
-            }}
-            style={{
-              marginTop: 6,
-              padding: '4px 10px',
-              fontSize: 10,
-              fontWeight: 700,
-              letterSpacing: 0.5,
-              borderRadius: 4,
-              background: `${meta.color}33`,
-              color: meta.color,
-              border: `1px solid ${meta.color}88`,
-              cursor: 'pointer',
-              textTransform: 'uppercase',
-            }}
-          >
-            Structural QC →
-          </button>
+        (data.onOpenStructuralQC || data.onOpenNipypeDag) && (
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 6 }}>
+            {data.onOpenStructuralQC && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  data.onOpenStructuralQC?.()
+                }}
+                style={{
+                  padding: '4px 10px',
+                  fontSize: 10,
+                  fontWeight: 700,
+                  letterSpacing: 0.5,
+                  borderRadius: 4,
+                  background: `${meta.color}33`,
+                  color: meta.color,
+                  border: `1px solid ${meta.color}88`,
+                  cursor: 'pointer',
+                  textTransform: 'uppercase',
+                }}
+              >
+                Structural QC →
+              </button>
+            )}
+            {data.onOpenNipypeDag && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  data.onOpenNipypeDag?.()
+                }}
+                style={{
+                  padding: '4px 10px',
+                  fontSize: 10,
+                  fontWeight: 700,
+                  letterSpacing: 0.5,
+                  borderRadius: 4,
+                  background: `${meta.color}33`,
+                  color: meta.color,
+                  border: `1px solid ${meta.color}88`,
+                  cursor: 'pointer',
+                  textTransform: 'uppercase',
+                }}
+              >
+                View DAG →
+              </button>
+            )}
+          </div>
         )}
 
       {clickable && (

--- a/frontend/src/components/workflow/WorkflowGraph.tsx
+++ b/frontend/src/components/workflow/WorkflowGraph.tsx
@@ -1,11 +1,12 @@
 /** ReactFlow graph for a single workflow run — one node per stage. */
-import { memo, useMemo } from 'react'
+import { memo, useEffect, useMemo, useRef } from 'react'
 import type { CSSProperties } from 'react'
 import {
   ReactFlow,
   ReactFlowProvider,
   Handle,
   Position,
+  useNodesState,
   type Node,
   type Edge,
   type NodeProps,
@@ -188,54 +189,29 @@ function WorkflowStageNodeInner({ data }: NodeProps & { data: StageNodeData }) {
         )}
 
       {data.stage === 'preproc' && data.status === 'done' &&
-        (data.onOpenStructuralQC || data.onOpenNipypeDag) && (
+        data.onOpenStructuralQC && (
           <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 6 }}>
-            {data.onOpenStructuralQC && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  data.onOpenStructuralQC?.()
-                }}
-                style={{
-                  padding: '4px 10px',
-                  fontSize: 10,
-                  fontWeight: 700,
-                  letterSpacing: 0.5,
-                  borderRadius: 4,
-                  background: `${meta.color}33`,
-                  color: meta.color,
-                  border: `1px solid ${meta.color}88`,
-                  cursor: 'pointer',
-                  textTransform: 'uppercase',
-                }}
-              >
-                Structural QC →
-              </button>
-            )}
-            {data.onOpenNipypeDag && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  data.onOpenNipypeDag?.()
-                }}
-                style={{
-                  padding: '4px 10px',
-                  fontSize: 10,
-                  fontWeight: 700,
-                  letterSpacing: 0.5,
-                  borderRadius: 4,
-                  background: `${meta.color}33`,
-                  color: meta.color,
-                  border: `1px solid ${meta.color}88`,
-                  cursor: 'pointer',
-                  textTransform: 'uppercase',
-                }}
-              >
-                View DAG →
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                data.onOpenStructuralQC?.()
+              }}
+              style={{
+                padding: '4px 10px',
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: 0.5,
+                borderRadius: 4,
+                background: `${meta.color}33`,
+                color: meta.color,
+                border: `1px solid ${meta.color}88`,
+                cursor: 'pointer',
+                textTransform: 'uppercase',
+              }}
+            >
+              Structural QC →
+            </button>
           </div>
         )}
 
@@ -346,6 +322,7 @@ const GRAPH_STYLE: CSSProperties = {
 }
 
 const NODE_SPACING_X = 280
+const NODE_GAP_X = 60
 const NODE_Y = 40
 
 function buildGraph(
@@ -393,7 +370,7 @@ function buildGraph(
       id: `edge-${i}`,
       source: `stage-${i}-${from.stage}`,
       target: `stage-${i + 1}-${to.stage}`,
-      type: 'smoothstep',
+      type: 'straight',
       animated: fromDone && toActive,
       style: { stroke, strokeWidth: fromDone ? 2 : 1.5 },
     })
@@ -435,33 +412,100 @@ export function WorkflowGraph(
         }
       `}</style>
       <ReactFlowProvider>
-        <ReactFlow
-          nodes={nodes}
+        <_WorkflowGraphInner
+          initialNodes={nodes}
           edges={edges}
-          nodeTypes={nodeTypes}
-          fitView
-          fitViewOptions={{ padding: 0.2 }}
-          nodesDraggable={false}
-          nodesConnectable={false}
-          elementsSelectable={false}
-          panOnDrag={false}
-          zoomOnScroll={false}
-          zoomOnPinch={false}
-          zoomOnDoubleClick={false}
-          preventScrolling={false}
-          onNodeClick={(_e, node) => {
-            if (!onStageClick) return
-            const data = node.data as unknown as StageNodeData
-            onStageClick(data)
-          }}
-          onNodeDoubleClick={(_e, node) => {
-            if (!onStageDoubleClick) return
-            const data = node.data as unknown as StageNodeData
-            onStageDoubleClick(data)
-          }}
-          proOptions={{ hideAttribution: true }}
+          onStageClick={onStageClick}
+          onStageDoubleClick={onStageDoubleClick}
         />
       </ReactFlowProvider>
     </div>
+  )
+}
+
+
+function _WorkflowGraphInner({
+  initialNodes,
+  edges,
+  onStageClick,
+  onStageDoubleClick,
+}: {
+  initialNodes: Node[]
+  edges: Edge[]
+  onStageClick?: (stage: WorkflowStageStatus) => void
+  onStageDoubleClick?: (stage: WorkflowStageStatus) => void
+}) {
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
+  const lastSig = useRef('')
+
+  // Resync when parent rebuilds the graph (live status updates).
+  useEffect(() => {
+    setNodes(initialNodes)
+    lastSig.current = ''
+  }, [initialNodes, setNodes])
+
+  // After xyflow measures each card, recompute x AND y from the
+  // measured sizes:
+  //   • x packs cards left-to-right with a constant gap, so wider
+  //     cards push the next one over and never overlap.
+  //   • y centers each card on a shared horizontal axis so their
+  //     handles line up → edges draw as straight horizontal lines.
+  useEffect(() => {
+    if (nodes.length === 0) return
+    const dims = nodes.map((n) => {
+      const m = (n as Node & {
+        measured?: { width?: number; height?: number }
+      }).measured
+      return {
+        w: m?.width && m.width > 0 ? m.width : 0,
+        h: m?.height && m.height > 0 ? m.height : 0,
+      }
+    })
+    if (dims.some((d) => d.w === 0 || d.h === 0)) return
+    const sig = dims.map((d) => `${d.w}x${d.h}`).join(',')
+    if (sig === lastSig.current) return
+    lastSig.current = sig
+
+    const maxH = Math.max(...dims.map((d) => d.h))
+    const centerY = NODE_Y + maxH / 2
+    let cursor = 0
+    const repositioned = nodes.map((n, i) => {
+      const x = cursor
+      const y = centerY - dims[i].h / 2
+      cursor += dims[i].w + NODE_GAP_X
+      if (n.position.x === x && n.position.y === y) return n
+      return { ...n, position: { x, y } }
+    })
+    if (repositioned.some((n, i) => n !== nodes[i])) setNodes(repositioned)
+  }, [nodes, setNodes])
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      nodeTypes={nodeTypes}
+      fitView
+      fitViewOptions={{ padding: 0.2 }}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable={false}
+      panOnDrag={false}
+      zoomOnScroll={false}
+      zoomOnPinch={false}
+      zoomOnDoubleClick={false}
+      preventScrolling={false}
+      onNodeClick={(_e, node) => {
+        if (!onStageClick) return
+        const data = node.data as unknown as StageNodeData
+        onStageClick(data)
+      }}
+      onNodeDoubleClick={(_e, node) => {
+        if (!onStageDoubleClick) return
+        const data = node.data as unknown as StageNodeData
+        onStageDoubleClick(data)
+      }}
+      proOptions={{ hideAttribution: true }}
+    />
   )
 }

--- a/frontend/src/components/workflow/__tests__/InnerNodesStrip.test.tsx
+++ b/frontend/src/components/workflow/__tests__/InnerNodesStrip.test.tsx
@@ -25,7 +25,10 @@ function nodes(statuses: ('running' | 'ok' | 'failed')[]): NipypeNodeStatus[] {
 
 
 function block(statuses: ('running' | 'ok' | 'failed')[]): NipypeStatusBlock {
-  const counts = { running: 0, ok: 0, failed: 0, total_seen: statuses.length }
+  const counts = {
+    running: 0, ok: 0, failed: 0,
+    completed_assumed: 0, total_seen: statuses.length,
+  }
   for (const s of statuses) counts[s] += 1
   return { counts, recent_nodes: nodes(statuses) }
 }

--- a/frontend/src/components/workflow/__tests__/InnerNodesStrip.test.tsx
+++ b/frontend/src/components/workflow/__tests__/InnerNodesStrip.test.tsx
@@ -1,0 +1,81 @@
+/** Compact one-line strip with View DAG button. */
+
+import { describe, it, expect, vi } from 'vitest'
+import { renderWithProviders, screen } from '../../../test/render'
+import { InnerNodesStrip } from '../InnerNodesStrip'
+import type {
+  NipypeNodeStatus,
+  NipypeStatusBlock,
+} from '../../../api/types'
+
+
+function nodes(statuses: ('running' | 'ok' | 'failed')[]): NipypeNodeStatus[] {
+  return statuses.map((s, i) => ({
+    node: `wf.n${i}`,
+    leaf: `n${i}`,
+    workflow: 'wf',
+    status: s,
+    started_at: 0,
+    finished_at: 0,
+    elapsed: 0,
+    crash_file: null,
+    level: s === 'failed' ? 'ERROR' : 'INFO',
+  }))
+}
+
+
+function block(statuses: ('running' | 'ok' | 'failed')[]): NipypeStatusBlock {
+  const counts = { running: 0, ok: 0, failed: 0, total_seen: statuses.length }
+  for (const s of statuses) counts[s] += 1
+  return { counts, recent_nodes: nodes(statuses) }
+}
+
+
+describe('<InnerNodesStrip />', () => {
+  it('renders the running/done/failed counts when nodes are present', () => {
+    renderWithProviders(
+      <InnerNodesStrip block={block(['running', 'running', 'ok', 'ok', 'ok', 'failed'])} />,
+    )
+    expect(screen.getByText('2 running')).toBeInTheDocument()
+    expect(screen.getByText('3 done')).toBeInTheDocument()
+    expect(screen.getByText('1 failed')).toBeInTheDocument()
+    expect(screen.getByText('(6 seen)')).toBeInTheDocument()
+  })
+
+  it('renders the empty-state message when nothing has been parsed', () => {
+    renderWithProviders(<InnerNodesStrip block={block([])} />)
+    expect(screen.getByText('no nodes seen yet')).toBeInTheDocument()
+  })
+
+  it('shows the View DAG button only when nodes exist', () => {
+    const onOpenDag = vi.fn()
+    const { rerender } = renderWithProviders(
+      <InnerNodesStrip block={block([])} onOpenDag={onOpenDag} />,
+    )
+    expect(screen.queryByRole('button', { name: /view dag/i })).not.toBeInTheDocument()
+
+    rerender(<InnerNodesStrip block={block(['ok'])} onOpenDag={onOpenDag} />)
+    expect(screen.getByRole('button', { name: /view dag/i })).toBeInTheDocument()
+  })
+
+  it('does not show the button when no callback is wired', () => {
+    renderWithProviders(<InnerNodesStrip block={block(['ok'])} />)
+    expect(screen.queryByRole('button', { name: /view dag/i })).not.toBeInTheDocument()
+  })
+
+  it('invokes the callback when View DAG is clicked', async () => {
+    const onOpenDag = vi.fn()
+    const { user } = renderWithProviders(
+      <InnerNodesStrip block={block(['ok'])} onOpenDag={onOpenDag} />,
+    )
+    await user.click(screen.getByRole('button', { name: /view dag/i }))
+    expect(onOpenDag).toHaveBeenCalledOnce()
+  })
+
+  it('only shows the categories that have a nonzero count', () => {
+    renderWithProviders(<InnerNodesStrip block={block(['ok', 'ok'])} />)
+    expect(screen.getByText('2 done')).toBeInTheDocument()
+    expect(screen.queryByText(/running/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/failed/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/workflow/__tests__/NodeOutputsPanel.test.tsx
+++ b/frontend/src/components/workflow/__tests__/NodeOutputsPanel.test.tsx
@@ -1,0 +1,156 @@
+/** Drawer that shows a node's work_dir contents. */
+
+import { describe, it, expect, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../../test/mocks/server'
+import { renderWithProviders, screen, waitFor } from '../../../test/render'
+import { NodeOutputsPanel } from '../NodeOutputsPanel'
+
+vi.mock('@niivue/niivue', () => ({
+  Niivue: vi.fn().mockImplementation(() => ({
+    attachToCanvas: vi.fn(),
+    loadVolumes: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+
+function mockOutputs(rows: any) {
+  server.use(
+    http.get('/api/preproc/runs/:run/node/:node/files', () =>
+      HttpResponse.json(rows),
+    ),
+  )
+}
+
+
+describe('<NodeOutputsPanel />', () => {
+  it('renders the file list with the node leaf in the header', async () => {
+    mockOutputs({
+      node: 'fmriprep_wf.anat_wf.smooth',
+      leaf_dir: '/work/.../smooth',
+      exists: true,
+      crashes: [],
+      files: [
+        { name: 'command.txt', rel: 'command.txt', suffix: '.txt',
+          size: 100, kind: 'view' },
+        { name: 'result.pklz', rel: 'result.pklz', suffix: '.pklz',
+          size: 200, kind: 'pickle' },
+      ],
+    })
+    renderWithProviders(
+      <NodeOutputsPanel runId="r1" node="fmriprep_wf.anat_wf.smooth"
+                        onClose={vi.fn()} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('smooth')).toBeInTheDocument()
+    })
+    expect(screen.getByText('command.txt')).toBeInTheDocument()
+    expect(screen.getByText('result.pklz')).toBeInTheDocument()
+    expect(screen.getByText(/\.txt · 100 B · view/)).toBeInTheDocument()
+    expect(screen.getByText(/\.pklz · 200 B · pickle/)).toBeInTheDocument()
+  })
+
+  it('expands a text file inline when clicked', async () => {
+    mockOutputs({
+      node: 'wf.x',
+      leaf_dir: '/w',
+      exists: true,
+      crashes: [],
+      files: [{ name: 'a.txt', rel: 'a.txt', suffix: '.txt',
+                size: 7, kind: 'view' }],
+    })
+    server.use(
+      http.get('/api/preproc/runs/r1/node/wf.x/file', () =>
+        new HttpResponse('hello\n', {
+          status: 200, headers: { 'content-type': 'text/plain' },
+        }),
+      ),
+    )
+    const { user } = renderWithProviders(
+      <NodeOutputsPanel runId="r1" node="wf.x" onClose={vi.fn()} />,
+    )
+    await waitFor(() => expect(screen.getByText('a.txt')).toBeInTheDocument())
+    await user.click(screen.getByText('a.txt'))
+    await waitFor(() => {
+      expect(screen.getByText(/hello/)).toBeInTheDocument()
+    })
+  })
+
+  it('decodes a pickle on expand', async () => {
+    mockOutputs({
+      node: 'wf.x',
+      leaf_dir: '/w',
+      exists: true,
+      crashes: [],
+      files: [{ name: 'r.pklz', rel: 'r.pklz', suffix: '.pklz',
+                size: 100, kind: 'pickle' }],
+    })
+    server.use(
+      http.get('/api/preproc/runs/r1/node/wf.x/pickle', () =>
+        HttpResponse.json({
+          name: 'r.pklz',
+          type: 'dict',
+          value: { fwhm: 5, n_iter: 3 },
+        }),
+      ),
+    )
+    const { user } = renderWithProviders(
+      <NodeOutputsPanel runId="r1" node="wf.x" onClose={vi.fn()} />,
+    )
+    await waitFor(() => expect(screen.getByText('r.pklz')).toBeInTheDocument())
+    await user.click(screen.getByText('r.pklz'))
+    await waitFor(() => {
+      expect(screen.getByText(/n_iter/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/fwhm/)).toBeInTheDocument()
+  })
+
+  it('shows a friendly empty state when leaf_dir does not exist', async () => {
+    mockOutputs({
+      node: 'wf.x', leaf_dir: '/w/missing',
+      exists: false, crashes: [], files: [],
+    })
+    renderWithProviders(
+      <NodeOutputsPanel runId="r1" node="wf.x" onClose={vi.fn()} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/No work_dir on disk for this node/i))
+        .toBeInTheDocument()
+    })
+  })
+
+  it('surfaces crash files at the top of the list', async () => {
+    mockOutputs({
+      node: 'wf.boom', leaf_dir: '/w/boom',
+      exists: true,
+      files: [],
+      crashes: [{
+        name: 'crash-20260505-boom-abc.txt',
+        path: '/log/crash-20260505-boom-abc.txt',
+        size: 1024,
+      }],
+    })
+    renderWithProviders(
+      <NodeOutputsPanel runId="r1" node="wf.boom" onClose={vi.fn()} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/Crashes \(1\)/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText('crash-20260505-boom-abc.txt')).toBeInTheDocument()
+  })
+
+  it('calls onClose when Close is clicked', async () => {
+    mockOutputs({
+      node: 'wf.x', leaf_dir: '/w', exists: true, files: [], crashes: [],
+    })
+    const onClose = vi.fn()
+    const { user } = renderWithProviders(
+      <NodeOutputsPanel runId="r1" node="wf.x" onClose={onClose} />,
+    )
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument(),
+    )
+    await user.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/workflow/__tests__/NodeOutputsPanel.test.tsx
+++ b/frontend/src/components/workflow/__tests__/NodeOutputsPanel.test.tsx
@@ -139,7 +139,7 @@ describe('<NodeOutputsPanel />', () => {
     expect(screen.getByText('crash-20260505-boom-abc.txt')).toBeInTheDocument()
   })
 
-  it('calls onClose when Close is clicked', async () => {
+  it('calls onClose when the hide-panel arrow is clicked', async () => {
     mockOutputs({
       node: 'wf.x', leaf_dir: '/w', exists: true, files: [], crashes: [],
     })
@@ -148,9 +148,9 @@ describe('<NodeOutputsPanel />', () => {
       <NodeOutputsPanel runId="r1" node="wf.x" onClose={onClose} />,
     )
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument(),
+      expect(screen.getByRole('button', { name: /hide outputs panel/i })).toBeInTheDocument(),
     )
-    await user.click(screen.getByRole('button', { name: /close/i }))
+    await user.click(screen.getByRole('button', { name: /hide outputs panel/i }))
     expect(onClose).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/components/workflow/__tests__/StructuralQCModal.test.tsx
+++ b/frontend/src/components/workflow/__tests__/StructuralQCModal.test.tsx
@@ -1,0 +1,72 @@
+/** Modal that wraps StructuralQCPanel for the Workflows-view drill-in. */
+
+import { describe, it, expect, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../../test/mocks/server'
+import { renderWithProviders, screen, waitFor } from '../../../test/render'
+import { StructuralQCModal } from '../StructuralQCModal'
+
+
+// niivue does WebGL — stub so the panel inside the modal mounts.
+vi.mock('@niivue/niivue', () => ({
+  Niivue: vi.fn().mockImplementation(() => ({
+    attachToCanvas: vi.fn(),
+    loadVolumes: vi.fn().mockResolvedValue(undefined),
+    loadMeshes: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+
+function mockReview(subject: string, status = 'pending') {
+  server.use(
+    http.get(`/api/preproc/subjects/${subject}/structural-qc`, () =>
+      HttpResponse.json({
+        dataset: 'ds-test', subject, status,
+        reviewer: '', timestamp: '2026-05-05T00:00:00Z',
+        notes: '', freeview_command_used: null,
+      }),
+    ),
+  )
+}
+
+
+describe('<StructuralQCModal />', () => {
+  it('renders the subject id in the header', async () => {
+    mockReview('AN', 'pending')
+    renderWithProviders(<StructuralQCModal subject="AN" onClose={vi.fn()} />)
+    // sub-AN appears only in the modal header; "Structural QC" also
+    // matches the underlying panel's section label so we don't assert it.
+    expect(screen.getByText('sub-AN')).toBeInTheDocument()
+  })
+
+  it('hosts the underlying StructuralQCPanel for the subject', async () => {
+    mockReview('AN', 'approved')
+    renderWithProviders(<StructuralQCModal subject="AN" onClose={vi.fn()} />)
+    await waitFor(() => {
+      // Header-line status pill from the inner panel.
+      expect(screen.getByText(/●\s*Approve/)).toBeInTheDocument()
+    })
+  })
+
+  it('calls onClose when the Close button is clicked', async () => {
+    mockReview('AN')
+    const onClose = vi.fn()
+    const { user } = renderWithProviders(
+      <StructuralQCModal subject="AN" onClose={onClose} />,
+    )
+    await user.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when the backdrop is clicked', async () => {
+    mockReview('AN')
+    const onClose = vi.fn()
+    const { container, user } = renderWithProviders(
+      <StructuralQCModal subject="AN" onClose={onClose} />,
+    )
+    // First top-level child is the backdrop (z-index'd absolute).
+    const backdrop = container.firstElementChild as HTMLElement
+    await user.click(backdrop)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/workflow/__tests__/nipype_tree.test.ts
+++ b/frontend/src/components/workflow/__tests__/nipype_tree.test.ts
@@ -58,7 +58,7 @@ describe('buildNipypeTree', () => {
     const root = tree.nodes.find((n) => n.id === 'wf')!
     expect(root.kind).toBe('workflow')
     expect(root.counts).toEqual({
-      running: 1, ok: 1, failed: 1, completed_assumed: 0, total: 3,
+      running: 1, ok: 1, failed: 1, completed_assumed: 0, cached: 0, total: 3,
     })
   })
 
@@ -72,13 +72,13 @@ describe('buildNipypeTree', () => {
     const ab = tree.nodes.find((n) => n.id === 'a.b')!
     const abc = tree.nodes.find((n) => n.id === 'a.b.c')!
     expect(a.counts).toEqual({
-      running: 1, ok: 1, failed: 1, completed_assumed: 0, total: 3,
+      running: 1, ok: 1, failed: 1, completed_assumed: 0, cached: 0, total: 3,
     })
     expect(ab.counts).toEqual({
-      running: 1, ok: 1, failed: 1, completed_assumed: 0, total: 3,
+      running: 1, ok: 1, failed: 1, completed_assumed: 0, cached: 0, total: 3,
     })
     expect(abc.counts).toEqual({
-      running: 0, ok: 1, failed: 1, completed_assumed: 0, total: 2,
+      running: 0, ok: 1, failed: 1, completed_assumed: 0, cached: 0, total: 2,
     })
   })
 

--- a/frontend/src/components/workflow/__tests__/nipype_tree.test.ts
+++ b/frontend/src/components/workflow/__tests__/nipype_tree.test.ts
@@ -57,7 +57,9 @@ describe('buildNipypeTree', () => {
     ])
     const root = tree.nodes.find((n) => n.id === 'wf')!
     expect(root.kind).toBe('workflow')
-    expect(root.counts).toEqual({ running: 1, ok: 1, failed: 1, total: 3 })
+    expect(root.counts).toEqual({
+      running: 1, ok: 1, failed: 1, completed_assumed: 0, total: 3,
+    })
   })
 
   it('rolls counts up multiple levels', () => {
@@ -69,9 +71,15 @@ describe('buildNipypeTree', () => {
     const a = tree.nodes.find((n) => n.id === 'a')!
     const ab = tree.nodes.find((n) => n.id === 'a.b')!
     const abc = tree.nodes.find((n) => n.id === 'a.b.c')!
-    expect(a.counts).toEqual({ running: 1, ok: 1, failed: 1, total: 3 })
-    expect(ab.counts).toEqual({ running: 1, ok: 1, failed: 1, total: 3 })
-    expect(abc.counts).toEqual({ running: 0, ok: 1, failed: 1, total: 2 })
+    expect(a.counts).toEqual({
+      running: 1, ok: 1, failed: 1, completed_assumed: 0, total: 3,
+    })
+    expect(ab.counts).toEqual({
+      running: 1, ok: 1, failed: 1, completed_assumed: 0, total: 3,
+    })
+    expect(abc.counts).toEqual({
+      running: 0, ok: 1, failed: 1, completed_assumed: 0, total: 2,
+    })
   })
 
   it('handles a single-segment path as a root leaf', () => {

--- a/frontend/src/components/workflow/__tests__/nipype_tree.test.ts
+++ b/frontend/src/components/workflow/__tests__/nipype_tree.test.ts
@@ -1,0 +1,111 @@
+/** Pure unit tests for the dotted-path → tree builder. */
+
+import { describe, it, expect } from 'vitest'
+import type { NipypeNodeStatus } from '../../../api/types'
+import { buildNipypeTree } from '../nipype_tree'
+
+
+function leaf(
+  node: string,
+  status: 'running' | 'ok' | 'failed' = 'ok',
+  elapsed = 0,
+): NipypeNodeStatus {
+  const seg = node.split('.')
+  return {
+    node,
+    leaf: seg[seg.length - 1],
+    workflow: seg.slice(0, -1).join('.'),
+    status,
+    started_at: 0,
+    finished_at: 0,
+    elapsed,
+    crash_file: null,
+    level: 'INFO',
+  }
+}
+
+
+describe('buildNipypeTree', () => {
+  it('builds parents from dotted paths', () => {
+    const tree = buildNipypeTree([
+      leaf('fmriprep_wf.bold_preproc_wf.bold_split'),
+      leaf('fmriprep_wf.bold_preproc_wf.bold_t1_trans_wf'),
+      leaf('fmriprep_wf.sdc_estimate_wf.unwarp_wf'),
+    ])
+    const ids = tree.nodes.map((n) => n.id).sort()
+    expect(ids).toContain('fmriprep_wf')
+    expect(ids).toContain('fmriprep_wf.bold_preproc_wf')
+    expect(ids).toContain('fmriprep_wf.sdc_estimate_wf')
+    expect(ids).toContain('fmriprep_wf.bold_preproc_wf.bold_split')
+    // 3 leaves + 3 unique ancestors (root + two sub).
+    expect(tree.nodes).toHaveLength(6)
+  })
+
+  it('emits parent→child edges', () => {
+    const tree = buildNipypeTree([leaf('a.b.c')])
+    const ab = tree.edges.find((e) => e.source === 'a' && e.target === 'a.b')
+    const abc = tree.edges.find((e) => e.source === 'a.b' && e.target === 'a.b.c')
+    expect(ab).toBeDefined()
+    expect(abc).toBeDefined()
+  })
+
+  it('rolls counts up to every ancestor', () => {
+    const tree = buildNipypeTree([
+      leaf('wf.x', 'ok'),
+      leaf('wf.y', 'failed'),
+      leaf('wf.z', 'running'),
+    ])
+    const root = tree.nodes.find((n) => n.id === 'wf')!
+    expect(root.kind).toBe('workflow')
+    expect(root.counts).toEqual({ running: 1, ok: 1, failed: 1, total: 3 })
+  })
+
+  it('rolls counts up multiple levels', () => {
+    const tree = buildNipypeTree([
+      leaf('a.b.c.x', 'ok'),
+      leaf('a.b.c.y', 'failed'),
+      leaf('a.b.d.z', 'running'),
+    ])
+    const a = tree.nodes.find((n) => n.id === 'a')!
+    const ab = tree.nodes.find((n) => n.id === 'a.b')!
+    const abc = tree.nodes.find((n) => n.id === 'a.b.c')!
+    expect(a.counts).toEqual({ running: 1, ok: 1, failed: 1, total: 3 })
+    expect(ab.counts).toEqual({ running: 1, ok: 1, failed: 1, total: 3 })
+    expect(abc.counts).toEqual({ running: 0, ok: 1, failed: 1, total: 2 })
+  })
+
+  it('handles a single-segment path as a root leaf', () => {
+    const tree = buildNipypeTree([leaf('only', 'ok')])
+    expect(tree.nodes).toHaveLength(1)
+    expect(tree.nodes[0].kind).toBe('leaf')
+    expect(tree.nodes[0].parentId).toBeNull()
+    expect(tree.edges).toHaveLength(0)
+  })
+
+  it('preserves leaf metadata on the corresponding tree node', () => {
+    const tree = buildNipypeTree([leaf('wf.x', 'failed', 12.5)])
+    const x = tree.nodes.find((n) => n.id === 'wf.x')!
+    expect(x.kind).toBe('leaf')
+    expect(x.status).toBe('failed')
+    expect(x.elapsed).toBe(12.5)
+    expect(x.full_node).toBe('wf.x')
+    expect(x.level).toBe('INFO')
+  })
+
+  it('handles an empty input', () => {
+    const tree = buildNipypeTree([])
+    expect(tree.nodes).toEqual([])
+    expect(tree.edges).toEqual([])
+  })
+
+  it('does not duplicate edges across multiple leaves under the same parent', () => {
+    const tree = buildNipypeTree([
+      leaf('wf.a'),
+      leaf('wf.b'),
+      leaf('wf.c'),
+    ])
+    // Three leaves all share parent `wf` — three distinct edges, none duplicated.
+    const wfChildren = tree.edges.filter((e) => e.source === 'wf').map((e) => e.target).sort()
+    expect(wfChildren).toEqual(['wf.a', 'wf.b', 'wf.c'])
+  })
+})

--- a/frontend/src/components/workflow/nipype_tree.ts
+++ b/frontend/src/components/workflow/nipype_tree.ts
@@ -22,7 +22,7 @@ export interface NipypeTreeNode {
   parentId: string | null
   kind: TreeNodeKind
   // Leaf-only fields (mirrored from NipypeNodeStatus for rendering).
-  status?: 'running' | 'ok' | 'failed' | 'completed_assumed'
+  status?: 'running' | 'ok' | 'failed' | 'completed_assumed' | 'cached'
   elapsed?: number
   level?: string
   full_node?: string
@@ -32,6 +32,7 @@ export interface NipypeTreeNode {
     ok: number
     failed: number
     completed_assumed: number
+    cached: number
     total: number
   }
 }
@@ -73,7 +74,7 @@ export function buildNipypeTree(leaves: NipypeNodeStatus[]): NipypeTree {
       parentId,
       kind,
       counts: kind === 'workflow'
-        ? { running: 0, ok: 0, failed: 0, completed_assumed: 0, total: 0 }
+        ? { running: 0, ok: 0, failed: 0, completed_assumed: 0, cached: 0, total: 0 }
         : undefined,
     }
     all.set(path, existing)
@@ -104,6 +105,7 @@ export function buildNipypeTree(leaves: NipypeNodeStatus[]): NipypeTree {
         else if (leaf.status === 'ok') p.counts.ok += 1
         else if (leaf.status === 'failed') p.counts.failed += 1
         else if (leaf.status === 'completed_assumed') p.counts.completed_assumed += 1
+        else if (leaf.status === 'cached') p.counts.cached += 1
       }
       parent = p.parentId
     }

--- a/frontend/src/components/workflow/nipype_tree.ts
+++ b/frontend/src/components/workflow/nipype_tree.ts
@@ -22,12 +22,18 @@ export interface NipypeTreeNode {
   parentId: string | null
   kind: TreeNodeKind
   // Leaf-only fields (mirrored from NipypeNodeStatus for rendering).
-  status?: 'running' | 'ok' | 'failed'
+  status?: 'running' | 'ok' | 'failed' | 'completed_assumed'
   elapsed?: number
   level?: string
   full_node?: string
   // Workflow-only summaries.
-  counts?: { running: number; ok: number; failed: number; total: number }
+  counts?: {
+    running: number
+    ok: number
+    failed: number
+    completed_assumed: number
+    total: number
+  }
 }
 
 
@@ -67,7 +73,7 @@ export function buildNipypeTree(leaves: NipypeNodeStatus[]): NipypeTree {
       parentId,
       kind,
       counts: kind === 'workflow'
-        ? { running: 0, ok: 0, failed: 0, total: 0 }
+        ? { running: 0, ok: 0, failed: 0, completed_assumed: 0, total: 0 }
         : undefined,
     }
     all.set(path, existing)
@@ -97,6 +103,7 @@ export function buildNipypeTree(leaves: NipypeNodeStatus[]): NipypeTree {
         if (leaf.status === 'running') p.counts.running += 1
         else if (leaf.status === 'ok') p.counts.ok += 1
         else if (leaf.status === 'failed') p.counts.failed += 1
+        else if (leaf.status === 'completed_assumed') p.counts.completed_assumed += 1
       }
       parent = p.parentId
     }

--- a/frontend/src/components/workflow/nipype_tree.ts
+++ b/frontend/src/components/workflow/nipype_tree.ts
@@ -1,0 +1,106 @@
+/** Build a ReactFlow-shape tree from a flat list of NipypeNodeStatus.
+ *
+ * The dotted node paths from nipype already form an implicit hierarchy
+ * (e.g. `fmriprep_wf.single_subject_01_wf.bold_preproc_wf.bold_split`).
+ * We use that hierarchy as a tree of parents → leaves; edges connect
+ * each parent to its direct children. Parents aren't "real" nipype
+ * nodes — they're virtual summary boxes whose counts roll up children.
+ *
+ * Output is intentionally framework-light (just `{nodes, edges}`); the
+ * caller hands it to dagre + XYFlow.
+ */
+
+import type { NipypeNodeStatus } from '../../api/types'
+
+
+export type TreeNodeKind = 'workflow' | 'leaf'
+
+
+export interface NipypeTreeNode {
+  id: string             // dotted path
+  label: string          // last segment
+  parentId: string | null
+  kind: TreeNodeKind
+  // Leaf-only fields (mirrored from NipypeNodeStatus for rendering).
+  status?: 'running' | 'ok' | 'failed'
+  elapsed?: number
+  level?: string
+  full_node?: string
+  // Workflow-only summaries.
+  counts?: { running: number; ok: number; failed: number; total: number }
+}
+
+
+export interface NipypeTreeEdge {
+  id: string
+  source: string
+  target: string
+}
+
+
+export interface NipypeTree {
+  nodes: NipypeTreeNode[]
+  edges: NipypeTreeEdge[]
+}
+
+
+function _segments(node: string): string[] {
+  return node ? node.split('.') : []
+}
+
+
+/** Build the tree. Stable across calls when input is stable. */
+export function buildNipypeTree(leaves: NipypeNodeStatus[]): NipypeTree {
+  const all = new Map<string, NipypeTreeNode>()
+  const edges: NipypeTreeEdge[] = []
+  const edgeKeys = new Set<string>()
+
+  function ensure(path: string, kind: TreeNodeKind): NipypeTreeNode {
+    let existing = all.get(path)
+    if (existing) return existing
+    const segs = _segments(path)
+    const label = segs.length ? segs[segs.length - 1] : path
+    const parentId = segs.length > 1 ? segs.slice(0, -1).join('.') : null
+    existing = {
+      id: path,
+      label,
+      parentId,
+      kind,
+      counts: kind === 'workflow'
+        ? { running: 0, ok: 0, failed: 0, total: 0 }
+        : undefined,
+    }
+    all.set(path, existing)
+    if (parentId) {
+      ensure(parentId, 'workflow')
+      const key = `${parentId}->${path}`
+      if (!edgeKeys.has(key)) {
+        edgeKeys.add(key)
+        edges.push({ id: `e-${edges.length}`, source: parentId, target: path })
+      }
+    }
+    return existing
+  }
+
+  for (const leaf of leaves) {
+    const node = ensure(leaf.node, 'leaf')
+    node.status = leaf.status
+    node.elapsed = leaf.elapsed
+    node.level = leaf.level
+    node.full_node = leaf.node
+    // Roll up counts on every ancestor.
+    let parent = node.parentId
+    while (parent) {
+      const p = ensure(parent, 'workflow')
+      if (p.counts) {
+        p.counts.total += 1
+        if (leaf.status === 'running') p.counts.running += 1
+        else if (leaf.status === 'ok') p.counts.ok += 1
+        else if (leaf.status === 'failed') p.counts.failed += 1
+      }
+      parent = p.parentId
+    }
+  }
+
+  return { nodes: Array.from(all.values()), edges }
+}

--- a/frontend/src/stores/graph-store.ts
+++ b/frontend/src/stores/graph-store.ts
@@ -82,13 +82,30 @@ export function isValidConnection(connection: Connection | Edge, nodes: Node[]):
 const NODE_WIDTH = 220
 const NODE_HEIGHT = 120
 
+type Measured = { width?: number; height?: number } | undefined
+
+function _sizeOf(node: Node): { w: number; h: number } {
+  // xyflow v12 fills `measured` after the first render with the real
+  // DOM size. Fall back to defaults on the first pass.
+  const m = (node as Node & { measured?: Measured }).measured
+  return {
+    w: m?.width && m.width > 0 ? m.width : NODE_WIDTH,
+    h: m?.height && m.height > 0 ? m.height : NODE_HEIGHT,
+  }
+}
+
 export function autoLayout(nodes: Node[], edges: Edge[]): Node[] {
   const g = new dagre.graphlib.Graph()
   g.setDefaultEdgeLabel(() => ({}))
-  g.setGraph({ rankdir: 'TB', ranksep: 80, nodesep: 60 })
+  // Generous separators so even worst-case nodes have breathing room;
+  // dagre uses these as minimums, not maximums.
+  g.setGraph({ rankdir: 'TB', ranksep: 120, nodesep: 80 })
 
+  const sizes = new Map<string, { w: number; h: number }>()
   nodes.forEach((node) => {
-    g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT })
+    const s = _sizeOf(node)
+    sizes.set(node.id, s)
+    g.setNode(node.id, { width: s.w, height: s.h })
   })
   edges.forEach((edge) => {
     g.setEdge(edge.source, edge.target)
@@ -98,14 +115,27 @@ export function autoLayout(nodes: Node[], edges: Edge[]): Node[] {
 
   return nodes.map((node) => {
     const pos = g.node(node.id)
+    const s = sizes.get(node.id) ?? { w: NODE_WIDTH, h: NODE_HEIGHT }
     return {
       ...node,
       position: {
-        x: pos.x - NODE_WIDTH / 2,
-        y: pos.y - NODE_HEIGHT / 2,
+        x: pos.x - s.w / 2,
+        y: pos.y - s.h / 2,
       },
     }
   })
+}
+
+/** Signature of all nodes' measured sizes; changes when the DOM
+ *  measures something new. Used by callers to decide whether a
+ *  re-layout pass is worth running. */
+export function measuredSignature(nodes: Node[]): string {
+  return nodes
+    .map((n) => {
+      const m = (n as Node & { measured?: Measured }).measured
+      return `${n.id}:${m?.width ?? 0}x${m?.height ?? 0}`
+    })
+    .join('|')
 }
 
 // ── Default edge style ──────────────────────────────────────────────────

--- a/frontend/src/views/PipelineGraph.tsx
+++ b/frontend/src/views/PipelineGraph.tsx
@@ -12,7 +12,7 @@ import {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 
-import { useGraphStore, isValidConnection, TEMPLATES } from '../stores/graph-store'
+import { useGraphStore, isValidConnection, TEMPLATES, measuredSignature } from '../stores/graph-store'
 import { nodeTypes } from '../components/graph/StageNode'
 import { NodeDetailPanel } from '../components/graph/NodeDetailPanel'
 import { NodePalette } from '../components/graph/NodePalette'
@@ -214,6 +214,24 @@ export function PipelineGraph() {
   const [template, setTemplate] = useState('')
   const [showYaml, setShowYaml] = useState(true)
   const applyTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastLayoutSig = useRef<string>('')
+
+  // Once xyflow has measured each node's real DOM size (its `measured`
+  // field), re-run dagre with those sizes so visually larger nodes
+  // get proportional spacing. Guarded by a signature so we only fire
+  // when measurements actually change.
+  useEffect(() => {
+    if (nodes.length === 0) return
+    const sig = measuredSignature(nodes)
+    if (sig === lastLayoutSig.current) return
+    const allMeasured = nodes.every((n) => {
+      const m = (n as { measured?: { width?: number; height?: number } }).measured
+      return m?.width && m.height
+    })
+    if (!allMeasured) return
+    lastLayoutSig.current = sig
+    relayout()
+  }, [nodes, relayout])
 
   // Load default template on first mount if graph is empty
   useEffect(() => {

--- a/frontend/src/views/PostPreprocBuilder.tsx
+++ b/frontend/src/views/PostPreprocBuilder.tsx
@@ -301,6 +301,22 @@ function Inner() {
     )
   }
 
+  const updateSelectedInput = (handle: string, value: string) => {
+    if (!selectedNode) return
+    setNodes((prev) =>
+      prev.map((n) => {
+        if (n.id !== selectedNode.id) return n
+        const params = ((n.data as { params?: Record<string, unknown> }).params ?? {}) as Record<string, unknown>
+        const existing = (params._inputs as Record<string, string> | undefined) ?? {}
+        const next = { ...existing, [handle]: value }
+        return {
+          ...n,
+          data: { ...n.data, params: { ...params, _inputs: next } },
+        }
+      }),
+    )
+  }
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 48px)' }}>
       <div style={{ marginBottom: 12 }}>
@@ -560,10 +576,64 @@ function Inner() {
                 {codeBusy ? 'Loading…' : 'View / edit code'}
               </button>
               <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginBottom: 8 }}>
-                inputs: {selectedMeta.inputs.join(', ') || '—'} · outputs:{' '}
-                {selectedMeta.outputs.join(', ') || '—'}
+                outputs: {selectedMeta.outputs.join(', ') || '—'}
               </div>
+              {selectedMeta.inputs.length > 0 && (
+                <div style={{ marginBottom: 12 }}>
+                  <div
+                    style={{
+                      fontSize: 10,
+                      fontWeight: 700,
+                      color: 'var(--text-secondary)',
+                      textTransform: 'uppercase',
+                      letterSpacing: 1,
+                      marginBottom: 6,
+                    }}
+                  >
+                    Inputs
+                  </div>
+                  {selectedMeta.inputs.map((handle) => {
+                    const incomingEdge = edges.find(
+                      (e) =>
+                        e.target === selectedNode.id &&
+                        (e.targetHandle ?? 'in_file') === handle,
+                    )
+                    const params = (selectedNode.data as { params?: Record<string, unknown> }).params ?? {}
+                    const literal = ((params._inputs as Record<string, string> | undefined) ?? {})[handle] ?? ''
+                    return (
+                      <div key={handle} style={{ marginBottom: 6 }}>
+                        <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>
+                          {handle}
+                        </div>
+                        {incomingEdge ? (
+                          <div
+                            style={{
+                              ...inputStyle,
+                              fontSize: 11,
+                              color: 'var(--accent-cyan)',
+                              background: 'var(--bg-card)',
+                            }}
+                          >
+                            ← from <code>{incomingEdge.source}</code>
+                            <span style={{ color: 'var(--text-secondary)', marginLeft: 6 }}>
+                              ({incomingEdge.sourceHandle ?? 'out_file'})
+                            </span>
+                          </div>
+                        ) : (
+                          <input
+                            style={inputStyle}
+                            placeholder="path to file (e.g. /path/to/in.nii.gz)"
+                            value={literal}
+                            onChange={(e) => updateSelectedInput(handle, e.target.value)}
+                          />
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
               {Object.entries(selectedMeta.params).map(([key, schema]) => {
+                if (key === '_inputs') return null
                 const params = (selectedNode.data as { params?: Record<string, unknown> }).params ?? {}
                 const v = params[key]
                 return (

--- a/frontend/src/views/PostPreprocBuilder.tsx
+++ b/frontend/src/views/PostPreprocBuilder.tsx
@@ -21,11 +21,16 @@ import type {
 import '@xyflow/react/dist/style.css'
 
 import Editor from '@monaco-editor/react'
+import { NipypeNode } from '../components/post_preproc/NipypeNode'
 import {
   fetchNipypeNodes,
   validateGraph,
   startRun,
   getRun,
+  fetchWorkflows,
+  fetchWorkflow,
+  saveWorkflow,
+  deleteWorkflow,
 } from '../api/post-preproc'
 import {
   fetchModuleCode,
@@ -36,7 +41,11 @@ import type {
   NipypeNodeMeta,
   PostPreprocGraph,
   PostPreprocRunHandle,
+  PostPreprocWorkflowSummary,
+  PostPreprocWorkflow,
 } from '../api/types'
+
+const nodeTypes = { nipype: NipypeNode }
 
 const sectionLabel: CSSProperties = {
   fontSize: 11,
@@ -65,6 +74,26 @@ const primaryBtn: CSSProperties = {
   border: 'none',
 }
 
+const modalBackdrop: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  zIndex: 100,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+const modalCard: CSSProperties = {
+  width: 460,
+  maxHeight: '70vh',
+  overflowY: 'auto',
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  borderRadius: 6,
+  padding: 16,
+}
+
 const inputStyle: CSSProperties = {
   padding: '6px 8px',
   fontSize: 12,
@@ -79,21 +108,7 @@ const inputStyle: CSSProperties = {
 let nodeCounter = 1
 const nextId = () => `n${nodeCounter++}`
 
-// Match the Workflows view's preproc-stage color so the eye carries through.
-const NODE_COLOR = '#10b981'
-
-function nodeStyle(): CSSProperties {
-  return {
-    background: `${NODE_COLOR}22`,
-    border: `1px solid ${NODE_COLOR}aa`,
-    color: 'var(--text-primary)',
-    borderRadius: 6,
-    padding: 8,
-    fontSize: 12,
-    fontWeight: 600,
-    minWidth: 140,
-  }
-}
+// (legacy color helper removed; see components/post_preproc/NipypeNode.tsx)
 
 function defaultsForNode(meta: NipypeNodeMeta): Record<string, unknown> {
   const out: Record<string, unknown> = {}
@@ -128,9 +143,21 @@ function Inner() {
   const [codeStatus, setCodeStatus] = useState<string | null>(null)
   const [codeBusy, setCodeBusy] = useState(false)
 
+  const [workflows, setWorkflows] = useState<PostPreprocWorkflowSummary[]>([])
+  const [showSubworkflowPicker, setShowSubworkflowPicker] = useState(false)
+  const [showSaveDialog, setShowSaveDialog] = useState(false)
+  const [showLoadPicker, setShowLoadPicker] = useState(false)
+  const [workflowName, setWorkflowName] = useState('')
+  const [workflowDesc, setWorkflowDesc] = useState('')
+
+  const refreshWorkflows = useCallback(() => {
+    fetchWorkflows().then(setWorkflows).catch((e) => console.warn(e))
+  }, [])
+
   useEffect(() => {
     fetchNipypeNodes().then(setPalette).catch((e) => console.error(e))
-  }, [])
+    refreshWorkflows()
+  }, [refreshWorkflows])
 
   // Poll active run.
   useEffect(() => {
@@ -177,16 +204,137 @@ function Inner() {
       ...prev,
       {
         id,
-        type: 'default',
+        type: 'nipype',
         data: {
           label: `${meta.name} (${id})`,
           nodeType: meta.name,
+          inputs: meta.inputs,
+          outputs: meta.outputs,
           params: defaultsForNode(meta),
+          iterating: false,
         },
-        position: { x: 80 + prev.length * 180, y: 120 },
-        style: nodeStyle(),
+        position: { x: 80 + prev.length * 220, y: 120 },
       },
     ])
+  }
+
+  const addSubworkflowNode = (wf: PostPreprocWorkflow) => {
+    const id = nextId()
+    setNodes((prev) => [
+      ...prev,
+      {
+        id,
+        type: 'nipype',
+        data: {
+          label: `subworkflow:${wf.name} (${id})`,
+          nodeType: 'subworkflow',
+          inputs: Object.keys(wf.inputs ?? {}),
+          outputs: Object.keys(wf.outputs ?? {}),
+          params: { workflow_name: wf.name },
+          iterating: false,
+        },
+        position: { x: 80 + prev.length * 220, y: 120 },
+      },
+    ])
+  }
+
+  const handleSaveWorkflow = async () => {
+    if (!workflowName) return
+    // Auto-derive inputs/outputs: any handle on a node that isn't wired and
+    // has no _inputs literal becomes a workflow-level input. Any output handle
+    // not consumed by a downstream edge becomes a workflow-level output.
+    const inputs: Record<string, { from: string }> = {}
+    const outputs: Record<string, { from: string }> = {}
+    for (const n of nodes) {
+      const meta = (n.data as { inputs?: string[]; outputs?: string[] })
+      const params = (n.data as { params?: Record<string, unknown> }).params ?? {}
+      const literal = (params._inputs as Record<string, string> | undefined) ?? {}
+      for (const h of meta.inputs ?? []) {
+        const wired = edges.some(
+          (e) => e.target === n.id && (e.targetHandle ?? 'in_file') === h,
+        )
+        if (!wired && !literal[h]) {
+          inputs[`${n.id}_${h}`] = { from: `${n.id}.${h}` }
+        }
+      }
+      for (const h of meta.outputs ?? []) {
+        const consumed = edges.some(
+          (e) => e.source === n.id && (e.sourceHandle ?? 'out_file') === h,
+        )
+        if (!consumed) {
+          outputs[`${n.id}_${h}`] = { from: `${n.id}.${h}` }
+        }
+      }
+    }
+    try {
+      await saveWorkflow({
+        name: workflowName,
+        description: workflowDesc,
+        graph: buildGraph(),
+        inputs,
+        outputs,
+      })
+      setShowSaveDialog(false)
+      setWorkflowName('')
+      setWorkflowDesc('')
+      refreshWorkflows()
+    } catch (e) {
+      alert(`save failed: ${e}`)
+    }
+  }
+
+  const handleLoadWorkflow = async (name: string) => {
+    try {
+      const wf = await fetchWorkflow(name)
+      const g = wf.graph
+      // Restore nodes with the right type and input/output handle metadata.
+      const metaByType = new Map(palette.map((m) => [m.name, m]))
+      const newNodes: Node[] = (g.nodes ?? []).map((n) => {
+        const meta = metaByType.get(n.type)
+        const isSubworkflow = n.type === 'subworkflow'
+        const subInputs = isSubworkflow
+          ? Object.keys(wf.inputs ?? {})
+          : meta?.inputs ?? []
+        const subOutputs = isSubworkflow
+          ? Object.keys(wf.outputs ?? {})
+          : meta?.outputs ?? []
+        return {
+          id: n.id,
+          type: 'nipype',
+          data: {
+            label: `${n.type} (${n.id})`,
+            nodeType: n.type,
+            inputs: subInputs,
+            outputs: subOutputs,
+            params: n.data?.params ?? {},
+            iterating: !!(n.data?.params as { _iter?: unknown })?._iter,
+          },
+          position: n.position ?? { x: 0, y: 0 },
+        }
+      })
+      const newEdges: Edge[] = (g.edges ?? []).map((e) => ({
+        id: e.id,
+        source: e.source,
+        target: e.target,
+        sourceHandle: e.sourceHandle ?? 'out_file',
+        targetHandle: e.targetHandle ?? 'in_file',
+      }))
+      setNodes(newNodes)
+      setEdges(newEdges)
+      setShowLoadPicker(false)
+    } catch (e) {
+      alert(`load failed: ${e}`)
+    }
+  }
+
+  const handleAddSubworkflow = async (name: string) => {
+    try {
+      const wf = await fetchWorkflow(name)
+      addSubworkflowNode(wf)
+      setShowSubworkflowPicker(false)
+    } catch (e) {
+      alert(`add failed: ${e}`)
+    }
   }
 
   const buildGraph = (): PostPreprocGraph => ({
@@ -240,8 +388,39 @@ function Inner() {
   const selectedMeta = useMemo(() => {
     if (!selectedNode) return null
     const t = (selectedNode.data as { nodeType?: string }).nodeType
-    return palette.find((p) => p.name === t) ?? null
+    const fromPalette = palette.find((p) => p.name === t) ?? null
+    if (!fromPalette) return null
+    // Subworkflow nodes carry their own inputs/outputs in node.data — overlay them.
+    const data = selectedNode.data as { inputs?: string[]; outputs?: string[] }
+    if (data.inputs && data.outputs) {
+      return { ...fromPalette, inputs: data.inputs, outputs: data.outputs }
+    }
+    return fromPalette
   }, [selectedNode, palette])
+
+  const toggleIterate = () => {
+    if (!selectedNode || !selectedMeta) return
+    setNodes((prev) =>
+      prev.map((n) => {
+        if (n.id !== selectedNode.id) return n
+        const params = ((n.data as { params?: Record<string, unknown> }).params ?? {}) as Record<string, unknown>
+        const isOn = !!params._iter
+        const next = { ...params }
+        if (isOn) {
+          delete next._iter
+        } else {
+          next._iter = {
+            handle: selectedMeta.inputs[0] ?? 'in_file',
+            from_source_manifest: true,
+          }
+        }
+        return {
+          ...n,
+          data: { ...n.data, params: next, iterating: !isOn },
+        }
+      }),
+    )
+  }
 
   const openCode = async () => {
     if (!selectedMeta) return
@@ -364,6 +543,18 @@ function Inner() {
         </button>
       </div>
 
+      <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+        <button style={btn} onClick={() => setShowSaveDialog(true)} disabled={nodes.length === 0}>
+          Save workflow
+        </button>
+        <button style={btn} onClick={() => { refreshWorkflows(); setShowLoadPicker(true) }}>
+          Load workflow
+        </button>
+        <button style={btn} onClick={() => { refreshWorkflows(); setShowSubworkflowPicker(true) }}>
+          + Subworkflow
+        </button>
+      </div>
+
       {validation && (
         <div
           style={{
@@ -418,6 +609,85 @@ function Inner() {
               {runErr}
             </pre>
           )}
+        </div>
+      )}
+
+      {/* Save workflow modal */}
+      {showSaveDialog && (
+        <div style={modalBackdrop} onClick={() => setShowSaveDialog(false)}>
+          <div style={modalCard} onClick={(e) => e.stopPropagation()}>
+            <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 8 }}>Save workflow</div>
+            <input
+              style={{ ...inputStyle, marginBottom: 6 }}
+              placeholder="name (e.g. smooth_then_mask)"
+              value={workflowName}
+              onChange={(e) => setWorkflowName(e.target.value)}
+            />
+            <input
+              style={{ ...inputStyle, marginBottom: 8 }}
+              placeholder="description (optional)"
+              value={workflowDesc}
+              onChange={(e) => setWorkflowDesc(e.target.value)}
+            />
+            <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 8 }}>
+              Free input/output handles will be auto-exposed as workflow inputs/outputs.
+            </div>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button style={btn} onClick={() => setShowSaveDialog(false)}>Cancel</button>
+              <button style={primaryBtn} onClick={handleSaveWorkflow} disabled={!workflowName}>Save</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Load workflow picker */}
+      {showLoadPicker && (
+        <div style={modalBackdrop} onClick={() => setShowLoadPicker(false)}>
+          <div style={modalCard} onClick={(e) => e.stopPropagation()}>
+            <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 8 }}>Load workflow</div>
+            {workflows.length === 0 && (
+              <div style={{ fontSize: 11, color: 'var(--text-secondary)' }}>None saved yet.</div>
+            )}
+            {workflows.map((w) => (
+              <button
+                key={w.name}
+                style={{ ...btn, width: '100%', textAlign: 'left', marginBottom: 4 }}
+                onClick={() => handleLoadWorkflow(w.name)}
+              >
+                <strong>{w.name}</strong>
+                <span style={{ marginLeft: 6, color: 'var(--text-secondary)', fontSize: 10 }}>
+                  ({w.n_nodes} nodes · in: {w.inputs.length} · out: {w.outputs.length})
+                </span>
+                {w.description && (
+                  <div style={{ fontSize: 10, color: 'var(--text-secondary)' }}>{w.description}</div>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Subworkflow picker */}
+      {showSubworkflowPicker && (
+        <div style={modalBackdrop} onClick={() => setShowSubworkflowPicker(false)}>
+          <div style={modalCard} onClick={(e) => e.stopPropagation()}>
+            <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 8 }}>Pick a saved workflow to embed</div>
+            {workflows.length === 0 && (
+              <div style={{ fontSize: 11, color: 'var(--text-secondary)' }}>None saved yet.</div>
+            )}
+            {workflows.map((w) => (
+              <button
+                key={w.name}
+                style={{ ...btn, width: '100%', textAlign: 'left', marginBottom: 4 }}
+                onClick={() => handleAddSubworkflow(w.name)}
+              >
+                <strong>{w.name}</strong>
+                <span style={{ marginLeft: 6, color: 'var(--text-secondary)', fontSize: 10 }}>
+                  in: {w.inputs.join(', ') || '—'} · out: {w.outputs.join(', ') || '—'}
+                </span>
+              </button>
+            ))}
+          </div>
         </div>
       )}
 
@@ -540,6 +810,7 @@ function Inner() {
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}
             onNodeClick={(_, n) => setSelected(n.id)}
+            nodeTypes={nodeTypes}
             fitView
           >
             <Background />
@@ -571,10 +842,31 @@ function Inner() {
               <button
                 style={{ ...btn, marginBottom: 8, width: '100%' }}
                 onClick={openCode}
-                disabled={codeBusy}
+                disabled={codeBusy || selectedMeta.name === 'subworkflow'}
+                title={selectedMeta.name === 'subworkflow' ? 'Subworkflows are stored as YAML, not Python' : ''}
               >
                 {codeBusy ? 'Loading…' : 'View / edit code'}
               </button>
+              {selectedMeta.inputs.length > 0 && (
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    fontSize: 11,
+                    color: 'var(--text-secondary)',
+                    marginBottom: 8,
+                    cursor: 'pointer',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={!!((selectedNode.data as { params?: Record<string, unknown> }).params?._iter)}
+                    onChange={toggleIterate}
+                  />
+                  Iterate over runs from source manifest
+                </label>
+              )}
               <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginBottom: 8 }}>
                 outputs: {selectedMeta.outputs.join(', ') || '—'}
               </div>

--- a/frontend/src/views/PostPreprocBuilder.tsx
+++ b/frontend/src/views/PostPreprocBuilder.tsx
@@ -1,0 +1,451 @@
+/** PostPreprocBuilder — compose a post-fmriprep nipype-style graph. */
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+} from '@xyflow/react'
+import type {
+  Edge,
+  Node,
+  NodeChange,
+  EdgeChange,
+  Connection,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+
+import {
+  fetchNipypeNodes,
+  validateGraph,
+  startRun,
+  getRun,
+} from '../api/post-preproc'
+import type {
+  NipypeNodeMeta,
+  PostPreprocGraph,
+  PostPreprocRunHandle,
+} from '../api/types'
+
+const sectionLabel: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  color: 'var(--text-secondary)',
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  marginBottom: 8,
+}
+
+const btn: CSSProperties = {
+  padding: '6px 12px',
+  fontSize: 12,
+  fontWeight: 600,
+  borderRadius: 4,
+  border: '1px solid var(--border)',
+  background: 'var(--bg-secondary)',
+  color: 'var(--text-primary)',
+  cursor: 'pointer',
+}
+
+const primaryBtn: CSSProperties = {
+  ...btn,
+  background: 'var(--accent-cyan)',
+  color: '#000',
+  border: 'none',
+}
+
+const inputStyle: CSSProperties = {
+  padding: '6px 8px',
+  fontSize: 12,
+  border: '1px solid var(--border)',
+  borderRadius: 4,
+  background: 'var(--bg-secondary)',
+  color: 'var(--text-primary)',
+  width: '100%',
+  boxSizing: 'border-box',
+}
+
+let nodeCounter = 1
+const nextId = () => `n${nodeCounter++}`
+
+function defaultsForNode(meta: NipypeNodeMeta): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(meta.params)) {
+    if (v && typeof v === 'object' && 'default' in v) out[k] = v.default
+  }
+  return out
+}
+
+export function PostPreprocBuilder() {
+  return (
+    <ReactFlowProvider>
+      <Inner />
+    </ReactFlowProvider>
+  )
+}
+
+function Inner() {
+  const [palette, setPalette] = useState<NipypeNodeMeta[]>([])
+  const [nodes, setNodes] = useState<Node[]>([])
+  const [edges, setEdges] = useState<Edge[]>([])
+  const [selected, setSelected] = useState<string | null>(null)
+  const [subject, setSubject] = useState('')
+  const [sourceManifest, setSourceManifest] = useState('')
+  const [outputDir, setOutputDir] = useState('./testing/post_preproc')
+  const [validation, setValidation] = useState<string[] | null>(null)
+  const [run, setRun] = useState<PostPreprocRunHandle | null>(null)
+  const [runErr, setRunErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchNipypeNodes().then(setPalette).catch((e) => console.error(e))
+  }, [])
+
+  // Poll active run.
+  useEffect(() => {
+    if (!run || run.status === 'done' || run.status === 'failed') return
+    const t = setInterval(async () => {
+      try {
+        const r = await getRun(run.run_id)
+        setRun(r as PostPreprocRunHandle)
+        if (r.status === 'failed' && r.error) setRunErr(r.error)
+      } catch (e) {
+        console.warn(e)
+      }
+    }, 1500)
+    return () => clearInterval(t)
+  }, [run])
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => setNodes((n) => applyNodeChanges(changes, n)),
+    [],
+  )
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => setEdges((e) => applyEdgeChanges(changes, e)),
+    [],
+  )
+  const onConnect = useCallback(
+    (c: Connection) =>
+      setEdges((e) =>
+        addEdge(
+          {
+            ...c,
+            id: `e-${c.source}-${c.target}-${Date.now()}`,
+            sourceHandle: c.sourceHandle ?? 'out_file',
+            targetHandle: c.targetHandle ?? 'in_file',
+          },
+          e,
+        ),
+      ),
+    [],
+  )
+
+  const addNode = (meta: NipypeNodeMeta) => {
+    const id = nextId()
+    setNodes((prev) => [
+      ...prev,
+      {
+        id,
+        type: 'default',
+        data: {
+          label: `${meta.name} (${id})`,
+          nodeType: meta.name,
+          params: defaultsForNode(meta),
+        },
+        position: { x: 80 + prev.length * 180, y: 120 },
+      },
+    ])
+  }
+
+  const buildGraph = (): PostPreprocGraph => ({
+    nodes: nodes.map((n) => ({
+      id: n.id,
+      type: (n.data as { nodeType?: string }).nodeType ?? 'unknown',
+      data: { params: (n.data as { params?: Record<string, unknown> }).params ?? {} },
+      position: n.position,
+    })),
+    edges: edges.map((e) => ({
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      sourceHandle: e.sourceHandle ?? 'out_file',
+      targetHandle: e.targetHandle ?? 'in_file',
+    })),
+  })
+
+  const handleValidate = async () => {
+    try {
+      const result = await validateGraph(buildGraph())
+      setValidation(result.errors)
+    } catch (e) {
+      setValidation([String(e)])
+    }
+  }
+
+  const handleRun = async () => {
+    setRunErr(null)
+    if (!subject || !sourceManifest) {
+      setRunErr('subject and source_manifest_path are required')
+      return
+    }
+    try {
+      const handle = await startRun({
+        subject,
+        source_manifest_path: sourceManifest,
+        graph: buildGraph(),
+        output_dir: outputDir,
+      })
+      setRun(handle)
+    } catch (e) {
+      setRunErr(String(e))
+    }
+  }
+
+  const selectedNode = useMemo(
+    () => nodes.find((n) => n.id === selected) ?? null,
+    [nodes, selected],
+  )
+  const selectedMeta = useMemo(() => {
+    if (!selectedNode) return null
+    const t = (selectedNode.data as { nodeType?: string }).nodeType
+    return palette.find((p) => p.name === t) ?? null
+  }, [selectedNode, palette])
+
+  const updateSelectedParam = (key: string, value: unknown) => {
+    if (!selectedNode) return
+    setNodes((prev) =>
+      prev.map((n) =>
+        n.id === selectedNode.id
+          ? {
+              ...n,
+              data: {
+                ...n.data,
+                params: {
+                  ...((n.data as { params?: Record<string, unknown> }).params ?? {}),
+                  [key]: value,
+                },
+              },
+            }
+          : n,
+      ),
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 48px)' }}>
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 4 }}>
+          Post-preprocessing (nipype)
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+          Compose nipype-style nodes that consume a preproc manifest and emit
+          new derivatives. Drag from the palette → connect → run.
+        </div>
+      </div>
+
+      {/* Top bar */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 2fr 2fr auto auto',
+          gap: 8,
+          marginBottom: 8,
+        }}
+      >
+        <input
+          placeholder="subject (e.g. sub01)"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          style={inputStyle}
+        />
+        <input
+          placeholder="source preproc_manifest.json path"
+          value={sourceManifest}
+          onChange={(e) => setSourceManifest(e.target.value)}
+          style={inputStyle}
+        />
+        <input
+          placeholder="output_dir"
+          value={outputDir}
+          onChange={(e) => setOutputDir(e.target.value)}
+          style={inputStyle}
+        />
+        <button style={btn} onClick={handleValidate}>
+          Validate
+        </button>
+        <button style={primaryBtn} onClick={handleRun}>
+          Run
+        </button>
+      </div>
+
+      {validation && (
+        <div
+          style={{
+            padding: 8,
+            marginBottom: 8,
+            border: '1px solid var(--border)',
+            borderRadius: 4,
+            background: 'var(--bg-card)',
+            fontSize: 12,
+            color: validation.length === 0 ? 'var(--accent-green)' : 'var(--accent-red)',
+          }}
+        >
+          {validation.length === 0
+            ? '✓ Graph is valid'
+            : validation.map((v, i) => <div key={i}>✗ {v}</div>)}
+        </div>
+      )}
+
+      {run && (
+        <div
+          style={{
+            padding: 8,
+            marginBottom: 8,
+            border: '1px solid var(--border)',
+            borderRadius: 4,
+            background: 'var(--bg-card)',
+            fontSize: 12,
+          }}
+        >
+          run <code>{run.run_id}</code> · status:{' '}
+          <strong
+            style={{
+              color:
+                run.status === 'done'
+                  ? 'var(--accent-green)'
+                  : run.status === 'failed'
+                  ? 'var(--accent-red)'
+                  : 'var(--accent-yellow)',
+            }}
+          >
+            {run.status}
+          </strong>
+          {runErr && (
+            <pre
+              style={{
+                marginTop: 6,
+                fontSize: 11,
+                whiteSpace: 'pre-wrap',
+                color: 'var(--accent-red)',
+              }}
+            >
+              {runErr}
+            </pre>
+          )}
+        </div>
+      )}
+
+      {/* Body: palette | canvas | params */}
+      <div style={{ display: 'grid', gridTemplateColumns: '200px 1fr 280px', gap: 8, flex: 1, minHeight: 0 }}>
+        {/* Palette */}
+        <div
+          style={{
+            border: '1px solid var(--border)',
+            borderRadius: 4,
+            background: 'var(--bg-secondary)',
+            padding: 8,
+            overflowY: 'auto',
+          }}
+        >
+          <div style={sectionLabel}>Palette</div>
+          {palette.map((m) => (
+            <button
+              key={m.name}
+              style={{ ...btn, width: '100%', marginBottom: 4, textAlign: 'left' }}
+              onClick={() => addNode(m)}
+              title={m.docstring}
+            >
+              {m.name}
+            </button>
+          ))}
+        </div>
+
+        {/* Canvas */}
+        <div
+          style={{
+            border: '1px solid var(--border)',
+            borderRadius: 4,
+            background: 'var(--bg-secondary)',
+            minHeight: 0,
+          }}
+        >
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            onNodeClick={(_, n) => setSelected(n.id)}
+            fitView
+          >
+            <Background />
+            <Controls />
+          </ReactFlow>
+        </div>
+
+        {/* Param editor */}
+        <div
+          style={{
+            border: '1px solid var(--border)',
+            borderRadius: 4,
+            background: 'var(--bg-secondary)',
+            padding: 8,
+            overflowY: 'auto',
+          }}
+        >
+          <div style={sectionLabel}>Parameters</div>
+          {!selectedNode && (
+            <div style={{ fontSize: 11, color: 'var(--text-secondary)' }}>
+              Click a node on the canvas.
+            </div>
+          )}
+          {selectedNode && selectedMeta && (
+            <div>
+              <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8 }}>
+                {selectedMeta.name} <code style={{ color: 'var(--text-secondary)' }}>{selectedNode.id}</code>
+              </div>
+              <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginBottom: 8 }}>
+                inputs: {selectedMeta.inputs.join(', ') || '—'} · outputs:{' '}
+                {selectedMeta.outputs.join(', ') || '—'}
+              </div>
+              {Object.entries(selectedMeta.params).map(([key, schema]) => {
+                const params = (selectedNode.data as { params?: Record<string, unknown> }).params ?? {}
+                const v = params[key]
+                return (
+                  <div key={key} style={{ marginBottom: 8 }}>
+                    <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginBottom: 2 }}>
+                      {key} <span style={{ opacity: 0.6 }}>({schema.type})</span>
+                    </div>
+                    <input
+                      style={inputStyle}
+                      value={v === undefined || v === null ? '' : String(v)}
+                      onChange={(e) => {
+                        const raw = e.target.value
+                        const coerced =
+                          schema.type === 'float' || schema.type === 'int'
+                            ? raw === ''
+                              ? ''
+                              : Number(raw)
+                            : raw
+                        updateSelectedParam(key, coerced)
+                      }}
+                    />
+                    {schema.description && (
+                      <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginTop: 2 }}>
+                        {schema.description}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/views/PostPreprocBuilder.tsx
+++ b/frontend/src/views/PostPreprocBuilder.tsx
@@ -20,12 +20,18 @@ import type {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 
+import Editor from '@monaco-editor/react'
 import {
   fetchNipypeNodes,
   validateGraph,
   startRun,
   getRun,
 } from '../api/post-preproc'
+import {
+  fetchModuleCode,
+  saveModuleCode,
+  reloadModule,
+} from '../api/client'
 import type {
   NipypeNodeMeta,
   PostPreprocGraph,
@@ -73,6 +79,22 @@ const inputStyle: CSSProperties = {
 let nodeCounter = 1
 const nextId = () => `n${nodeCounter++}`
 
+// Match the Workflows view's preproc-stage color so the eye carries through.
+const NODE_COLOR = '#10b981'
+
+function nodeStyle(): CSSProperties {
+  return {
+    background: `${NODE_COLOR}22`,
+    border: `1px solid ${NODE_COLOR}aa`,
+    color: 'var(--text-primary)',
+    borderRadius: 6,
+    padding: 8,
+    fontSize: 12,
+    fontWeight: 600,
+    minWidth: 140,
+  }
+}
+
 function defaultsForNode(meta: NipypeNodeMeta): Record<string, unknown> {
   const out: Record<string, unknown> = {}
   for (const [k, v] of Object.entries(meta.params)) {
@@ -100,6 +122,11 @@ function Inner() {
   const [validation, setValidation] = useState<string[] | null>(null)
   const [run, setRun] = useState<PostPreprocRunHandle | null>(null)
   const [runErr, setRunErr] = useState<string | null>(null)
+  const [codeOpen, setCodeOpen] = useState(false)
+  const [codeText, setCodeText] = useState('')
+  const [codePath, setCodePath] = useState('')
+  const [codeStatus, setCodeStatus] = useState<string | null>(null)
+  const [codeBusy, setCodeBusy] = useState(false)
 
   useEffect(() => {
     fetchNipypeNodes().then(setPalette).catch((e) => console.error(e))
@@ -157,6 +184,7 @@ function Inner() {
           params: defaultsForNode(meta),
         },
         position: { x: 80 + prev.length * 180, y: 120 },
+        style: nodeStyle(),
       },
     ])
   }
@@ -214,6 +242,44 @@ function Inner() {
     const t = (selectedNode.data as { nodeType?: string }).nodeType
     return palette.find((p) => p.name === t) ?? null
   }, [selectedNode, palette])
+
+  const openCode = async () => {
+    if (!selectedMeta) return
+    setCodeBusy(true)
+    setCodeStatus(null)
+    try {
+      const r = await fetchModuleCode('nipype_nodes', selectedMeta.name)
+      setCodeText(r.code)
+      setCodePath(r.path)
+      setCodeOpen(true)
+    } catch (e) {
+      setCodeStatus(`load failed: ${e}`)
+    } finally {
+      setCodeBusy(false)
+    }
+  }
+
+  const saveCode = async () => {
+    if (!selectedMeta) return
+    setCodeBusy(true)
+    setCodeStatus(null)
+    try {
+      await saveModuleCode('nipype_nodes', selectedMeta.name, codeText)
+      const r = await reloadModule('nipype_nodes', selectedMeta.name)
+      setCodeStatus(r.reloaded ? '✓ saved & reloaded' : '✓ saved')
+      // Refresh palette so updated PARAM_SCHEMA / IO appears.
+      try {
+        const fresh = await fetchNipypeNodes()
+        setPalette(fresh)
+      } catch {
+        /* ignore */
+      }
+    } catch (e) {
+      setCodeStatus(`save failed: ${e}`)
+    } finally {
+      setCodeBusy(false)
+    }
+  }
 
   const updateSelectedParam = (key: string, value: unknown) => {
     if (!selectedNode) return
@@ -339,6 +405,84 @@ function Inner() {
         </div>
       )}
 
+      {/* Code editor modal */}
+      {codeOpen && selectedMeta && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.65)',
+            zIndex: 100,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          onClick={() => setCodeOpen(false)}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: '90vw',
+              height: '85vh',
+              background: 'var(--bg-card)',
+              border: '1px solid var(--border)',
+              borderRadius: 6,
+              padding: 12,
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                marginBottom: 8,
+              }}
+            >
+              <div style={{ fontSize: 13, fontWeight: 700 }}>
+                {selectedMeta.name}
+              </div>
+              <code style={{ fontSize: 11, color: 'var(--text-secondary)' }}>
+                {codePath}
+              </code>
+              <div style={{ flex: 1 }} />
+              {codeStatus && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: codeStatus.startsWith('✓')
+                      ? 'var(--accent-green)'
+                      : 'var(--accent-red)',
+                  }}
+                >
+                  {codeStatus}
+                </span>
+              )}
+              <button style={primaryBtn} onClick={saveCode} disabled={codeBusy}>
+                {codeBusy ? 'Saving…' : 'Save & reload'}
+              </button>
+              <button style={btn} onClick={() => setCodeOpen(false)}>
+                Close
+              </button>
+            </div>
+            <div style={{ flex: 1, minHeight: 0, border: '1px solid var(--border)', borderRadius: 4 }}>
+              <Editor
+                language="python"
+                theme="vs-dark"
+                value={codeText}
+                onChange={(v) => setCodeText(v ?? '')}
+                options={{
+                  minimap: { enabled: false },
+                  fontSize: 12,
+                  scrollBeyondLastLine: false,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Body: palette | canvas | params */}
       <div style={{ display: 'grid', gridTemplateColumns: '200px 1fr 280px', gap: 8, flex: 1, minHeight: 0 }}>
         {/* Palette */}
@@ -408,6 +552,13 @@ function Inner() {
               <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8 }}>
                 {selectedMeta.name} <code style={{ color: 'var(--text-secondary)' }}>{selectedNode.id}</code>
               </div>
+              <button
+                style={{ ...btn, marginBottom: 8, width: '100%' }}
+                onClick={openCode}
+                disabled={codeBusy}
+              >
+                {codeBusy ? 'Loading…' : 'View / edit code'}
+              </button>
               <div style={{ fontSize: 10, color: 'var(--text-secondary)', marginBottom: 8 }}>
                 inputs: {selectedMeta.inputs.join(', ') || '—'} · outputs:{' '}
                 {selectedMeta.outputs.join(', ') || '—'}

--- a/frontend/src/views/QCReviews.tsx
+++ b/frontend/src/views/QCReviews.tsx
@@ -1,0 +1,248 @@
+/** Cross-dataset list of structural-QC reviews.
+ *
+ * One row per (dataset, subject) review. Filter by status, click a row
+ * to open the StructuralQCModal for that subject.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+import { fetchAllReviews } from '../api/structural-qc'
+import type { StructuralQCReview, StructuralQCStatus } from '../api/types'
+import { StructuralQCModal } from '../components/workflow/StructuralQCModal'
+
+const STATUSES: { value: StructuralQCStatus | 'all'; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'needs_edits', label: 'Needs edits' },
+  { value: 'rejected', label: 'Rejected' },
+]
+
+const STATUS_COLOR: Record<StructuralQCStatus, string> = {
+  pending: 'var(--text-secondary)',
+  approved: 'var(--accent-green)',
+  needs_edits: 'var(--accent-yellow)',
+  rejected: 'var(--accent-red)',
+}
+
+const pageTitle: CSSProperties = {
+  fontSize: 22,
+  fontWeight: 700,
+  color: 'var(--text-primary)',
+  marginBottom: 4,
+}
+
+const pageDesc: CSSProperties = {
+  fontSize: 12,
+  color: 'var(--text-secondary)',
+  marginBottom: 16,
+}
+
+const filterRow: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 8,
+  marginBottom: 12,
+}
+
+const filterBtn = (active: boolean): CSSProperties => ({
+  padding: '4px 10px',
+  fontSize: 11,
+  fontWeight: 600,
+  borderRadius: 4,
+  border: '1px solid var(--border)',
+  background: active ? 'var(--accent-cyan)' : 'var(--bg-secondary)',
+  color: active ? '#000' : 'var(--text-primary)',
+  cursor: 'pointer',
+})
+
+const tableStyle: CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: 12,
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  borderRadius: 6,
+  overflow: 'hidden',
+}
+
+const thStyle: CSSProperties = {
+  textAlign: 'left',
+  padding: '8px 12px',
+  background: 'var(--bg-secondary)',
+  color: 'var(--text-secondary)',
+  borderBottom: '1px solid var(--border)',
+  fontSize: 10,
+  fontWeight: 700,
+  letterSpacing: 0.5,
+  textTransform: 'uppercase',
+}
+
+const tdStyle: CSSProperties = {
+  padding: '10px 12px',
+  borderBottom: '1px solid var(--border)',
+  color: 'var(--text-primary)',
+}
+
+const trClickable: CSSProperties = {
+  cursor: 'pointer',
+}
+
+function StatusPill({ status }: { status: StructuralQCStatus }) {
+  const color = STATUS_COLOR[status]
+  const label = status.replace('_', ' ')
+  return (
+    <span
+      style={{
+        fontSize: 10,
+        padding: '2px 8px',
+        borderRadius: 8,
+        background: status === 'pending' ? 'transparent' : `${color}22`,
+        color,
+        border: `1px solid ${color}66`,
+        textTransform: 'uppercase',
+        letterSpacing: 0.4,
+        fontWeight: 700,
+      }}
+    >
+      {label}
+    </span>
+  )
+}
+
+
+export function QCReviews() {
+  const [reviews, setReviews] = useState<StructuralQCReview[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState<StructuralQCStatus | 'all'>('all')
+  const [modalSubject, setModalSubject] = useState<string | null>(null)
+
+  const reload = () => {
+    setLoading(true)
+    setError(null)
+    fetchAllReviews()
+      .then((r) => setReviews(r))
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false))
+  }
+  useEffect(() => {
+    reload()
+  }, [])
+
+  const counts = useMemo(() => {
+    const c: Record<StructuralQCStatus, number> = {
+      pending: 0, approved: 0, needs_edits: 0, rejected: 0,
+    }
+    for (const r of reviews) c[r.status] = (c[r.status] || 0) + 1
+    return c
+  }, [reviews])
+
+  const filtered = useMemo(() => {
+    if (filter === 'all') return reviews
+    return reviews.filter((r) => r.status === filter)
+  }, [reviews, filter])
+
+  return (
+    <div>
+      <div style={pageTitle}>Structural QC reviews</div>
+      <div style={pageDesc}>
+        Reviewer sign-offs across all subjects, filed under
+        <code style={{ marginLeft: 4 }}>~/.fmriflow/structural_qc/</code>.
+        Click a row to reopen the panel for that subject.
+      </div>
+
+      <div style={filterRow}>
+        {STATUSES.map((s) => {
+          const count = s.value === 'all'
+            ? reviews.length
+            : counts[s.value as StructuralQCStatus]
+          return (
+            <button
+              key={s.value}
+              style={filterBtn(filter === s.value)}
+              onClick={() => setFilter(s.value)}
+            >
+              {s.label} ({count})
+            </button>
+          )
+        })}
+        <span style={{ flex: 1 }} />
+        <button
+          style={filterBtn(false)}
+          onClick={reload}
+          disabled={loading}
+        >
+          {loading ? '…' : 'Reload'}
+        </button>
+      </div>
+
+      {error && (
+        <div style={{ color: 'var(--accent-red)', fontSize: 12, marginBottom: 8 }}>
+          {error}
+        </div>
+      )}
+
+      <table style={tableStyle}>
+        <thead>
+          <tr>
+            <th style={thStyle}>Status</th>
+            <th style={thStyle}>Dataset</th>
+            <th style={thStyle}>Subject</th>
+            <th style={thStyle}>Reviewer</th>
+            <th style={thStyle}>Saved</th>
+            <th style={thStyle}>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.length === 0 && !loading && (
+            <tr>
+              <td style={{ ...tdStyle, color: 'var(--text-secondary)' }} colSpan={6}>
+                No reviews{filter !== 'all' ? ` with status “${filter}”` : ''} yet.
+              </td>
+            </tr>
+          )}
+          {filtered.map((r) => (
+            <tr
+              key={`${r.dataset}|${r.subject}`}
+              style={trClickable}
+              onClick={() => setModalSubject(r.subject)}
+            >
+              <td style={tdStyle}><StatusPill status={r.status} /></td>
+              <td style={tdStyle}>{r.dataset}</td>
+              <td style={{ ...tdStyle, fontWeight: 600 }}>sub-{r.subject}</td>
+              <td style={tdStyle}>{r.reviewer || <span style={{ color: 'var(--text-secondary)' }}>—</span>}</td>
+              <td style={{ ...tdStyle, fontSize: 11, color: 'var(--text-secondary)' }}>
+                {r.timestamp ? new Date(r.timestamp).toLocaleString() : '—'}
+              </td>
+              <td
+                style={{
+                  ...tdStyle,
+                  fontSize: 11,
+                  color: 'var(--text-secondary)',
+                  maxWidth: 360,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+                title={r.notes}
+              >
+                {r.notes || '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {modalSubject && (
+        <StructuralQCModal
+          subject={modalSubject}
+          onClose={() => {
+            setModalSubject(null)
+            reload()
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -17,11 +17,13 @@ import {
   deleteWorkflowRun,
   fetchInFlightRun,
   fetchPreprocRunLive,
+  fetchPreprocRun,
 } from '../api/client'
 import type { AnalysisInnerStage, NipypeStatusBlock } from '../api/types'
 import { WorkflowGraph } from '../components/workflow/WorkflowGraph'
 import { StageLogModal } from '../components/workflow/StageLogModal'
 import { NipypeGraphModal } from '../components/workflow/NipypeGraphModal'
+import { StructuralQCModal } from '../components/workflow/StructuralQCModal'
 import { LiveStageLog } from '../components/workflow/LiveStageLog'
 import { useDialog } from '../components/common/Dialog'
 
@@ -289,6 +291,7 @@ export function WorkflowsView() {
   const [analysisInner, setAnalysisInner] = useState<{ runId: string; stages: AnalysisInnerStage[] } | null>(null)
   const [preprocNipype, setPreprocNipype] = useState<{ runId: string; block: NipypeStatusBlock } | null>(null)
   const [nipypeGraph, setNipypeGraph] = useState<{ runId: string; isRunning: boolean } | null>(null)
+  const [structuralQC, setStructuralQC] = useState<{ subject: string } | null>(null)
   const [editing, setEditing] = useState(false)
   const [yamlDraft, setYamlDraft] = useState('')
   const [saving, setSaving] = useState(false)
@@ -586,6 +589,15 @@ export function WorkflowsView() {
                 isRunning: s.status === 'running',
               })
             }}
+            onOpenStructuralQC={async (s) => {
+              if (s.stage !== 'preproc' || !s.run_id) return
+              try {
+                const detail = await fetchPreprocRun(s.run_id)
+                setStructuralQC({ subject: detail.subject })
+              } catch (e) {
+                alert(`Could not load preproc run: ${e}`)
+              }
+            }}
           />
           <LiveStageLog
             stages={selectedRun.stages}
@@ -608,6 +620,13 @@ export function WorkflowsView() {
           runId={nipypeGraph.runId}
           isRunning={nipypeGraph.isRunning}
           onClose={() => setNipypeGraph(null)}
+        />
+      )}
+
+      {structuralQC && (
+        <StructuralQCModal
+          subject={structuralQC.subject}
+          onClose={() => setStructuralQC(null)}
         />
       )}
 

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -21,6 +21,7 @@ import {
 import type { AnalysisInnerStage, NipypeStatusBlock } from '../api/types'
 import { WorkflowGraph } from '../components/workflow/WorkflowGraph'
 import { StageLogModal } from '../components/workflow/StageLogModal'
+import { NipypeGraphModal } from '../components/workflow/NipypeGraphModal'
 import { LiveStageLog } from '../components/workflow/LiveStageLog'
 import { useDialog } from '../components/common/Dialog'
 
@@ -287,6 +288,7 @@ export function WorkflowsView() {
   const [logStage, setLogStage] = useState<{ stage: string; runId: string; subject?: string } | null>(null)
   const [analysisInner, setAnalysisInner] = useState<{ runId: string; stages: AnalysisInnerStage[] } | null>(null)
   const [preprocNipype, setPreprocNipype] = useState<{ runId: string; block: NipypeStatusBlock } | null>(null)
+  const [nipypeGraph, setNipypeGraph] = useState<{ runId: string; isRunning: boolean } | null>(null)
   const [editing, setEditing] = useState(false)
   const [yamlDraft, setYamlDraft] = useState('')
   const [saving, setSaving] = useState(false)
@@ -577,6 +579,14 @@ export function WorkflowsView() {
               if (!s.run_id) return
               setLogStage({ stage: s.stage, runId: s.run_id })
             }}
+            onStageDoubleClick={(s) => {
+              if (s.stage !== 'preproc' || !s.run_id) return
+              if (!s.nipype_status || s.nipype_status.counts.total_seen === 0) return
+              setNipypeGraph({
+                runId: s.run_id,
+                isRunning: s.status === 'running',
+              })
+            }}
           />
           <LiveStageLog
             stages={selectedRun.stages}
@@ -591,6 +601,14 @@ export function WorkflowsView() {
           runId={logStage.runId}
           subjectHint={logStage.subject}
           onClose={() => setLogStage(null)}
+        />
+      )}
+
+      {nipypeGraph && (
+        <NipypeGraphModal
+          runId={nipypeGraph.runId}
+          isRunning={nipypeGraph.isRunning}
+          onClose={() => setNipypeGraph(null)}
         />
       )}
 

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -579,9 +579,8 @@ export function WorkflowsView() {
               if (!s.run_id) return
               setLogStage({ stage: s.stage, runId: s.run_id })
             }}
-            onStageDoubleClick={(s) => {
+            onOpenNipypeDag={(s) => {
               if (s.stage !== 'preproc' || !s.run_id) return
-              if (!s.nipype_status || s.nipype_status.counts.total_seen === 0) return
               setNipypeGraph({
                 runId: s.run_id,
                 isRunning: s.status === 'running',

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -16,8 +16,9 @@ import {
   cancelWorkflowRun,
   deleteWorkflowRun,
   fetchInFlightRun,
+  fetchPreprocRunLive,
 } from '../api/client'
-import type { AnalysisInnerStage } from '../api/types'
+import type { AnalysisInnerStage, NipypeStatusBlock } from '../api/types'
 import { WorkflowGraph } from '../components/workflow/WorkflowGraph'
 import { StageLogModal } from '../components/workflow/StageLogModal'
 import { LiveStageLog } from '../components/workflow/LiveStageLog'
@@ -285,6 +286,7 @@ export function WorkflowsView() {
   const [selectedRun, setSelectedRun] = useState<WorkflowRunSummary | null>(null)
   const [logStage, setLogStage] = useState<{ stage: string; runId: string; subject?: string } | null>(null)
   const [analysisInner, setAnalysisInner] = useState<{ runId: string; stages: AnalysisInnerStage[] } | null>(null)
+  const [preprocNipype, setPreprocNipype] = useState<{ runId: string; block: NipypeStatusBlock } | null>(null)
   const [editing, setEditing] = useState(false)
   const [yamlDraft, setYamlDraft] = useState('')
   const [saving, setSaving] = useState(false)
@@ -478,17 +480,48 @@ export function WorkflowsView() {
   }, [selectedRun?.stages.find((s) => s.stage === 'analysis')?.run_id,
       selectedRun?.stages.find((s) => s.stage === 'analysis')?.status])
 
-  // Merge fetched inner_stages onto the analysis stage before handing
-  // to WorkflowGraph so the custom node renders them inline.
+  // Fetch the preproc stage's nipype-node status while it's the active
+  // (running / done / failed) stage. Same cadence as analysis. The
+  // /live endpoint includes the parsed JSONL even after the run ends,
+  // so the strip remains populated for completed / failed runs.
+  useEffect(() => {
+    const preprocStage = selectedRun?.stages.find((s) => s.stage === 'preproc')
+    const rid = preprocStage?.run_id
+    if (!rid || !preprocStage || preprocStage.status === 'pending') {
+      setPreprocNipype(null)
+      return
+    }
+    let cancelled = false
+    async function load() {
+      try {
+        const detail = await fetchPreprocRunLive(rid!)
+        if (!cancelled && detail.nipype_status) {
+          setPreprocNipype({ runId: rid!, block: detail.nipype_status })
+        }
+      } catch { /* ignore */ }
+    }
+    load()
+    if (preprocStage.status !== 'running') return () => { cancelled = true }
+    const id = setInterval(load, 2000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [selectedRun?.stages.find((s) => s.stage === 'preproc')?.run_id,
+      selectedRun?.stages.find((s) => s.stage === 'preproc')?.status])
+
+  // Merge fetched inner_stages and nipype_status onto their respective
+  // stages before handing to WorkflowGraph so the custom node renders
+  // them inline.
   const graphStages = useMemo(() => {
     if (!selectedRun) return []
-    if (!analysisInner) return selectedRun.stages
-    return selectedRun.stages.map((s) =>
-      s.stage === 'analysis' && s.run_id === analysisInner.runId
-        ? { ...s, inner_stages: analysisInner.stages }
-        : s,
-    )
-  }, [selectedRun, analysisInner])
+    return selectedRun.stages.map((s) => {
+      if (analysisInner && s.stage === 'analysis' && s.run_id === analysisInner.runId) {
+        return { ...s, inner_stages: analysisInner.stages }
+      }
+      if (preprocNipype && s.stage === 'preproc' && s.run_id === preprocNipype.runId) {
+        return { ...s, nipype_status: preprocNipype.block }
+      }
+      return s
+    })
+  }, [selectedRun, analysisInner, preprocNipype])
 
   const currentMeta = configs.find((c) => c.filename === selected?.filename)
 

--- a/frontend/src/views/__tests__/QCReviews.test.tsx
+++ b/frontend/src/views/__tests__/QCReviews.test.tsx
@@ -1,0 +1,110 @@
+/** Cross-dataset Structural-QC reviews view: filters, table, modal hand-off. */
+
+import { describe, it, expect, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/mocks/server'
+import { renderWithProviders, screen, waitFor } from '../../test/render'
+import { QCReviews } from '../QCReviews'
+
+vi.mock('@niivue/niivue', () => ({
+  Niivue: vi.fn().mockImplementation(() => ({
+    attachToCanvas: vi.fn(),
+    loadVolumes: vi.fn().mockResolvedValue(undefined),
+    loadMeshes: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+const REVIEWS = [
+  { dataset: 'ds-a', subject: 'sub01', status: 'approved',
+    reviewer: 'omar', timestamp: '2026-05-04T12:00:00Z',
+    notes: 'looks good', freeview_command_used: null },
+  { dataset: 'ds-a', subject: 'sub02', status: 'needs_edits',
+    reviewer: 'fatma', timestamp: '2026-05-03T12:00:00Z',
+    notes: 'edit pial near temporal pole', freeview_command_used: null },
+  { dataset: 'ds-b', subject: 'sub01', status: 'rejected',
+    reviewer: 'omar', timestamp: '2026-05-02T12:00:00Z',
+    notes: '', freeview_command_used: null },
+]
+
+
+function mockReviews(rows = REVIEWS) {
+  server.use(
+    http.get('/api/structural-qc/reviews', () => HttpResponse.json(rows)),
+  )
+}
+
+
+describe('<QCReviews />', () => {
+  it('renders one row per review across all datasets', async () => {
+    mockReviews()
+    renderWithProviders(<QCReviews />)
+    await waitFor(() => {
+      // Two ds-a/ds-b rows both name sub01 — there should be 2 matches.
+      expect(screen.getAllByText('sub-sub01').length).toBe(2)
+    })
+    expect(screen.getByText('sub-sub02')).toBeInTheDocument()
+    expect(screen.getByText('looks good')).toBeInTheDocument()
+    expect(screen.getAllByText('ds-a').length).toBe(2)
+    expect(screen.getAllByText('ds-b').length).toBe(1)
+  })
+
+  it('shows counts in the filter chips', async () => {
+    mockReviews()
+    renderWithProviders(<QCReviews />)
+    await waitFor(() => expect(screen.getByText(/All \(3\)/)).toBeInTheDocument())
+    expect(screen.getByText(/Approved \(1\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Needs edits \(1\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Rejected \(1\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Pending \(0\)/)).toBeInTheDocument()
+  })
+
+  it('filters rows by status when a chip is clicked', async () => {
+    mockReviews()
+    const { user } = renderWithProviders(<QCReviews />)
+    await waitFor(() => expect(screen.getByText('sub-sub02')).toBeInTheDocument())
+
+    await user.click(screen.getByText(/Approved \(1\)/))
+    expect(screen.queryByText('sub-sub02')).not.toBeInTheDocument()
+    expect(screen.getAllByText(/sub-sub01/).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows an empty-state row when filtered to a status with zero hits', async () => {
+    mockReviews()
+    const { user } = renderWithProviders(<QCReviews />)
+    await waitFor(() => expect(screen.getByText('sub-sub02')).toBeInTheDocument())
+    await user.click(screen.getByText(/Pending \(0\)/))
+    expect(screen.getByText(/no reviews .*pending/i)).toBeInTheDocument()
+  })
+
+  it('opens the StructuralQC modal when a row is clicked', async () => {
+    mockReviews()
+    server.use(
+      http.get('/api/preproc/subjects/sub02/structural-qc', () =>
+        HttpResponse.json({
+          dataset: 'ds-a', subject: 'sub02', status: 'needs_edits',
+          reviewer: 'fatma', timestamp: '2026-05-03T12:00:00Z',
+          notes: 'fix pial', freeview_command_used: null,
+        }),
+      ),
+    )
+    const { user } = renderWithProviders(<QCReviews />)
+    await waitFor(() => expect(screen.getByText('sub-sub02')).toBeInTheDocument())
+    await user.click(screen.getByText('sub-sub02'))
+    // Modal renders the same `sub-<id>` label in its header.
+    await waitFor(() => {
+      expect(screen.getAllByText('sub-sub02').length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  it('surfaces a load error', async () => {
+    server.use(
+      http.get('/api/structural-qc/reviews',
+        () => new HttpResponse('boom', { status: 500 }),
+      ),
+    )
+    renderWithProviders(<QCReviews />)
+    await waitFor(() => {
+      expect(screen.getByText(/500/)).toBeInTheDocument()
+    })
+  })
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
     - Preprocessing: guide/preprocessing.md
     - DICOM to BIDS: guide/dicom-to-bids.md
     - Autoflatten: guide/autoflatten.md
+    - Post-preproc: guide/post-preproc.md
     - Pipeline Graph: guide/pipeline-graph.md
     - Workflows: guide/workflows.md
     - Web UI: guide/web-ui.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
     - Python API: guide/python-api.md
     - Writing Modules: guide/modules.md
     - Preprocessing: guide/preprocessing.md
+    - Structural QC: guide/structural-qc.md
     - DICOM to BIDS: guide/dicom-to-bids.md
     - Autoflatten: guide/autoflatten.md
     - Pipeline Graph: guide/pipeline-graph.md

--- a/scripts/backfill_nipype_events.py
+++ b/scripts/backfill_nipype_events.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Rewrite a nipype_events.jsonl to use full dotted paths everywhere.
+
+Replays the JSONL through the same FIFO leaf-matching the live
+aggregator does, then writes back a normalized version where every
+``node_done`` / ``node_fail`` event has the full path of its matching
+``node_start``. Useful for older finished runs whose JSONL was
+produced before the parser fix shipped.
+
+Idempotent: running it twice is a no-op (every event already has a
+full dotted path on the second pass).
+
+Usage::
+
+    python scripts/backfill_nipype_events.py [--dry-run] PATH...
+
+PATH can be a JSONL file or a directory containing one (in which case
+the script walks the directory looking for ``nipype_events.jsonl``).
+A ``.bak`` sidecar is written next to each rewritten file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import deque
+from pathlib import Path
+
+
+def _backfill_lines(lines: list[str]) -> tuple[list[str], dict[str, int]]:
+    """Return (new_lines, stats). Each line is a JSONL event."""
+    starts_by_leaf: dict[str, deque[str]] = {}
+    out: list[str] = []
+    stats = {"rewritten": 0, "passthrough": 0, "orphan_terminals": 0,
+             "skipped_malformed": 0}
+    for line in lines:
+        s = line.strip()
+        if not s:
+            out.append(line.rstrip("\n"))
+            continue
+        try:
+            ev = json.loads(s)
+        except (ValueError, json.JSONDecodeError):
+            stats["skipped_malformed"] += 1
+            out.append(line.rstrip("\n"))
+            continue
+
+        kind = ev.get("event")
+        node = ev.get("node")
+        leaf = ev.get("leaf") or (node.rsplit(".", 1)[-1] if node else None)
+        if not node or not leaf:
+            stats["passthrough"] += 1
+            out.append(line.rstrip("\n"))
+            continue
+
+        if kind == "node_start" and "." in node:
+            starts_by_leaf.setdefault(leaf, deque()).append(node)
+        elif kind in ("node_done", "node_fail") and "." not in node:
+            queue = starts_by_leaf.get(leaf)
+            if queue:
+                full = queue.popleft()
+                ev["node"] = full
+                ev["leaf"] = full.rsplit(".", 1)[-1]
+                if "." in full:
+                    ev["workflow"] = full.rsplit(".", 1)[0]
+                if not queue:
+                    del starts_by_leaf[leaf]
+                stats["rewritten"] += 1
+                out.append(json.dumps(ev, ensure_ascii=False))
+                continue
+            stats["orphan_terminals"] += 1
+        stats["passthrough"] += 1
+        out.append(json.dumps(ev, ensure_ascii=False))
+    return out, stats
+
+
+def _process_file(p: Path, *, dry_run: bool) -> dict[str, int]:
+    raw = p.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=False,
+    )
+    new_lines, stats = _backfill_lines(raw)
+    if dry_run:
+        print(f"  would rewrite {stats['rewritten']} events; "
+              f"{stats['orphan_terminals']} orphan terminals; "
+              f"{stats['passthrough']} passthrough")
+        return stats
+    if stats["rewritten"] == 0:
+        print(f"  nothing to rewrite — {stats['passthrough']} events untouched")
+        return stats
+    backup = p.with_suffix(p.suffix + ".bak")
+    backup.write_text("\n".join(raw) + ("\n" if raw else ""), encoding="utf-8")
+    p.write_text("\n".join(new_lines) + ("\n" if new_lines else ""), encoding="utf-8")
+    print(f"  rewrote {stats['rewritten']} events, "
+          f"backup at {backup}")
+    return stats
+
+
+def _resolve_targets(paths: list[Path]) -> list[Path]:
+    out: list[Path] = []
+    for p in paths:
+        if p.is_file():
+            out.append(p)
+        elif p.is_dir():
+            out.extend(sorted(p.rglob("nipype_events.jsonl")))
+        else:
+            print(f"warning: skipping {p} (not a file or directory)",
+                  file=sys.stderr)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("paths", nargs="+", type=Path,
+                    help="JSONL file(s) or directory tree(s) to walk.")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Show what would change without writing.")
+    args = ap.parse_args(argv)
+
+    targets = _resolve_targets(args.paths)
+    if not targets:
+        print("nothing to do — no nipype_events.jsonl files found",
+              file=sys.stderr)
+        return 1
+
+    overall = {"rewritten": 0, "passthrough": 0, "orphan_terminals": 0,
+               "skipped_malformed": 0, "files": 0}
+    for t in targets:
+        print(t)
+        s = _process_file(t, dry_run=args.dry_run)
+        overall["files"] += 1
+        for k in ("rewritten", "passthrough", "orphan_terminals", "skipped_malformed"):
+            overall[k] += s[k]
+
+    print()
+    print(f"summary: {overall['files']} file(s) · "
+          f"{overall['rewritten']} rewritten · "
+          f"{overall['orphan_terminals']} orphan terminals · "
+          f"{overall['passthrough']} passthrough · "
+          f"{overall['skipped_malformed']} malformed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_post_preproc/test_graph.py
+++ b/tests/test_post_preproc/test_graph.py
@@ -1,0 +1,90 @@
+"""ReactFlow JSON ↔ PostPreprocGraph round-trip + topology + validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from fmriflow.post_preproc.graph import PostPreprocGraph
+
+
+REACTFLOW = {
+    "nodes": [
+        {"id": "src", "type": "preproc_run",
+         "data": {"params": {"run_name": "task01"}},
+         "position": {"x": 0, "y": 0}},
+        {"id": "smo", "type": "smooth",
+         "data": {"params": {"fwhm": 5.0}},
+         "position": {"x": 200, "y": 0}},
+        {"id": "msk", "type": "mask_apply",
+         "data": {"params": {"mask_path": "/m.nii.gz"}},
+         "position": {"x": 400, "y": 0}},
+    ],
+    "edges": [
+        {"id": "e1", "source": "src", "target": "smo",
+         "sourceHandle": "out_file", "targetHandle": "in_file"},
+        {"id": "e2", "source": "smo", "target": "msk",
+         "sourceHandle": "out_file", "targetHandle": "in_file"},
+    ],
+}
+
+
+def test_roundtrip_preserves_shape():
+    g = PostPreprocGraph.from_reactflow(REACTFLOW)
+    out = g.to_reactflow()
+    assert {n["id"] for n in out["nodes"]} == {"src", "smo", "msk"}
+    assert {e["id"] for e in out["edges"]} == {"e1", "e2"}
+
+
+def test_topo_order_linear():
+    g = PostPreprocGraph.from_reactflow(REACTFLOW)
+    order = [n.id for n in g.topo_order()]
+    assert order == ["src", "smo", "msk"]
+
+
+def test_cycle_rejected():
+    cyclic = {
+        "nodes": [
+            {"id": "a", "type": "smooth", "data": {"params": {}}, "position": {}},
+            {"id": "b", "type": "smooth", "data": {"params": {}}, "position": {}},
+        ],
+        "edges": [
+            {"id": "e1", "source": "a", "target": "b",
+             "sourceHandle": "out_file", "targetHandle": "in_file"},
+            {"id": "e2", "source": "b", "target": "a",
+             "sourceHandle": "out_file", "targetHandle": "in_file"},
+        ],
+    }
+    g = PostPreprocGraph.from_reactflow(cyclic)
+    with pytest.raises(ValueError):
+        g.topo_order()
+
+
+def test_validate_unknown_node_type():
+    bad = {
+        "nodes": [
+            {"id": "x", "type": "no_such_node", "data": {"params": {}},
+             "position": {}},
+        ],
+        "edges": [],
+    }
+    g = PostPreprocGraph.from_reactflow(bad)
+    errors = g.validate_against({"smooth": object})
+    assert any("Unknown node type" in e for e in errors)
+
+
+def test_validate_unknown_handle():
+    from fmriflow.modules.nipype_nodes.smooth import SmoothNode
+
+    bogus = {
+        "nodes": [
+            {"id": "a", "type": "smooth", "data": {"params": {}}, "position": {}},
+            {"id": "b", "type": "smooth", "data": {"params": {}}, "position": {}},
+        ],
+        "edges": [
+            {"id": "e1", "source": "a", "target": "b",
+             "sourceHandle": "out_file", "targetHandle": "bogus_handle"},
+        ],
+    }
+    g = PostPreprocGraph.from_reactflow(bogus)
+    errors = g.validate_against({"smooth": SmoothNode})
+    assert any("bogus_handle" in e for e in errors)

--- a/tests/test_post_preproc/test_iter.py
+++ b/tests/test_post_preproc/test_iter.py
@@ -1,0 +1,99 @@
+"""Iterate a smooth node over every run in the source manifest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+nibabel = pytest.importorskip("nibabel")
+np = pytest.importorskip("numpy")
+pytest.importorskip("scipy")
+
+from fmriflow.post_preproc.graph import PostPreprocGraph
+from fmriflow.post_preproc.manifest import PostPreprocConfig
+from fmriflow.post_preproc.runner import run_post_preproc
+from fmriflow.preproc.manifest import PreprocManifest, RunRecord
+from fmriflow.registry import ModuleRegistry
+
+
+def _write_nii(path: Path):
+    affine = np.eye(4)
+    affine[0, 0] = affine[1, 1] = affine[2, 2] = 2.0
+    nibabel.Nifti1Image(np.zeros((4, 4, 4, 2), "float32"), affine).to_filename(str(path))
+
+
+def test_iter_over_source_manifest_runs(tmp_path):
+    bolds = [tmp_path / f"bold_{i}.nii.gz" for i in range(2)]
+    for b in bolds:
+        _write_nii(b)
+
+    src_manifest_path = tmp_path / "preproc_manifest.json"
+    PreprocManifest(
+        subject="01", dataset="ds", sessions=[],
+        runs=[
+            RunRecord(run_name=f"r{i}", source_file=str(b),
+                      output_file=str(b), n_trs=2, shape=[4, 4, 4, 2])
+            for i, b in enumerate(bolds)
+        ],
+        backend="x", backend_version="0", parameters={}, space="MNI",
+        output_dir=str(tmp_path),
+    ).save(src_manifest_path)
+
+    graph = {
+        "nodes": [{
+            "id": "smo", "type": "smooth",
+            "data": {"params": {
+                "fwhm": 4.0,
+                "_iter": {"handle": "in_file", "from_source_manifest": True},
+            }},
+            "position": {},
+        }],
+        "edges": [],
+    }
+
+    config = PostPreprocConfig(
+        subject="01",
+        source_manifest_path=str(src_manifest_path),
+        graph=graph,
+        output_dir=str(tmp_path / "post"),
+    )
+    registry = ModuleRegistry()
+    registry.discover()
+
+    result = run_post_preproc(config, registry=registry)
+    smo_record = next(r for r in result.nodes_run if r.node_id == "smo")
+    out_files = smo_record.outputs["out_file"].split(",")
+    assert len(out_files) == 2
+    for f in out_files:
+        assert Path(f).is_file()
+
+
+def test_iter_validates_handle_and_sink():
+    g = PostPreprocGraph.from_reactflow({
+        "nodes": [
+            {"id": "src", "type": "preproc_run",
+             "data": {"params": {"run_name": "r0"}}, "position": {}},
+            {"id": "smo", "type": "smooth",
+             "data": {"params": {"fwhm": 4.0,
+                                 "_iter": {"handle": "wrong_handle"}}}, "position": {}},
+        ],
+        "edges": [
+            {"id": "e1", "source": "src", "target": "smo",
+             "sourceHandle": "out_file", "targetHandle": "in_file"},
+            # Add an outgoing edge from the iterating node to a 3rd node.
+        ],
+    })
+    g.nodes.append(type(g.nodes[0])(id="x", type="smooth", params={}, position={}))
+    g.edges.append(type(g.edges[0])(
+        id="e2", source="smo", target="x",
+        source_handle="out_file", target_handle="in_file",
+    ))
+    from fmriflow.modules.nipype_nodes.smooth import SmoothNode
+    from fmriflow.modules.nipype_nodes.source import PreprocRunSourceNode
+    errors = g.validate_against({
+        "smooth": SmoothNode,
+        "preproc_run": PreprocRunSourceNode,
+    })
+    assert any("_iter handle" in e for e in errors)
+    assert any("outgoing edges" in e for e in errors)

--- a/tests/test_post_preproc/test_literal_inputs.py
+++ b/tests/test_post_preproc/test_literal_inputs.py
@@ -1,0 +1,62 @@
+"""Literal _inputs path overrides for nodes without an upstream edge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+nibabel = pytest.importorskip("nibabel")
+np = pytest.importorskip("numpy")
+pytest.importorskip("scipy")
+
+from fmriflow.post_preproc.manifest import PostPreprocConfig
+from fmriflow.post_preproc.runner import run_post_preproc
+from fmriflow.preproc.manifest import PreprocManifest, RunRecord
+from fmriflow.registry import ModuleRegistry
+
+
+def _write_nii(path: Path):
+    affine = np.eye(4)
+    affine[0, 0] = affine[1, 1] = affine[2, 2] = 2.0
+    nibabel.Nifti1Image(np.zeros((4, 4, 4, 2), "float32"), affine).to_filename(str(path))
+
+
+def test_smooth_with_literal_input_path(tmp_path):
+    bold = tmp_path / "bold.nii.gz"
+    _write_nii(bold)
+
+    # Stub manifest just so the runner can read the dataset name.
+    src_manifest = tmp_path / "preproc_manifest.json"
+    PreprocManifest(
+        subject="01",
+        dataset="ds-test",
+        sessions=[],
+        runs=[RunRecord(run_name="r1", source_file=str(bold),
+                        output_file=str(bold), n_trs=2, shape=[4, 4, 4, 2])],
+        backend="fmriprep", backend_version="0", parameters={}, space="MNI",
+        output_dir=str(tmp_path),
+    ).save(src_manifest)
+
+    # No source node, no edges — the smooth node receives in_file via _inputs.
+    graph = {
+        "nodes": [
+            {"id": "smo", "type": "smooth",
+             "data": {"params": {"fwhm": 4.0, "_inputs": {"in_file": str(bold)}}},
+             "position": {}},
+        ],
+        "edges": [],
+    }
+
+    config = PostPreprocConfig(
+        subject="01",
+        source_manifest_path=str(src_manifest),
+        graph=graph,
+        output_dir=str(tmp_path / "post"),
+    )
+    registry = ModuleRegistry()
+    registry.discover()
+
+    result = run_post_preproc(config, registry=registry)
+    out = Path(result.nodes_run[0].outputs["out_file"])
+    assert out.is_file()

--- a/tests/test_post_preproc/test_runner.py
+++ b/tests/test_post_preproc/test_runner.py
@@ -1,0 +1,92 @@
+"""Run a small smooth-only post-preproc graph against a stub PreprocManifest."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+nibabel = pytest.importorskip("nibabel")
+np = pytest.importorskip("numpy")
+pytest.importorskip("scipy")
+
+from fmriflow.post_preproc.manifest import PostPreprocConfig
+from fmriflow.post_preproc.runner import run_post_preproc
+from fmriflow.preproc.manifest import PreprocManifest, RunRecord
+from fmriflow.registry import ModuleRegistry
+
+
+def _write_nii(path: Path, shape=(4, 4, 4, 3)):
+    affine = np.eye(4)
+    affine[0, 0] = affine[1, 1] = affine[2, 2] = 2.0  # 2 mm voxels
+    data = np.random.RandomState(0).rand(*shape).astype("float32")
+    nibabel.Nifti1Image(data, affine).to_filename(str(path))
+
+
+def test_smooth_only_pipeline(tmp_path):
+    # Stub upstream PreprocManifest + a fake BOLD nifti.
+    out_dir = tmp_path / "deriv"
+    (out_dir / "sub-01").mkdir(parents=True)
+    bold = out_dir / "sub-01" / "bold_run01.nii.gz"
+    _write_nii(bold)
+
+    manifest = PreprocManifest(
+        subject="01",
+        dataset="ds-test",
+        sessions=[],
+        runs=[RunRecord(
+            run_name="run01",
+            source_file=str(bold),
+            output_file=str(bold.relative_to(out_dir)),
+            n_trs=3,
+            shape=[4, 4, 4, 3],
+        )],
+        backend="fmriprep",
+        backend_version="0.0.0",
+        parameters={},
+        space="MNI",
+        output_dir=str(out_dir),
+    )
+    src_manifest_path = out_dir / "preproc_manifest.json"
+    src_manifest_path.write_text(manifest.to_json())
+
+    graph = {
+        "nodes": [
+            {"id": "src", "type": "preproc_run",
+             "data": {"params": {"run_name": "run01"}}, "position": {}},
+            {"id": "smo", "type": "smooth",
+             "data": {"params": {"fwhm": 4.0}}, "position": {}},
+        ],
+        "edges": [
+            {"id": "e1", "source": "src", "target": "smo",
+             "sourceHandle": "out_file", "targetHandle": "in_file"},
+        ],
+    }
+
+    config = PostPreprocConfig(
+        subject="01",
+        source_manifest_path=str(src_manifest_path),
+        graph=graph,
+        output_dir=str(tmp_path / "post"),
+    )
+
+    registry = ModuleRegistry()
+    registry.discover()
+
+    result = run_post_preproc(config, registry=registry)
+
+    # Manifest contains both nodes' run records.
+    assert {r.node_id for r in result.nodes_run} == {"src", "smo"}
+    smo_record = next(r for r in result.nodes_run if r.node_id == "smo")
+    out_file = Path(smo_record.outputs["out_file"])
+    assert out_file.is_file()
+
+    # Output is a valid NIfTI of the same shape.
+    out_img = nibabel.load(str(out_file))
+    assert out_img.shape == (4, 4, 4, 3)
+
+    # Manifest JSON is on disk.
+    disk = json.loads((Path(config.output_dir) / "post_preproc_manifest.json").read_text())
+    assert disk["subject"] == "01"
+    assert len(disk["nodes_run"]) == 2

--- a/tests/test_post_preproc/test_stage_dispatch.py
+++ b/tests/test_post_preproc/test_stage_dispatch.py
@@ -1,0 +1,83 @@
+"""PostPreprocManager.start_run_from_config_file → WorkflowManager fan-in."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+nibabel = pytest.importorskip("nibabel")
+np = pytest.importorskip("numpy")
+pytest.importorskip("scipy")
+yaml = pytest.importorskip("yaml")
+
+from fmriflow.preproc.manifest import PreprocManifest, RunRecord
+from fmriflow.registry import ModuleRegistry
+from fmriflow.server.services.post_preproc_manager import PostPreprocManager
+from fmriflow.server.services.post_preproc_workflow_store import (
+    PostPreprocWorkflowStore,
+)
+
+
+def _write_nii(path: Path):
+    affine = np.eye(4)
+    affine[0, 0] = affine[1, 1] = affine[2, 2] = 2.0
+    nibabel.Nifti1Image(np.zeros((4, 4, 4, 2), "float32"), affine).to_filename(str(path))
+
+
+def test_start_run_from_config_file_runs_saved_graph(tmp_path):
+    bold = tmp_path / "bold.nii.gz"
+    _write_nii(bold)
+
+    src = tmp_path / "preproc_manifest.json"
+    PreprocManifest(
+        subject="01", dataset="ds", sessions=[],
+        runs=[RunRecord(run_name="r1", source_file=str(bold),
+                        output_file=str(bold), n_trs=2, shape=[4, 4, 4, 2])],
+        backend="x", backend_version="0", parameters={}, space="MNI",
+        output_dir=str(tmp_path),
+    ).save(src)
+
+    store = PostPreprocWorkflowStore(tmp_path / "wfs")
+    store.save(
+        "smooth_only",
+        {
+            "nodes": [{
+                "id": "smo", "type": "smooth",
+                "data": {"params": {"fwhm": 4.0}}, "position": {},
+            }],
+            "edges": [],
+        },
+        inputs={"in_file": {"from": "smo.in_file"}},
+        outputs={"out_file": {"from": "smo.out_file"}},
+    )
+
+    # Stage YAML referencing the saved graph.
+    stage_yaml = tmp_path / "stage.yaml"
+    stage_yaml.write_text(yaml.safe_dump({
+        "graph": "smooth_only",
+        "subject": "01",
+        "source_manifest_path": str(src),
+        "output_dir": str(tmp_path / "post"),
+        "bindings": {"in_file": {"source_run": "r1"}},
+    }))
+
+    registry = ModuleRegistry()
+    registry.discover()
+    mgr = PostPreprocManager()
+    mgr.bind_dependencies(registry=registry, workflow_store=store)
+
+    run_id = mgr.start_run_from_config_file(str(stage_yaml))
+    # WorkflowManager polls active_runs until status leaves "running".
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        h = mgr.active_runs.get(run_id)
+        assert h is not None
+        if h.status in ("done", "failed"):
+            break
+        time.sleep(0.1)
+    h = mgr.active_runs[run_id]
+    assert h.status == "done", h.error
+    assert h.manifest is not None
+    assert any(r["node_type"] == "smooth" for r in h.manifest["nodes_run"])

--- a/tests/test_post_preproc/test_subworkflow.py
+++ b/tests/test_post_preproc/test_subworkflow.py
@@ -1,0 +1,134 @@
+"""Run a graph that wraps a saved smooth workflow as a subworkflow node."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+nibabel = pytest.importorskip("nibabel")
+np = pytest.importorskip("numpy")
+pytest.importorskip("scipy")
+
+from fmriflow.post_preproc.manifest import PostPreprocConfig
+from fmriflow.post_preproc.runner import run_post_preproc
+from fmriflow.preproc.manifest import PreprocManifest, RunRecord
+from fmriflow.registry import ModuleRegistry
+from fmriflow.server.services.post_preproc_workflow_store import (
+    PostPreprocWorkflowStore,
+)
+
+
+def _write_nii(path: Path):
+    affine = np.eye(4)
+    affine[0, 0] = affine[1, 1] = affine[2, 2] = 2.0
+    nibabel.Nifti1Image(np.zeros((4, 4, 4, 2), "float32"), affine).to_filename(str(path))
+
+
+def test_subworkflow_runs_inner_smooth(tmp_path):
+    bold = tmp_path / "bold.nii.gz"
+    _write_nii(bold)
+
+    src_manifest_path = tmp_path / "preproc_manifest.json"
+    PreprocManifest(
+        subject="01", dataset="ds", sessions=[],
+        runs=[RunRecord(run_name="r1", source_file=str(bold),
+                        output_file=str(bold), n_trs=2, shape=[4, 4, 4, 2])],
+        backend="x", backend_version="0", parameters={}, space="MNI",
+        output_dir=str(tmp_path),
+    ).save(src_manifest_path)
+
+    # Save an inner workflow with a single smooth node, exposing in_file/out_file.
+    store = PostPreprocWorkflowStore(tmp_path / "wfs")
+    inner_graph = {
+        "nodes": [{
+            "id": "smo", "type": "smooth",
+            "data": {"params": {"fwhm": 4.0}}, "position": {},
+        }],
+        "edges": [],
+    }
+    store.save(
+        "smooth_inner",
+        inner_graph,
+        inputs={"in_file": {"from": "smo.in_file"}},
+        outputs={"out_file": {"from": "smo.out_file"}},
+    )
+
+    # Outer graph: subworkflow node, in_file fed via _inputs.
+    outer_graph = {
+        "nodes": [{
+            "id": "sw", "type": "subworkflow",
+            "data": {"params": {
+                "workflow_name": "smooth_inner",
+                "_inputs": {"in_file": str(bold)},
+            }},
+            "position": {},
+        }],
+        "edges": [],
+    }
+
+    config = PostPreprocConfig(
+        subject="01",
+        source_manifest_path=str(src_manifest_path),
+        graph=outer_graph,
+        output_dir=str(tmp_path / "post"),
+    )
+    registry = ModuleRegistry()
+    registry.discover()
+
+    result = run_post_preproc(config, registry=registry, workflow_store=store)
+    sw_record = next(r for r in result.nodes_run if r.node_id == "sw")
+    out_file = Path(sw_record.outputs["out_file"])
+    assert out_file.is_file()
+
+
+def test_subworkflow_cycle_detected(tmp_path):
+    """If wf A includes wf A, we raise instead of recursing forever."""
+    bold = tmp_path / "bold.nii.gz"
+    _write_nii(bold)
+
+    src_manifest_path = tmp_path / "preproc_manifest.json"
+    PreprocManifest(
+        subject="01", dataset="ds", sessions=[],
+        runs=[RunRecord(run_name="r1", source_file=str(bold),
+                        output_file=str(bold), n_trs=2, shape=[4, 4, 4, 2])],
+        backend="x", backend_version="0", parameters={}, space="MNI",
+        output_dir=str(tmp_path),
+    ).save(src_manifest_path)
+
+    store = PostPreprocWorkflowStore(tmp_path / "wfs")
+    self_call = {
+        "nodes": [{
+            "id": "sw", "type": "subworkflow",
+            "data": {"params": {"workflow_name": "loop"}}, "position": {},
+        }],
+        "edges": [],
+    }
+    store.save(
+        "loop",
+        self_call,
+        inputs={"in_file": {"from": "sw.in_file"}},
+        outputs={"out_file": {"from": "sw.out_file"}},
+    )
+
+    outer = {
+        "nodes": [{
+            "id": "sw", "type": "subworkflow",
+            "data": {"params": {
+                "workflow_name": "loop",
+                "_inputs": {"in_file": str(bold)},
+            }}, "position": {},
+        }],
+        "edges": [],
+    }
+    config = PostPreprocConfig(
+        subject="01",
+        source_manifest_path=str(src_manifest_path),
+        graph=outer,
+        output_dir=str(tmp_path / "post"),
+    )
+    registry = ModuleRegistry()
+    registry.discover()
+
+    with pytest.raises(RuntimeError, match="subworkflow cycle"):
+        run_post_preproc(config, registry=registry, workflow_store=store)

--- a/tests/test_post_preproc/test_workflow_store.py
+++ b/tests/test_post_preproc/test_workflow_store.py
@@ -1,0 +1,42 @@
+"""Round-trip the post-preproc workflow YAML store."""
+
+from __future__ import annotations
+
+import pytest
+
+from fmriflow.server.services.post_preproc_workflow_store import (
+    PostPreprocWorkflowStore,
+)
+
+
+def test_save_get_list_delete(tmp_path):
+    store = PostPreprocWorkflowStore(tmp_path)
+    graph = {
+        "nodes": [{"id": "smo", "type": "smooth", "data": {"params": {}}, "position": {}}],
+        "edges": [],
+    }
+    store.save(
+        "smooth_only",
+        graph,
+        description="just smooth",
+        inputs={"in_file": {"from": "smo.in_file"}},
+        outputs={"out_file": {"from": "smo.out_file"}},
+    )
+
+    listed = store.list()
+    assert any(w["name"] == "smooth_only" and w["n_nodes"] == 1 for w in listed)
+
+    got = store.get("smooth_only")
+    assert got is not None
+    assert got["description"] == "just smooth"
+    assert "in_file" in got["inputs"]
+    assert "out_file" in got["outputs"]
+
+    assert store.delete("smooth_only") is True
+    assert store.get("smooth_only") is None
+
+
+def test_unsafe_name_rejected(tmp_path):
+    store = PostPreprocWorkflowStore(tmp_path)
+    with pytest.raises(ValueError):
+        store.save("../bad", {"nodes": [], "edges": []})

--- a/tests/test_preproc/test_manifest_discovery.py
+++ b/tests/test_preproc/test_manifest_discovery.py
@@ -1,0 +1,146 @@
+"""PreprocManager discovers manifests recorded by the run registry,
+even when they live outside the configured derivatives root."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fmriflow.preproc.manifest import PreprocManifest, RunRecord
+from fmriflow.server.services.preproc_manager import PreprocManager
+from fmriflow.server.services.run_registry import RunRegistry, RunStateFile
+
+
+def _write_manifest(out_dir: Path, subject: str, dataset: str = "ds-test") -> Path:
+    sub_dir = out_dir / f"sub-{subject}"
+    sub_dir.mkdir(parents=True)
+    manifest = PreprocManifest(
+        subject=subject,
+        dataset=dataset,
+        sessions=[],
+        runs=[RunRecord(
+            run_name="r1",
+            source_file="src.nii.gz",
+            output_file="bold.nii.gz",
+            n_trs=1,
+            shape=[1, 1, 1, 1],
+        )],
+        backend="fmriprep",
+        backend_version="25.1.3",
+        parameters={},
+        space="MNI",
+        output_dir=str(out_dir),
+    )
+    p = sub_dir / "preproc_manifest.json"
+    manifest.save(p)
+    return p
+
+
+def test_finds_manifests_under_derivatives_dir(tmp_path):
+    derivatives = tmp_path / "derivatives"
+    derivatives.mkdir()
+    _write_manifest(derivatives / "fmriprep", "01")
+    registry = RunRegistry(root=tmp_path / "runs")
+    mgr = PreprocManager(derivatives, registry=registry)
+    summaries = mgr.scan_manifests()
+    subjects = [s["subject"] for s in summaries]
+    assert "01" in subjects
+
+
+def test_finds_manifests_via_registry_outside_derivatives_dir(tmp_path):
+    """Manifest at /<elsewhere>/sub-AN/preproc_manifest.json should be
+    discovered as long as a completed preproc run on the registry
+    points its output_dir at <elsewhere>."""
+    elsewhere = tmp_path / "testing" / "study" / "derivatives" / "fmriprep"
+    elsewhere.mkdir(parents=True)
+    manifest_path = _write_manifest(elsewhere, "AN")
+
+    registry = RunRegistry(root=tmp_path / "runs")
+    state = RunStateFile(
+        run_id="preproc_AN_xyz",
+        kind="preproc",
+        backend="fmriprep",
+        subject="AN",
+        status="done",
+        params={"output_dir": str(elsewhere)},
+        manifest_path=str(manifest_path),
+    )
+    registry.register(state)
+    registry.update(state)
+
+    derivatives = tmp_path / "configured-derivatives"  # empty — manifest isn't under here
+    derivatives.mkdir()
+    mgr = PreprocManager(derivatives, registry=registry)
+    summaries = mgr.scan_manifests()
+    paths = [s["path"] for s in summaries]
+    assert str(manifest_path.resolve()) in paths
+    assert summaries[0]["subject"] == "AN"
+
+
+def test_dedups_when_manifest_appears_in_both_sources(tmp_path):
+    derivatives = tmp_path / "derivatives"
+    derivatives.mkdir()
+    fmri_out = derivatives / "fmriprep"
+    manifest_path = _write_manifest(fmri_out, "01")
+
+    registry = RunRegistry(root=tmp_path / "runs")
+    state = RunStateFile(
+        run_id="preproc_01_xyz",
+        kind="preproc",
+        backend="fmriprep",
+        subject="01",
+        status="done",
+        params={"output_dir": str(fmri_out)},
+        manifest_path=str(manifest_path),
+    )
+    registry.register(state)
+    registry.update(state)
+
+    mgr = PreprocManager(derivatives, registry=registry)
+    summaries = mgr.scan_manifests()
+    assert len([s for s in summaries if s["subject"] == "01"]) == 1
+
+
+def test_skips_runs_that_are_not_done(tmp_path):
+    elsewhere = tmp_path / "testing"
+    elsewhere.mkdir()
+    manifest_path = _write_manifest(elsewhere, "02")
+    registry = RunRegistry(root=tmp_path / "runs")
+    state = RunStateFile(
+        run_id="r1", kind="preproc", backend="fmriprep", subject="02",
+        status="running",  # still in flight — manifest path may be stale
+        params={"output_dir": str(elsewhere)},
+        manifest_path=str(manifest_path),
+    )
+    registry.register(state)
+    registry.update(state)
+
+    derivatives = tmp_path / "configured-derivatives"
+    derivatives.mkdir()
+    mgr = PreprocManager(derivatives, registry=registry)
+    summaries = mgr.scan_manifests()
+    assert summaries == []
+
+
+def test_falls_back_to_output_dir_when_manifest_path_missing(tmp_path):
+    """A run state lacking ``manifest_path`` still finds the manifest
+    by deriving ``{output_dir}/sub-{subject}/preproc_manifest.json``."""
+    elsewhere = tmp_path / "testing"
+    elsewhere.mkdir()
+    _write_manifest(elsewhere, "03")
+
+    registry = RunRegistry(root=tmp_path / "runs")
+    state = RunStateFile(
+        run_id="r3", kind="preproc", backend="fmriprep", subject="03",
+        status="done",
+        params={"output_dir": str(elsewhere)},
+        manifest_path=None,  # not set
+    )
+    registry.register(state)
+    registry.update(state)
+
+    derivatives = tmp_path / "configured-derivatives"
+    derivatives.mkdir()
+    mgr = PreprocManager(derivatives, registry=registry)
+    summaries = mgr.scan_manifests()
+    assert len(summaries) == 1
+    assert summaries[0]["subject"] == "03"

--- a/tests/test_preproc/test_nipype_log.py
+++ b/tests/test_preproc/test_nipype_log.py
@@ -93,7 +93,8 @@ def test_aggregator_collapses_jsonl(tmp_path):
     assert by_leaf["smooth"].elapsed == 10.0
     assert by_leaf["mask"].status == "failed"
     assert by_leaf["mask"].elapsed == 10.0
-    assert block.counts == {"running": 0, "ok": 1, "failed": 1, "total_seen": 2}
+    assert block.counts == {"running": 0, "ok": 1, "failed": 1,
+                            "completed_assumed": 0, "total_seen": 2}
 
 
 def test_aggregator_unfinished_nodes_default_to_running(tmp_path):
@@ -119,7 +120,8 @@ def test_aggregator_caps_total_returned(tmp_path):
 
 def test_aggregator_empty_path_returns_zeros(tmp_path):
     block = parse_nipype_events_file(tmp_path / "missing.jsonl")
-    assert block.counts == {"running": 0, "ok": 0, "failed": 0, "total_seen": 0}
+    assert block.counts == {"running": 0, "ok": 0, "failed": 0,
+                            "completed_assumed": 0, "total_seen": 0}
     assert block.recent_nodes == []
 
 

--- a/tests/test_preproc/test_nipype_log.py
+++ b/tests/test_preproc/test_nipype_log.py
@@ -1,0 +1,133 @@
+"""Parse fmriprep nipype log lines into structured node-status events."""
+
+from __future__ import annotations
+
+import json
+
+from fmriflow.preproc.nipype_log import (
+    NipypeLogParser,
+    append_jsonl,
+    parse_nipype_events_file,
+)
+
+
+# A short captured-style fmriprep log snippet covering setup / finish / error.
+SAMPLE_LOG = """\
+250504-12:31:02,123 nipype.workflow INFO:
+\t [Node] Setting-up "fmriprep_wf.single_subject_01_wf.bold_preproc_wf.bold_split" in "/work/.../bold_split".
+250504-12:31:18,847 nipype.workflow INFO:
+\t [Node] Finished "fmriprep_wf.single_subject_01_wf.bold_preproc_wf.bold_split", elapsed time 16.7s.
+250504-12:31:20,001 nipype.workflow INFO:
+\t [Node] Setting-up "fmriprep_wf.single_subject_01_wf.bold_t1_trans_wf.merge" in "/work/.../merge".
+250504-12:35:11,002 nipype.workflow ERROR:
+\t [Node] Error on "fmriprep_wf.sdc_estimate_wf.fmap2field_wf.unwarp_wf" (some traceback that follows on later lines)
+random unrelated stdout line we should ignore
+"""
+
+
+def _drain(parser: NipypeLogParser, lines: list[str]) -> list[dict]:
+    out: list[dict] = []
+    for line in lines:
+        out.extend(parser.feed(line))
+    return out
+
+
+def test_parser_emits_start_finish_error():
+    parser = NipypeLogParser()
+    events = _drain(parser, SAMPLE_LOG.splitlines())
+
+    kinds = [e["event"] for e in events]
+    assert kinds == ["node_start", "node_done", "node_start", "node_fail"]
+
+    # First event metadata
+    e0 = events[0]
+    assert e0["leaf"] == "bold_split"
+    assert e0["workflow"].startswith("fmriprep_wf.")
+    assert "node" in e0 and "fmriprep_wf" in e0["node"]
+    assert e0["t"] > 0
+
+    # Failure event has level ERROR
+    fail = events[-1]
+    assert fail["event"] == "node_fail"
+    assert fail["level"] == "ERROR"
+    assert fail["leaf"] == "unwarp_wf"
+
+
+def test_parser_drops_unmatched_lines():
+    parser = NipypeLogParser()
+    events = _drain(parser, [
+        "totally unrelated stdout",
+        "Bash: command not found",
+        "",
+    ])
+    assert events == []
+
+
+def test_parser_recovers_from_lone_header():
+    parser = NipypeLogParser()
+    # A header followed immediately by a non-node line should not stick.
+    events = _drain(parser, [
+        "250504-12:31:02,123 nipype.workflow INFO:",
+        "  ... payload that doesn't match [Node] pattern ...",
+        "250504-12:31:18,847 nipype.workflow INFO:",
+        "\t [Node] Finished \"foo.bar.baz\", elapsed time 5s.",
+    ])
+    assert [e["event"] for e in events] == ["node_done"]
+    assert events[0]["leaf"] == "baz"
+
+
+def test_aggregator_collapses_jsonl(tmp_path):
+    p = tmp_path / "nipype_events.jsonl"
+    append_jsonl(p, {"event": "node_start", "node": "wf.a.smooth", "leaf": "smooth",
+                     "workflow": "wf.a", "t": 100.0, "level": "INFO"})
+    append_jsonl(p, {"event": "node_start", "node": "wf.a.mask", "leaf": "mask",
+                     "workflow": "wf.a", "t": 105.0, "level": "INFO"})
+    append_jsonl(p, {"event": "node_done", "node": "wf.a.smooth", "leaf": "smooth",
+                     "workflow": "wf.a", "t": 110.0, "level": "INFO"})
+    append_jsonl(p, {"event": "node_fail", "node": "wf.a.mask", "leaf": "mask",
+                     "workflow": "wf.a", "t": 115.0, "level": "ERROR"})
+
+    block = parse_nipype_events_file(p)
+    by_leaf = {n.leaf: n for n in block.recent_nodes}
+    assert by_leaf["smooth"].status == "ok"
+    assert by_leaf["smooth"].elapsed == 10.0
+    assert by_leaf["mask"].status == "failed"
+    assert by_leaf["mask"].elapsed == 10.0
+    assert block.counts == {"running": 0, "ok": 1, "failed": 1, "total_seen": 2}
+
+
+def test_aggregator_unfinished_nodes_default_to_running(tmp_path):
+    p = tmp_path / "events.jsonl"
+    append_jsonl(p, {"event": "node_start", "node": "wf.a.x", "leaf": "x",
+                     "workflow": "wf.a", "t": 10.0, "level": "INFO"})
+    block = parse_nipype_events_file(p)
+    assert block.counts["running"] == 1
+    assert block.recent_nodes[0].status == "running"
+
+
+def test_aggregator_caps_total_returned(tmp_path):
+    p = tmp_path / "events.jsonl"
+    for i in range(50):
+        append_jsonl(p, {"event": "node_done", "node": f"wf.a.n{i}", "leaf": f"n{i}",
+                         "workflow": "wf.a", "t": 100.0 + i, "level": "INFO"})
+    block = parse_nipype_events_file(p, cap=10)
+    assert len(block.recent_nodes) == 10
+    # Most-recent retained.
+    assert block.recent_nodes[-1].leaf == "n49"
+    assert block.counts["total_seen"] == 50  # counts reflect full set
+
+
+def test_aggregator_empty_path_returns_zeros(tmp_path):
+    block = parse_nipype_events_file(tmp_path / "missing.jsonl")
+    assert block.counts == {"running": 0, "ok": 0, "failed": 0, "total_seen": 0}
+    assert block.recent_nodes == []
+
+
+def test_aggregator_skips_malformed_lines(tmp_path):
+    p = tmp_path / "events.jsonl"
+    p.write_text("not json\n" + json.dumps({
+        "event": "node_done", "node": "wf.x", "leaf": "x", "workflow": "wf",
+        "t": 1.0, "level": "INFO",
+    }) + "\n")
+    block = parse_nipype_events_file(p)
+    assert block.counts["ok"] == 1

--- a/tests/test_preproc/test_nipype_log.py
+++ b/tests/test_preproc/test_nipype_log.py
@@ -123,6 +123,26 @@ def test_aggregator_empty_path_returns_zeros(tmp_path):
     assert block.recent_nodes == []
 
 
+def test_parser_rewrites_leaf_only_terminal_events_to_full_path():
+    """fmriprep's `[Node] Finished "leaf"` lines drop the workflow path.
+
+    The parser remembers the full path from the matching `Setting-up`
+    and reattaches it on the terminal event so aggregation collapses
+    start + done into one node instead of two.
+    """
+    parser = NipypeLogParser()
+    events = _drain(parser, [
+        '250504-12:31:02,123 nipype.workflow INFO:',
+        '\t [Node] Setting-up "fmriprep_wf.sub_AN_wf.surface_recon_wf.recon_config" in "/work/...".',
+        '250504-12:31:04,000 nipype.workflow INFO:',
+        '\t [Node] Finished "recon_config", elapsed time 2.0s.',
+    ])
+    assert [e["event"] for e in events] == ["node_start", "node_done"]
+    # Both events refer to the same fully-qualified node path.
+    assert events[0]["node"] == events[1]["node"]
+    assert events[1]["workflow"] == "fmriprep_wf.sub_AN_wf.surface_recon_wf"
+
+
 def test_aggregator_skips_malformed_lines(tmp_path):
     p = tmp_path / "events.jsonl"
     p.write_text("not json\n" + json.dumps({

--- a/tests/test_preproc/test_nipype_log_pairing.py
+++ b/tests/test_preproc/test_nipype_log_pairing.py
@@ -1,0 +1,138 @@
+"""FIFO leaf matching + read-time reconciliation + run-end sweep."""
+
+from __future__ import annotations
+
+from fmriflow.preproc.nipype_log import (
+    NipypeLogParser,
+    append_jsonl,
+    parse_nipype_events_file,
+    reconcile_with_run_state,
+)
+
+
+def _drain(parser: NipypeLogParser, lines: list[str]) -> list[dict]:
+    out: list[dict] = []
+    for line in lines:
+        out.extend(parser.feed(line))
+    return out
+
+
+def test_parser_fifo_pairs_concurrent_same_leaf_in_order():
+    """Two `Setting-up` events for the same leaf, then two `Finished` —
+    each terminal pops the matching full path FIFO-style."""
+    parser = NipypeLogParser()
+    events = _drain(parser, [
+        '250504-12:00:00,000 nipype.workflow INFO:',
+        '\t [Node] Setting-up "wf.a.smooth" in "/work/.../a.smooth".',
+        '250504-12:00:00,001 nipype.workflow INFO:',
+        '\t [Node] Setting-up "wf.b.smooth" in "/work/.../b.smooth".',
+        '250504-12:00:05,000 nipype.workflow INFO:',
+        '\t [Node] Finished "smooth", elapsed time 5.0s.',
+        '250504-12:00:06,000 nipype.workflow INFO:',
+        '\t [Node] Finished "smooth", elapsed time 6.0s.',
+    ])
+    # 4 events: 2 starts, 2 dones — but the dones must reattach the
+    # FIRST start (a.smooth) and THEN the second (b.smooth).
+    assert [e["event"] for e in events] == [
+        "node_start", "node_start", "node_done", "node_done",
+    ]
+    assert events[0]["node"] == "wf.a.smooth"
+    assert events[1]["node"] == "wf.b.smooth"
+    assert events[2]["node"] == "wf.a.smooth"   # first done → first start
+    assert events[3]["node"] == "wf.b.smooth"
+
+
+def test_parser_fifo_documented_limitation_when_finish_order_differs():
+    """If sibling leaves finish out of order, FIFO mis-pairs them.
+
+    This is the documented v1 limitation — the run-end sweep catches
+    the resulting "stuck running" node afterwards.
+    """
+    parser = NipypeLogParser()
+    events = _drain(parser, [
+        '250504-12:00:00,000 nipype.workflow INFO:',
+        '\t [Node] Setting-up "wf.a.smooth" in "/work/.../a.smooth".',
+        '250504-12:00:00,001 nipype.workflow INFO:',
+        '\t [Node] Setting-up "wf.b.smooth" in "/work/.../b.smooth".',
+        # b finishes first, but FIFO will assign this done to a.
+        '250504-12:00:03,000 nipype.workflow INFO:',
+        '\t [Node] Finished "smooth", elapsed time 3.0s.',
+    ])
+    # FIFO assigns the done to the first start (a.smooth).
+    done = events[-1]
+    assert done["event"] == "node_done"
+    assert done["node"] == "wf.a.smooth"
+
+
+def test_aggregator_reconciles_legacy_jsonl_with_leaf_only_dones(tmp_path):
+    """The on-disk JSONL we produced before the FIFO fix had bare-leaf
+    terminal events. The aggregator now does a read-time leaf-walk so
+    the existing files render correctly without rewrite.
+    """
+    p = tmp_path / "nipype_events.jsonl"
+    # Two starts with full paths, both dones with bare leaves — the
+    # exact shape of the bug we hit on the AN run.
+    append_jsonl(p, {"event": "node_start", "node": "wf.a.smooth", "leaf": "smooth",
+                     "workflow": "wf.a", "t": 100.0, "level": "INFO"})
+    append_jsonl(p, {"event": "node_start", "node": "wf.b.smooth", "leaf": "smooth",
+                     "workflow": "wf.b", "t": 101.0, "level": "INFO"})
+    append_jsonl(p, {"event": "node_done", "node": "smooth", "leaf": "smooth",
+                     "workflow": "", "t": 105.0, "level": "INFO"})
+    append_jsonl(p, {"event": "node_done", "node": "smooth", "leaf": "smooth",
+                     "workflow": "", "t": 106.0, "level": "INFO"})
+
+    block = parse_nipype_events_file(p)
+    assert block.counts == {"running": 0, "ok": 2, "failed": 0,
+                            "completed_assumed": 0, "total_seen": 2}
+    by_node = {n.node: n.status for n in block.recent_nodes}
+    assert by_node == {"wf.a.smooth": "ok", "wf.b.smooth": "ok"}
+
+
+def test_aggregator_handles_one_done_and_one_orphan_start(tmp_path):
+    """One bare-leaf done pops the oldest start; the other start stays
+    open and surfaces as ``running``."""
+    p = tmp_path / "events.jsonl"
+    append_jsonl(p, {"event": "node_start", "node": "wf.a.smooth", "leaf": "smooth",
+                     "workflow": "wf.a", "t": 100.0, "level": "INFO"})
+    append_jsonl(p, {"event": "node_start", "node": "wf.b.smooth", "leaf": "smooth",
+                     "workflow": "wf.b", "t": 101.0, "level": "INFO"})
+    append_jsonl(p, {"event": "node_done", "node": "smooth", "leaf": "smooth",
+                     "workflow": "", "t": 105.0, "level": "INFO"})
+    block = parse_nipype_events_file(p)
+    assert block.counts["ok"] == 1
+    assert block.counts["running"] == 1
+
+
+def test_aggregator_keeps_unmatched_bare_leaf_as_separate_node(tmp_path):
+    """Bare-leaf done with no matching start at all → recorded as its
+    own node so we don't silently drop information."""
+    p = tmp_path / "events.jsonl"
+    append_jsonl(p, {"event": "node_done", "node": "lonely_leaf", "leaf": "lonely_leaf",
+                     "workflow": "", "t": 1.0, "level": "INFO"})
+    block = parse_nipype_events_file(p)
+    assert block.counts == {"running": 0, "ok": 1, "failed": 0,
+                            "completed_assumed": 0, "total_seen": 1}
+    assert block.recent_nodes[0].node == "lonely_leaf"
+
+
+def test_run_end_sweep_marks_orphans_completed_assumed_when_done(tmp_path):
+    """When state.json says ``done``, any node still ``running`` in the
+    aggregated block is flipped to ``completed_assumed``."""
+    p = tmp_path / "events.jsonl"
+    append_jsonl(p, {"event": "node_start", "node": "wf.x", "leaf": "x",
+                     "workflow": "wf", "t": 1.0, "level": "INFO"})
+    block = parse_nipype_events_file(p)
+    assert block.counts["running"] == 1
+    sweep = reconcile_with_run_state(block, run_status="done")
+    assert sweep.counts["running"] == 0
+    assert sweep.counts["completed_assumed"] == 1
+    assert sweep.recent_nodes[0].status == "completed_assumed"
+
+
+def test_run_end_sweep_no_op_when_run_still_running(tmp_path):
+    p = tmp_path / "events.jsonl"
+    append_jsonl(p, {"event": "node_start", "node": "wf.x", "leaf": "x",
+                     "workflow": "wf", "t": 1.0, "level": "INFO"})
+    block = parse_nipype_events_file(p)
+    sweep = reconcile_with_run_state(block, run_status="running")
+    assert sweep.counts == block.counts

--- a/tests/test_preproc/test_node_outputs.py
+++ b/tests/test_preproc/test_node_outputs.py
@@ -1,0 +1,207 @@
+"""/api/preproc/runs/{id}/node/{path}/(files|file|pickle) endpoints."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import pickle
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fmriflow.server.services.preproc_manager import (
+    PreprocManager,
+    PreprocRunHandle,
+)
+from fmriflow.server.services.run_registry import RunRegistry, RunStateFile
+
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app_with_run(tmp_path, monkeypatch):
+    """An app whose preproc_manager has a single completed run with a
+    real on-disk work_dir + a couple of node leaves prepared for us."""
+    from fmriflow.server.app import create_app
+
+    work_dir = tmp_path / "work"
+    output_dir = tmp_path / "out"
+    leaf = work_dir / "fmriprep_wf" / "anat_wf" / "smooth"
+    leaf.mkdir(parents=True)
+    (leaf / "command.txt").write_text("smooth -fwhm 5\n")
+    (leaf / "_inputs.json").write_text(json.dumps({"fwhm": 5.0}))
+    (leaf / "ignore.unknown").write_text("not whitelisted")
+
+    # A pickled dict as result_smooth.pklz (gzip-wrapped, like nipype).
+    p = leaf / "result_smooth.pklz"
+    with gzip.open(p, "wb") as f:
+        pickle.dump({"out_file": "/tmp/x.nii.gz", "n_iter": 3}, f)
+
+    # A bogus pickle that won't decode.
+    bad = leaf / "broken.pkl"
+    bad.write_bytes(b"not actually a pickle")
+
+    app = create_app(derivatives_dir=str(tmp_path / "derivatives"))
+    mgr: PreprocManager = app.state.preproc_manager
+    handle = PreprocRunHandle(
+        run_id="run_demo",
+        subject="01",
+        backend="fmriprep",
+        status="done",
+        params={"work_dir": str(work_dir), "output_dir": str(output_dir)},
+    )
+    mgr.active_runs["run_demo"] = handle
+    return app, handle
+
+
+def test_files_lists_whitelisted_artefacts(app_with_run):
+    app, _ = app_with_run
+    c = TestClient(app)
+    r = c.get(
+        "/api/preproc/runs/run_demo/node/fmriprep_wf.anat_wf.smooth/files",
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["exists"] is True
+    names = {f["name"] for f in data["files"]}
+    assert names == {"command.txt", "_inputs.json", "result_smooth.pklz",
+                     "broken.pkl"}
+    assert "ignore.unknown" not in names
+
+    by_name = {f["name"]: f for f in data["files"]}
+    assert by_name["command.txt"]["kind"] == "view"
+    assert by_name["_inputs.json"]["kind"] == "view"
+    assert by_name["result_smooth.pklz"]["kind"] == "pickle"
+    assert by_name["broken.pkl"]["kind"] == "pickle"
+
+
+def test_files_returns_exists_false_for_missing_leaf(app_with_run):
+    app, _ = app_with_run
+    c = TestClient(app)
+    r = c.get(
+        "/api/preproc/runs/run_demo/node/fmriprep_wf.anat_wf.no_such_node/files",
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["exists"] is False
+    assert body["files"] == []
+
+
+def test_file_serves_content(app_with_run):
+    app, _ = app_with_run
+    c = TestClient(app)
+    r = c.get(
+        "/api/preproc/runs/run_demo/node/fmriprep_wf.anat_wf.smooth/file",
+        params={"rel": "command.txt"},
+    )
+    assert r.status_code == 200
+    assert "smooth -fwhm 5" in r.text
+
+
+def test_file_refuses_unknown_suffix(app_with_run):
+    app, _ = app_with_run
+    c = TestClient(app)
+    r = c.get(
+        "/api/preproc/runs/run_demo/node/fmriprep_wf.anat_wf.smooth/file",
+        params={"rel": "ignore.unknown"},
+    )
+    assert r.status_code == 403
+
+
+def test_file_refuses_path_traversal(app_with_run):
+    app, _ = app_with_run
+    c = TestClient(app)
+    r = c.get(
+        "/api/preproc/runs/run_demo/node/fmriprep_wf.anat_wf.smooth/file",
+        params={"rel": "../../../etc/passwd.txt"},
+    )
+    assert r.status_code in (403, 404)
+
+
+def test_pickle_decodes_dict(app_with_run):
+    app, _ = app_with_run
+    c = TestClient(app)
+    r = c.get(
+        "/api/preproc/runs/run_demo/node/fmriprep_wf.anat_wf.smooth/pickle",
+        params={"rel": "result_smooth.pklz"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["type"] == "dict"
+    assert body["value"]["n_iter"] == 3
+    assert body["value"]["out_file"].endswith("x.nii.gz")
+
+
+def test_pickle_returns_error_for_corrupt(app_with_run):
+    app, _ = app_with_run
+    c = TestClient(app)
+    r = c.get(
+        "/api/preproc/runs/run_demo/node/fmriprep_wf.anat_wf.smooth/pickle",
+        params={"rel": "broken.pkl"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert "error" in body
+
+
+def test_pickle_refuses_non_pickle_suffix(app_with_run):
+    app, _ = app_with_run
+    c = TestClient(app)
+    r = c.get(
+        "/api/preproc/runs/run_demo/node/fmriprep_wf.anat_wf.smooth/pickle",
+        params={"rel": "command.txt"},
+    )
+    assert r.status_code == 403
+
+
+def test_404_when_run_unknown(tmp_path):
+    from fmriflow.server.app import create_app
+    app = create_app(derivatives_dir=str(tmp_path))
+    c = TestClient(app)
+    r = c.get(
+        "/api/preproc/runs/no-such-run/node/wf.x/files",
+    )
+    assert r.status_code == 404
+
+
+def test_409_when_run_has_no_work_dir(tmp_path):
+    from fmriflow.server.app import create_app
+    app = create_app(derivatives_dir=str(tmp_path))
+    mgr: PreprocManager = app.state.preproc_manager
+    mgr.active_runs["r"] = PreprocRunHandle(
+        run_id="r", subject="01", backend="fmriprep", status="done",
+        params={},  # no work_dir
+    )
+    c = TestClient(app)
+    r = c.get("/api/preproc/runs/r/node/wf.x/files")
+    assert r.status_code == 409
+
+
+def test_finds_matching_crash_files(tmp_path):
+    """When a run has crashes for the leaf, /files surfaces them."""
+    from fmriflow.server.app import create_app
+
+    work_dir = tmp_path / "work"
+    output_dir = tmp_path / "out"
+    leaf = work_dir / "fmriprep_wf" / "boom"
+    leaf.mkdir(parents=True)
+    log_dir = output_dir / "sub-01" / "log" / "20260505-150000"
+    log_dir.mkdir(parents=True)
+    (log_dir / "crash-20260505-boom-abc.txt").write_text("traceback...")
+    (log_dir / "crash-20260505-other-abc.txt").write_text("unrelated")
+
+    app = create_app(derivatives_dir=str(tmp_path))
+    mgr: PreprocManager = app.state.preproc_manager
+    mgr.active_runs["r"] = PreprocRunHandle(
+        run_id="r", subject="01", backend="fmriprep", status="failed",
+        params={"work_dir": str(work_dir), "output_dir": str(output_dir)},
+    )
+    c = TestClient(app)
+    r = c.get("/api/preproc/runs/r/node/fmriprep_wf.boom/files")
+    assert r.status_code == 200
+    crashes = r.json()["crashes"]
+    assert len(crashes) == 1
+    assert crashes[0]["name"].startswith("crash-")
+    assert "boom" in crashes[0]["name"]

--- a/tests/test_qc/test_freeview_command.py
+++ b/tests/test_qc/test_freeview_command.py
@@ -1,0 +1,33 @@
+"""Build a freeview command from a stub FS subject directory."""
+
+from __future__ import annotations
+
+from fmriflow.server.routes.structural_qc import _build_freeview_command
+
+
+def test_command_includes_only_existing_files(tmp_path):
+    fs_subject = tmp_path / "sub-01"
+    (fs_subject / "mri").mkdir(parents=True)
+    (fs_subject / "surf").mkdir(parents=True)
+
+    # Only create T1.mgz and lh.pial
+    (fs_subject / "mri" / "T1.mgz").write_bytes(b"")
+    (fs_subject / "surf" / "lh.pial").write_bytes(b"")
+
+    cmd = _build_freeview_command(fs_subject)
+
+    assert cmd.startswith("freeview")
+    assert "T1.mgz" in cmd
+    assert "lh.pial" in cmd
+    # Files we didn't create must be absent
+    assert "aseg.mgz" not in cmd
+    assert "rh.pial" not in cmd
+    assert "lh.white" not in cmd
+    assert "brainmask.mgz" not in cmd
+
+
+def test_empty_fs_dir_yields_bare_command(tmp_path):
+    fs_subject = tmp_path / "sub-01"
+    fs_subject.mkdir()
+    cmd = _build_freeview_command(fs_subject)
+    assert cmd == "freeview"

--- a/tests/test_qc/test_list_all_reviews.py
+++ b/tests/test_qc/test_list_all_reviews.py
@@ -1,0 +1,37 @@
+"""StructuralQCStore.list_all walks every dataset under root."""
+
+from __future__ import annotations
+
+from fmriflow.qc.structural_review import StructuralQCReview
+from fmriflow.server.services.structural_qc_store import StructuralQCStore
+
+
+def test_list_all_returns_reviews_across_datasets(tmp_path):
+    store = StructuralQCStore(tmp_path)
+    store.save(StructuralQCReview(dataset="ds-a", subject="sub01", status="approved"))
+    store.save(StructuralQCReview(dataset="ds-a", subject="sub02", status="needs_edits"))
+    store.save(StructuralQCReview(dataset="ds-b", subject="sub01", status="rejected"))
+
+    rows = store.list_all()
+    keyed = {(r.dataset, r.subject): r.status for r in rows}
+    assert keyed == {
+        ("ds-a", "sub01"): "approved",
+        ("ds-a", "sub02"): "needs_edits",
+        ("ds-b", "sub01"): "rejected",
+    }
+
+
+def test_list_all_empty_when_no_root(tmp_path):
+    store = StructuralQCStore(tmp_path / "missing")
+    assert store.list_all() == []
+
+
+def test_list_all_skips_unsafe_dataset_dirs(tmp_path):
+    """Stray directories that aren't valid dataset names are ignored."""
+    store = StructuralQCStore(tmp_path)
+    store.save(StructuralQCReview(dataset="ds-a", subject="sub01", status="approved"))
+    # Create a directory that wouldn't pass the safe-name regex.
+    (tmp_path / ".hidden").mkdir()
+    rows = store.list_all()
+    assert len(rows) == 1
+    assert rows[0].dataset == "ds-a"

--- a/tests/test_qc/test_structural_qc_store.py
+++ b/tests/test_qc/test_structural_qc_store.py
@@ -1,0 +1,59 @@
+"""Round-trip StructuralQCReview through StructuralQCStore."""
+
+from __future__ import annotations
+
+import pytest
+
+from fmriflow.qc.structural_review import StructuralQCReview
+from fmriflow.server.services.structural_qc_store import StructuralQCStore
+
+
+def test_save_and_get_roundtrip(tmp_path):
+    store = StructuralQCStore(tmp_path)
+    review = StructuralQCReview(
+        dataset="ds-foo",
+        subject="sub01",
+        status="approved",
+        reviewer="omar",
+        notes="surfaces look good",
+    )
+    store.save(review)
+
+    got = store.get("ds-foo", "sub01")
+    assert got is not None
+    assert got.status == "approved"
+    assert got.reviewer == "omar"
+    assert got.notes == "surfaces look good"
+    # save() refreshes timestamp
+    assert got.timestamp
+
+
+def test_get_missing_returns_none(tmp_path):
+    store = StructuralQCStore(tmp_path)
+    assert store.get("ds-foo", "sub01") is None
+
+
+def test_list_for_dataset(tmp_path):
+    store = StructuralQCStore(tmp_path)
+    store.save(StructuralQCReview(dataset="ds", subject="sub01", status="approved"))
+    store.save(StructuralQCReview(dataset="ds", subject="sub02", status="needs_edits"))
+    store.save(StructuralQCReview(dataset="other", subject="sub01", status="approved"))
+
+    rows = store.list_for_dataset("ds")
+    assert {(r.subject, r.status) for r in rows} == {
+        ("sub01", "approved"),
+        ("sub02", "needs_edits"),
+    }
+
+
+def test_unsafe_dataset_name_rejected(tmp_path):
+    store = StructuralQCStore(tmp_path)
+    with pytest.raises(ValueError):
+        store.save(
+            StructuralQCReview(dataset="../etc", subject="sub01", status="approved")
+        )
+
+
+def test_invalid_status_rejected():
+    with pytest.raises(ValueError):
+        StructuralQCReview(dataset="ds", subject="sub01", status="bogus")

--- a/tests/test_scripts/test_backfill_nipype_events.py
+++ b/tests/test_scripts/test_backfill_nipype_events.py
@@ -1,0 +1,110 @@
+"""Backfill the JSONL of an old finished run with FIFO leaf matching."""
+
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+
+# Import the script as a module (it lives outside fmriflow/).
+_SCRIPT = (
+    Path(__file__).resolve().parent.parent.parent
+    / "scripts" / "backfill_nipype_events.py"
+)
+spec = importlib.util.spec_from_file_location("backfill", _SCRIPT)
+backfill = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(backfill)  # type: ignore[union-attr]
+
+
+def _write_jsonl(p: Path, events: list[dict]) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+
+
+def _read_jsonl(p: Path) -> list[dict]:
+    return [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
+
+
+def test_backfill_rewrites_bare_leaf_dones_to_full_paths(tmp_path):
+    p = tmp_path / "nipype_events.jsonl"
+    _write_jsonl(p, [
+        {"event": "node_start", "node": "wf.a.smooth", "leaf": "smooth",
+         "workflow": "wf.a", "t": 1.0, "level": "INFO"},
+        {"event": "node_start", "node": "wf.b.smooth", "leaf": "smooth",
+         "workflow": "wf.b", "t": 2.0, "level": "INFO"},
+        {"event": "node_done", "node": "smooth", "leaf": "smooth",
+         "workflow": "", "t": 5.0, "level": "INFO"},
+        {"event": "node_done", "node": "smooth", "leaf": "smooth",
+         "workflow": "", "t": 6.0, "level": "INFO"},
+    ])
+    rc = backfill.main([str(p)])
+    assert rc == 0
+    events = _read_jsonl(p)
+    dones = [e for e in events if e["event"] == "node_done"]
+    assert dones[0]["node"] == "wf.a.smooth"
+    assert dones[1]["node"] == "wf.b.smooth"
+    # Original preserved as .bak
+    assert (p.with_suffix(p.suffix + ".bak")).is_file()
+
+
+def test_backfill_dry_run_does_not_modify_file(tmp_path):
+    p = tmp_path / "nipype_events.jsonl"
+    _write_jsonl(p, [
+        {"event": "node_start", "node": "wf.a.x", "leaf": "x",
+         "workflow": "wf.a", "t": 1.0, "level": "INFO"},
+        {"event": "node_done", "node": "x", "leaf": "x",
+         "workflow": "", "t": 2.0, "level": "INFO"},
+    ])
+    before = p.read_text()
+    rc = backfill.main(["--dry-run", str(p)])
+    assert rc == 0
+    assert p.read_text() == before
+    assert not (p.with_suffix(p.suffix + ".bak")).exists()
+
+
+def test_backfill_walks_directory(tmp_path):
+    p1 = tmp_path / "run-a" / "nipype_events.jsonl"
+    p2 = tmp_path / "run-b" / "nipype_events.jsonl"
+    for p in (p1, p2):
+        _write_jsonl(p, [
+            {"event": "node_start", "node": "wf.x", "leaf": "x",
+             "workflow": "wf", "t": 1.0, "level": "INFO"},
+            {"event": "node_done", "node": "x", "leaf": "x",
+             "workflow": "", "t": 2.0, "level": "INFO"},
+        ])
+    rc = backfill.main([str(tmp_path)])
+    assert rc == 0
+    for p in (p1, p2):
+        events = _read_jsonl(p)
+        assert events[1]["node"] == "wf.x"
+
+
+def test_backfill_idempotent(tmp_path):
+    p = tmp_path / "nipype_events.jsonl"
+    _write_jsonl(p, [
+        {"event": "node_start", "node": "wf.x", "leaf": "x",
+         "workflow": "wf", "t": 1.0, "level": "INFO"},
+        {"event": "node_done", "node": "x", "leaf": "x",
+         "workflow": "", "t": 2.0, "level": "INFO"},
+    ])
+    backfill.main([str(p)])
+    after_first = p.read_text()
+    backfill.main([str(p)])
+    assert p.read_text() == after_first
+
+
+def test_backfill_skips_malformed_lines(tmp_path):
+    p = tmp_path / "nipype_events.jsonl"
+    p.write_text(
+        "not json\n"
+        + json.dumps({"event": "node_start", "node": "wf.x", "leaf": "x",
+                      "workflow": "wf", "t": 1.0, "level": "INFO"}) + "\n"
+        + json.dumps({"event": "node_done", "node": "x", "leaf": "x",
+                      "workflow": "", "t": 2.0, "level": "INFO"}) + "\n"
+    )
+    rc = backfill.main([str(p)])
+    assert rc == 0
+    lines = p.read_text().splitlines()
+    assert lines[0] == "not json"  # malformed left intact


### PR DESCRIPTION
## Summary

Long-running feature branch covering the live nipype-node monitoring stack and the Structural QC / Workflows UX work that grew out of it.

### Live nipype-node monitoring
- Live DAG modal with per-node status, FIFO leaf matching, run-end sweep + backfill script.
- Hierarchical, searchable, collapsible node list (left of the DAG); cached leaves discovered by walking `work_dir` for `_node.pklz` are merged as synthetic `cached` entries so search/filter find them.
- Selecting a node pans + zooms the DAG canvas; per-node fmriprep output drawer renders JSON / TSV / text / SVG / NIfTI inline.

### Structural QC
- Reviewer sign-off flow (browser + freeview), cross-dataset QC Reviews view, manifest status pill.
- 3D viewer: pial/white/inflated overlay, freeview palette, X-ray slider, Volume on/off, fullscreen-only entry.
- Serves fmriprep report's relative figure assets.

### Workflows graph polish
- Straight edges + adaptive cumulative-width spacing on the Workflows-tab graph; cards centred on a shared y so straight edges stay horizontal across varying card heights.
- Builder-tab `PipelineGraph` re-runs `autoLayout` once dagre has measured sizes.
- Single View DAG button on the preproc card.

## Test plan
- [x] Open Workflows tab on a finished preproc run → cards lay out with equal gaps and straight horizontal edges.
- [x] Open the DAG modal → node list defaults to collapsed workflows; searching auto-expands matches; collapse/expand still works during search.
- [x] Search for a `bold_hmc_wf` leaf on a fmriprep run that streamed events in a prior session → cached leaves appear.
- [x] Click a leaf → outputs drawer opens; close it via the arrow without closing the modal.
- [x] Structural QC → Show 3D viewer opens fullscreen directly; Close dismisses.
- [x] `pytest tests/` and `cd frontend && npm test` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)