### PR TITLE
Dockerize fmriflow: slim + full images, one-step compose up

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Version control
+.git
+.gitignore
+.github
+
+# Frontend build artefacts
+frontend/node_modules
+frontend/dist
+frontend/.vite
+frontend/coverage
+frontend/playwright-report
+frontend/test-results
+
+# Backend build artefacts
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/*.pyd
+.pytest_cache
+.mypy_cache
+.ruff_cache
+htmlcov
+.coverage
+*.egg-info
+build/
+dist/
+
+# Pipeline working dirs (developers may have these locally)
+testing/
+work/
+work_dir/
+derivatives/
+results/
+experiments/
+license/
+bids/
+dicoms/
+.fmriflow/
+
+# Editor / OS noise
+.vscode
+.idea
+.DS_Store
+*.swp
+
+# Internal dev docs (gitignored anyway, but be explicit)
+devdocs/
+
+# Compose files referencing local paths
+docker-compose.override.yml
+.env
+.env.*
+!.env.example
+
+# Existing static build (we rebuild from source in the image)
+fmriflow/server/static

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -16,8 +16,8 @@ services:
       context: .
       dockerfile: docker/Dockerfile.full
       args:
-        PUID: ${UID:-1000}
-        PGID: ${GID:-1000}
+        PUID: ${PUID:-1000}
+        PGID: ${PGID:-1000}
         # Bump this to test against a newer fmriprep without
         # editing the Dockerfile.
         FMRIPREP_TAG: 24.1.1
@@ -27,8 +27,8 @@ services:
     environment:
       FS_LICENSE: /data/license/license.txt
       FS_LICENSE_TEXT: ${FS_LICENSE_TEXT:-}
-      PUID: ${UID:-1000}
-      PGID: ${GID:-1000}
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
     volumes:
       - fmriflow-state:/data
       - ./experiments:/workspace/experiments

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -1,0 +1,45 @@
+# fmriflow full — self-contained image with fmriprep + FreeSurfer
+# baked in. No second container runtime required.
+#
+# Usage:
+#   docker compose -f docker-compose.full.yml up
+#
+# The full image is heavy (~25 GB) because it builds on
+# nipreps/fmriprep. Use docker-compose.yml (slim) instead if you
+# already have docker or apptainer on the host and just want the
+# fmriflow orchestrator.
+
+services:
+  fmriflow:
+    container_name: fmriflow
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.full
+      args:
+        PUID: ${UID:-1000}
+        PGID: ${GID:-1000}
+        # Bump this to test against a newer fmriprep without
+        # editing the Dockerfile.
+        FMRIPREP_TAG: 24.1.1
+    image: fmriflow:full
+    ports:
+      - "8421:8421"
+    environment:
+      FS_LICENSE: /data/license/license.txt
+      FS_LICENSE_TEXT: ${FS_LICENSE_TEXT:-}
+      PUID: ${UID:-1000}
+      PGID: ${GID:-1000}
+    volumes:
+      - fmriflow-state:/data
+      - ./experiments:/workspace/experiments
+      - ./results:/workspace/results
+      - ./derivatives:/workspace/derivatives
+      - ./bids:/workspace/bids:ro
+      - ./dicoms:/workspace/dicoms:ro
+      - ./license:/data/license:ro
+      # No /var/run/docker.sock — fmriprep runs in-process via
+      # `container_type: bare` in your preproc YAML.
+    restart: unless-stopped
+
+volumes:
+  fmriflow-state:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       context: .
       dockerfile: docker/Dockerfile.slim
       args:
-        PUID: ${UID:-1000}
-        PGID: ${GID:-1000}
+        PUID: ${PUID:-1000}
+        PGID: ${PGID:-1000}
     image: fmriflow:slim
     ports:
       - "8421:8421"
@@ -29,8 +29,8 @@ services:
       #   - set FS_LICENSE_TEXT in your shell / .env to pass the content inline.
       FS_LICENSE: /data/license/license.txt
       FS_LICENSE_TEXT: ${FS_LICENSE_TEXT:-}
-      PUID: ${UID:-1000}
-      PGID: ${GID:-1000}
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
     volumes:
       # Persistent state: ~/.fmriflow/ (run registry, modules, QC,
       # workflows, registered heuristics).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+# fmriflow slim — orchestrator only.
+#
+# fmriprep is delegated to the host's docker daemon by mounting
+# /var/run/docker.sock. Configure your preproc YAML with
+# `container_type: docker` and `container: nipreps/fmriprep:24.1.1`.
+#
+# For the standalone variant (FreeSurfer + fmriprep baked in), use:
+#   docker compose -f docker-compose.full.yml up
+#
+# For apptainer-on-host instead of docker-out-of-docker, see
+# docs/guide/docker.md.
+
+services:
+  fmriflow:
+    container_name: fmriflow
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.slim
+      args:
+        PUID: ${UID:-1000}
+        PGID: ${GID:-1000}
+    image: fmriflow:slim
+    ports:
+      - "8421:8421"
+    environment:
+      # Path the FS license file resolves to inside the container.
+      # Provide one of:
+      #   - bind ./license/license.txt to /data/license/license.txt (default below), or
+      #   - set FS_LICENSE_TEXT in your shell / .env to pass the content inline.
+      FS_LICENSE: /data/license/license.txt
+      FS_LICENSE_TEXT: ${FS_LICENSE_TEXT:-}
+      PUID: ${UID:-1000}
+      PGID: ${GID:-1000}
+    volumes:
+      # Persistent state: ~/.fmriflow/ (run registry, modules, QC,
+      # workflows, registered heuristics).
+      - fmriflow-state:/data
+      # User-editable workspace.
+      - ./experiments:/workspace/experiments
+      - ./results:/workspace/results
+      - ./derivatives:/workspace/derivatives
+      # BIDS + DICOM inputs (read-only). Adjust to your data layout.
+      - ./bids:/workspace/bids:ro
+      - ./dicoms:/workspace/dicoms:ro
+      # FreeSurfer license (drop your license.txt under ./license/).
+      - ./license:/data/license:ro
+      # docker-out-of-docker for fmriprep. Comment this line if you
+      # are using apptainer-on-host instead.
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+
+volumes:
+  fmriflow-state:

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -59,7 +59,6 @@ RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir '.[frontend,bids]'
 
 COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/
-COPY heuristics/ /app/heuristics/
 
 RUN mkdir -p /workspace/experiments /workspace/results /workspace/derivatives \
              /data/.fmriflow /data/heuristics /data/modules \

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -1,0 +1,80 @@
+# syntax=docker/dockerfile:1.7
+# fmriflow full — self-contained image with fmriprep + FreeSurfer
+# + ANTs + AFNI baked in (built on top of nipreps/fmriprep). Use
+# this when you don't want to manage a second container runtime;
+# preproc YAMLs can run with `container_type: bare`.
+
+ARG FMRIPREP_TAG=24.1.1
+
+# ── Stage 1: build the frontend ─────────────────────────────────────
+FROM node:20-alpine AS frontend-build
+
+WORKDIR /build/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY frontend/ ./
+RUN npm run build
+
+
+# ── Stage 2: runtime on top of fmriprep ─────────────────────────────
+FROM nipreps/fmriprep:${FMRIPREP_TAG} AS runtime
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# tini + gosu for the entrypoint. The fmriprep image already ships
+# Python, FreeSurfer, fmriprep, ANTs, AFNI, and dcm2niix.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gosu \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node 20 + bids-validator. Some fmriprep tags ship an old node; use
+# NodeSource to be safe.
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g bids-validator \
+    && npm cache clean --force
+
+ARG PUID=1000
+ARG PGID=1000
+RUN groupadd -g ${PGID} fmriflow \
+    && useradd -m -u ${PUID} -g ${PGID} -d /home/fmriflow -s /bin/bash fmriflow
+
+WORKDIR /app
+
+# Install fmriflow on top of the fmriprep python env.
+COPY pyproject.toml README.md ./
+COPY fmriflow/ ./fmriflow/
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir heudiconv \
+    && pip install --no-cache-dir '.[frontend,bids]'
+
+COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/
+COPY heuristics/ /app/heuristics/
+
+RUN mkdir -p /workspace/experiments /workspace/results /workspace/derivatives \
+             /data/.fmriflow /data/heuristics /data/modules \
+    && chown -R fmriflow:fmriflow /app /workspace /data
+
+ENV HOME=/data \
+    FMRIFLOW_HEURISTICS_DIR=/data/heuristics \
+    FMRIFLOW_MODULES_DIR=/data/modules
+
+EXPOSE 8421
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /workspace
+# Override fmriprep's default ENTRYPOINT.
+ENTRYPOINT ["tini", "--", "/usr/local/bin/entrypoint.sh"]
+CMD ["fmriflow", "serve", "--host", "0.0.0.0", "--port", "8421"]

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -64,10 +64,8 @@ RUN pip install --no-cache-dir --upgrade pip \
 # Frontend bundle from stage 1.
 COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/
 
-# Repo-shipped heuristics (the user heuristics dir is a volume).
-COPY heuristics/ /app/heuristics/
-
-# Default workspace + persistent state dirs.
+# Default workspace + persistent state dirs. Heuristics are provided
+# via the runtime data directory rather than copied from the repo.
 RUN mkdir -p /workspace/experiments /workspace/results /workspace/derivatives \
              /data/.fmriflow /data/heuristics /data/modules \
     && chown -R fmriflow:fmriflow /app /workspace /data

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -1,0 +1,88 @@
+# syntax=docker/dockerfile:1.7
+# fmriflow slim — orchestrator only.
+# fmriprep is delegated to the host (via /var/run/docker.sock or
+# apptainer-on-host). This image is the FastAPI backend + the built
+# Vite frontend + heudiconv + bids-validator + dcm2niix.
+
+# ── Stage 1: build the frontend ─────────────────────────────────────
+FROM node:20-alpine AS frontend-build
+
+WORKDIR /build/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY frontend/ ./
+# Build script writes to ../fmriflow/server/static (i.e. /build/fmriflow/server/static).
+RUN npm run build
+
+
+# ── Stage 2: runtime image ──────────────────────────────────────────
+FROM python:3.11-slim AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# System deps: dcm2niix (heudiconv backend), git, tini (PID 1),
+# curl/ca-certs, gosu (drop privs in entrypoint), nodejs+npm
+# (bids-validator), docker-cli (docker-out-of-docker for fmriprep).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dcm2niix \
+        docker.io \
+        git \
+        gosu \
+        nodejs \
+        npm \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# bids-validator (optional — fmriflow gracefully skips if missing).
+RUN npm install -g bids-validator \
+    && npm cache clean --force
+
+ARG PUID=1000
+ARG PGID=1000
+RUN groupadd -g ${PGID} fmriflow \
+    && useradd -m -u ${PUID} -g ${PGID} -d /home/fmriflow -s /bin/bash fmriflow
+
+WORKDIR /app
+
+# Install fmriflow + heudiconv. We keep the slim image to the
+# extras the orchestrator actually needs at runtime; users can
+# pip-install more inside a derived image if they want
+# pycortex/autoflatten.
+COPY pyproject.toml README.md ./
+COPY fmriflow/ ./fmriflow/
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir heudiconv \
+    && pip install --no-cache-dir '.[frontend,bids]'
+
+# Frontend bundle from stage 1.
+COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/
+
+# Repo-shipped heuristics (the user heuristics dir is a volume).
+COPY heuristics/ /app/heuristics/
+
+# Default workspace + persistent state dirs.
+RUN mkdir -p /workspace/experiments /workspace/results /workspace/derivatives \
+             /data/.fmriflow /data/heuristics /data/modules \
+    && chown -R fmriflow:fmriflow /app /workspace /data
+
+# ~/.fmriflow lives under /data so it survives container restarts
+# when /data is a volume. Heuristics + modules dirs are env-driven.
+ENV HOME=/data \
+    FMRIFLOW_HEURISTICS_DIR=/data/heuristics \
+    FMRIFLOW_MODULES_DIR=/data/modules
+
+EXPOSE 8421
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /workspace
+ENTRYPOINT ["tini", "--", "/usr/local/bin/entrypoint.sh"]
+CMD ["fmriflow", "serve", "--host", "0.0.0.0", "--port", "8421"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,99 @@
+# Docker images for fmriflow
+
+Two variants live here:
+
+| Variant | Dockerfile | Size | What's included |
+|---|---|---|---|
+| **slim** | `Dockerfile.slim` | ~1–2 GB | FastAPI backend + Vite frontend + heudiconv + bids-validator + dcm2niix. fmriprep is delegated to the host (docker socket, or apptainer-on-host). |
+| **full** | `Dockerfile.full` | ~25 GB | slim + everything in `nipreps/fmriprep` (fmriprep, FreeSurfer, ANTs, AFNI). No second runtime needed; preproc YAML can use `container_type: bare`. |
+
+## Quickstart (slim)
+
+From the repo root:
+
+```bash
+mkdir -p license experiments results derivatives bids dicoms
+cp /path/to/your/freesurfer_license.txt license/license.txt
+
+docker compose up --build
+# UI on http://localhost:8421
+```
+
+Configure your preproc YAML with:
+
+```yaml
+backend: fmriprep
+container_type: docker
+container: nipreps/fmriprep:24.1.1
+```
+
+## Standalone (full)
+
+```bash
+docker compose -f docker-compose.full.yml up --build
+```
+
+Then in your preproc YAML:
+
+```yaml
+backend: fmriprep
+container_type: bare
+```
+
+The full image first build is slow because it pulls `nipreps/fmriprep`.
+
+## Apptainer-on-host instead of docker socket
+
+If your host runs apptainer/singularity (e.g. shared HPC node), edit
+`docker-compose.yml`: comment the `/var/run/docker.sock` line, then add
+
+```yaml
+    volumes:
+      - /usr/bin/apptainer:/usr/bin/apptainer:ro
+      - /path/to/your/fmriprep.sif:/opt/fmriprep.sif:ro
+    environment:
+      FMRIFLOW_SINGULARITY_BIN: /usr/bin/apptainer
+```
+
+In your preproc YAML:
+
+```yaml
+backend: fmriprep
+container_type: apptainer
+container: /opt/fmriprep.sif
+```
+
+## What's mounted where
+
+| Host path | Container path | Purpose |
+|---|---|---|
+| `fmriflow-state` (named volume) | `/data` | `~/.fmriflow/` — run registry, modules, QC store, workflows, registered heuristics |
+| `./experiments/` | `/workspace/experiments` | YAML configs (convert, preproc, autoflatten, workflows) |
+| `./derivatives/` | `/workspace/derivatives` | fmriprep + autoflatten outputs |
+| `./results/` | `/workspace/results` | analysis run outputs |
+| `./bids/` (ro) | `/workspace/bids` | BIDS roots |
+| `./dicoms/` (ro) | `/workspace/dicoms` | DICOM roots |
+| `./license/` (ro) | `/data/license` | FreeSurfer license file |
+| `/var/run/docker.sock` (slim only) | same | Lets fmriflow spawn sibling fmriprep containers |
+
+## File ownership on bind mounts
+
+The container creates files as `fmriflow:fmriflow`, with uid/gid taken
+from `PUID`/`PGID` (default `1000:1000`). Override per-host with:
+
+```bash
+UID=$(id -u) GID=$(id -g) docker compose up
+```
+
+## Pinning fmriprep version (full image)
+
+```bash
+docker compose -f docker-compose.full.yml build \
+    --build-arg FMRIPREP_TAG=24.1.1
+```
+
+## Troubleshooting
+
+- **`heudiconv: command not found`** — slim image only ships heudiconv on PATH; if you derived your own image, re-run `pip install heudiconv`.
+- **fmriprep container can't see /workspace** — when running fmriprep as a sibling container via the docker socket, the *host* path is what the sibling sees. Make sure your bind mounts match between fmriflow and the spawned fmriprep container, or use the full image instead.
+- **FreeSurfer license errors** — confirm `license/license.txt` exists and is readable, or set `FS_LICENSE_TEXT` in your shell env.

--- a/docker/README.md
+++ b/docker/README.md
@@ -82,7 +82,7 @@ The container creates files as `fmriflow:fmriflow`, with uid/gid taken
 from `PUID`/`PGID` (default `1000:1000`). Override per-host with:
 
 ```bash
-UID=$(id -u) GID=$(id -g) docker compose up
+PUID=$(id -u) PGID=$(id -g) docker compose up
 ```
 
 ## Pinning fmriprep version (full image)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# fmriflow container entrypoint.
+#
+# Responsibilities:
+#  1. If FS_LICENSE_TEXT is set, write it to FS_LICENSE so users can
+#     pass the license inline (env) instead of bind-mounting a file.
+#  2. Align the in-container fmriflow user's uid/gid with PUID/PGID
+#     so bind-mounted files don't end up root-owned on the host.
+#  3. chown HOME + /workspace once, then drop privileges with gosu
+#     and exec the original CMD under PID 1 (tini).
+
+set -euo pipefail
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+
+# License-file shim: only write if FS_LICENSE doesn't already
+# point to an existing file.
+if [ -n "${FS_LICENSE_TEXT:-}" ]; then
+    target="${FS_LICENSE:-/data/license/license.txt}"
+    if [ ! -f "$target" ]; then
+        mkdir -p "$(dirname "$target")"
+        printf '%s\n' "$FS_LICENSE_TEXT" > "$target"
+    fi
+    export FS_LICENSE="$target"
+fi
+
+# uid/gid alignment + privilege drop. Only relevant when started
+# as root (compose default).
+if [ "$(id -u)" = "0" ]; then
+    if id fmriflow >/dev/null 2>&1; then
+        current_uid="$(id -u fmriflow)"
+        current_gid="$(getent group fmriflow | cut -d: -f3)"
+        if [ "$current_uid" != "$PUID" ]; then
+            usermod -o -u "$PUID" fmriflow >/dev/null 2>&1 || true
+        fi
+        if [ "$current_gid" != "$PGID" ]; then
+            groupmod -o -g "$PGID" fmriflow >/dev/null 2>&1 || true
+        fi
+    fi
+
+    mkdir -p "$HOME/.fmriflow" \
+             "${FMRIFLOW_HEURISTICS_DIR:-$HOME/heuristics}" \
+             "${FMRIFLOW_MODULES_DIR:-$HOME/modules}"
+    chown -R fmriflow:fmriflow "$HOME" 2>/dev/null || true
+    chown -R fmriflow:fmriflow /workspace 2>/dev/null || true
+
+    exec gosu fmriflow "$@"
+fi
+
+exec "$@"

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -111,7 +111,7 @@ Bind-mounted directories pick up the uid/gid of the in-container
 host user with:
 
 ```bash
-UID=$(id -u) GID=$(id -g) docker compose up
+PUID=$(id -u) PGID=$(id -g) docker compose up
 ```
 
 This is sticky in the named volume, so set it once at first launch.
@@ -145,5 +145,5 @@ For `FS_LICENSE_TEXT`, remove that read-only license mount or point
   removed it, reinstall.
 - **`mkdir: cannot create /data/.fmriflow`** — the named volume
   isn't writable by the in-container user. Re-run with
-  `UID=$(id -u) GID=$(id -g) docker compose up` so the entrypoint
+  `PUID=$(id -u) PGID=$(id -g) docker compose up` so the entrypoint
   picks up the right uid/gid.

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -1,0 +1,145 @@
+# Running fMRIflow with Docker
+
+fMRIflow ships two Docker images so you don't have to install
+fmriprep, FreeSurfer, heudiconv, and the Vite frontend toolchain by
+hand.
+
+| Variant | Size | Use when |
+|---|---|---|
+| **slim** | ~1–2 GB | You already have Docker (or apptainer) on the host and want fmriflow to delegate fmriprep to it. |
+| **full** | ~25 GB | You want a single self-contained image — fmriprep + FreeSurfer + ANTs + AFNI baked in. |
+
+Both images expose the web UI on port `8421` and run as a non-root
+user. Persistent state (run registry, modules, QC store, workflow
+configs) lives on a named Docker volume so it survives container
+restarts.
+
+## Quickstart — slim image
+
+The slim image runs fmriflow as the orchestrator and shells out to
+the host's Docker daemon to spawn fmriprep as a sibling container.
+This is the recommended path on a workstation that already runs
+Docker.
+
+```bash
+git clone https://github.com/osherifo/denizenspipeline.git
+cd denizenspipeline
+
+# 1. Drop your FreeSurfer license under ./license/.
+mkdir -p license experiments results derivatives bids dicoms
+cp /path/to/your/freesurfer_license.txt license/license.txt
+
+# 2. Bring it up.
+docker compose up --build
+```
+
+Open `http://localhost:8421` and you should see the fmriflow UI.
+
+In your preproc YAML, point fmriprep at the bidsapp image:
+
+```yaml
+backend: fmriprep
+container_type: docker
+container: nipreps/fmriprep:24.1.1
+```
+
+## Standalone — full image
+
+The full image is built **on top of** `nipreps/fmriprep`, so
+fmriprep, FreeSurfer, ANTs, AFNI, and dcm2niix are all on PATH.
+Preproc YAMLs can use `container_type: bare` directly:
+
+```bash
+docker compose -f docker-compose.full.yml up --build
+```
+
+```yaml
+backend: fmriprep
+container_type: bare
+```
+
+Pin a specific fmriprep version with:
+
+```bash
+docker compose -f docker-compose.full.yml build \
+    --build-arg FMRIPREP_TAG=24.1.1
+```
+
+## Apptainer-on-host (HPC pattern)
+
+On nodes that run apptainer/singularity instead of Docker, you can
+keep using the slim image and bind the apptainer binary in:
+
+1. Edit `docker-compose.yml` and **comment out** the line
+   `- /var/run/docker.sock:/var/run/docker.sock`.
+2. Add to the `volumes:` block:
+   ```yaml
+       - /usr/bin/apptainer:/usr/bin/apptainer:ro
+       - /path/to/your/fmriprep.sif:/opt/fmriprep.sif:ro
+   ```
+3. Add to the `environment:` block:
+   ```yaml
+       FMRIFLOW_SINGULARITY_BIN: /usr/bin/apptainer
+   ```
+4. In your preproc YAML:
+   ```yaml
+   backend: fmriprep
+   container_type: apptainer
+   container: /opt/fmriprep.sif
+   ```
+
+## Mounted paths
+
+| Host path | Container path | Purpose |
+|---|---|---|
+| `fmriflow-state` (named volume) | `/data` | `~/.fmriflow/` — run registry, modules, QC store, workflows, registered heuristics |
+| `./experiments/` | `/workspace/experiments` | Convert / preproc / autoflatten / workflow YAML configs |
+| `./derivatives/` | `/workspace/derivatives` | fmriprep + autoflatten outputs |
+| `./results/` | `/workspace/results` | Analysis run outputs |
+| `./bids/` (ro) | `/workspace/bids` | BIDS roots |
+| `./dicoms/` (ro) | `/workspace/dicoms` | DICOM roots |
+| `./license/` (ro) | `/data/license` | FreeSurfer license file |
+| `/var/run/docker.sock` *(slim only)* | same | docker-out-of-docker for fmriprep |
+
+Adjust the host paths in `docker-compose.yml` to match where your
+data actually lives.
+
+## File ownership on bind mounts
+
+Bind-mounted directories pick up the uid/gid of the in-container
+`fmriflow` user. By default that's `1000:1000`; align it with your
+host user with:
+
+```bash
+UID=$(id -u) GID=$(id -g) docker compose up
+```
+
+This is sticky in the named volume, so set it once at first launch.
+
+## Passing the FreeSurfer license inline
+
+If you don't want to bind-mount a license file, set the env var
+`FS_LICENSE_TEXT` on your host (e.g. via a `.env` file):
+
+```env
+FS_LICENSE_TEXT="abc123\nyou@example.com\n0001\n..."
+```
+
+The container's entrypoint writes it into `$FS_LICENSE` on first
+boot.
+
+## Troubleshooting
+
+- **fmriprep sibling container can't see /workspace** — when slim
+  spawns fmriprep via the docker socket, the *host* path is what
+  the sibling container sees. Make sure your `./derivatives/` etc.
+  sit at paths that exist on the host and inside the fmriflow
+  container at the same location, or switch to the full image
+  where everything runs in one container.
+- **Heudiconv complains about `dcm2niix`** — both slim and full
+  ship `dcm2niix` on PATH; if you've forked the Dockerfile and
+  removed it, reinstall.
+- **`mkdir: cannot create /data/.fmriflow`** — the named volume
+  isn't writable by the in-container user. Re-run with
+  `UID=$(id -u) GID=$(id -g) docker compose up` so the entrypoint
+  picks up the right uid/gid.

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -126,7 +126,11 @@ FS_LICENSE_TEXT="abc123\nyou@example.com\n0001\n..."
 ```
 
 The container's entrypoint writes it into `$FS_LICENSE` on first
-boot.
+boot, but that path must be writable. If your Compose setup
+bind-mounts `./license` read-only at `/data/license` and sets
+`FS_LICENSE` inside that mount, inline mode will not work as-is.
+For `FS_LICENSE_TEXT`, remove that read-only license mount or point
+`FS_LICENSE` at a writable location under `/data` instead.
 
 ## Troubleshooting
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
   - Getting Started:
     - Installation: guide/installation.md
     - Quickstart: guide/quickstart.md
+    - Docker: guide/docker.md
   - User Guide:
     - Configuration: guide/configuration.md
     - CLI Reference: guide/cli.md


### PR DESCRIPTION
## Summary

Two Docker variants so that bringing up fmriflow on a fresh machine is `docker compose up`:

- **slim** (~1-2 GB) — FastAPI backend + Vite frontend + heudiconv + bids-validator + dcm2niix + docker-cli. fmriprep is delegated to the host's docker socket by default, with an apptainer-on-host alternative documented.
- **full** (~25 GB) — same, but built `FROM nipreps/fmriprep:24.1.1` so fmriprep + FreeSurfer + ANTs + AFNI are on PATH. Preproc YAMLs can use `container_type: bare` with no second runtime to manage.

Both set `HOME=/data` and route `~/.fmriflow/` (run registry, modules, QC store, workflows, registered heuristics) onto a named volume so state survives restarts and the existing reattach machinery just works. `PUID`/`PGID` env vars + a `gosu` drop in the entrypoint align uid/gid with the host user, so bind-mounted files don't end up root-owned.

## Files added

- `docker/Dockerfile.slim`, `docker/Dockerfile.full`, `docker/entrypoint.sh`, `docker/README.md`
- `docker-compose.yml` (slim, default), `docker-compose.full.yml` (full, opt-in)
- `.dockerignore`
- `docs/guide/docker.md` (wired into mkdocs nav)

No `fmriflow/` source changes — every knob we needed (`HOME`, `FMRIFLOW_HEURISTICS_DIR`, `FMRIFLOW_MODULES_DIR`, `FMRIFLOW_SINGULARITY_BIN`, `FS_LICENSE`, `serve --host`) was already exposed.

## Test plan

- [ ] `docker compose build` produces a slim image < 2 GB and `docker compose up` boots the UI on `http://localhost:8421`.
- [ ] `docker compose -f docker-compose.full.yml build` succeeds (slow, ~25 GB).
- [ ] Convert tab runs heudiconv against a bind-mounted DICOM dir and writes BIDS into `./bids/`.
- [ ] Preproc YAML with `container_type: docker` + `nipreps/fmriprep:24.1.1` runs fmriprep as a sibling container under the slim image; outputs land in `./derivatives/`.
- [ ] Same YAML with `container_type: bare` runs in-process under the full image.
- [ ] Stop + restart the container; live runs reattach via `RunRegistry` (state preserved on the `fmriflow-state` named volume).
- [ ] `mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)