### PR TITLE
fix(docker): unblock build (DicomScanResult test) + boot (sklearn/himalaya extras)

### DIFF
--- a/frontend/src/stores/__tests__/convert-store.test.ts
+++ b/frontend/src/stores/__tests__/convert-store.test.ts
@@ -86,7 +86,7 @@ describe('useConvertStore', () => {
   describe('scan + collect + run', () => {
     it('scanDicom populates scanResult', async () => {
       await useConvertStore.getState().scanDicom('/tmp/dicom')
-      expect(useConvertStore.getState().scanResult?.n_files).toBe(10)
+      expect(useConvertStore.getState().scanResult?.series.length).toBe(1)
     })
 
     it('collect populates collectResult', async () => {

--- a/frontend/src/test/mocks/handlers.convert.ts
+++ b/frontend/src/test/mocks/handlers.convert.ts
@@ -36,11 +36,11 @@ export const convertHandlers = [
   ),
   http.post('/api/convert/scan', () =>
     HttpResponse.json({
-      source_dir: '/tmp',
-      n_files: 10,
-      subjects: ['01'],
-      sessions: ['ses-01'],
-      sample_dicoms: [],
+      scanner: null,
+      series: [
+        { number: 1, description: 'T1w', n_images: 10, modality_guess: 'anat' },
+      ],
+      matching_heuristic: null,
     }),
   ),
   http.post('/api/convert/collect', () =>


### PR DESCRIPTION
## Summary

Two fixes needed to make the Docker images build and boot end-to-end on a fresh checkout.

### 1. Frontend build was failing on `tsc -b`

```
src/stores/__tests__/convert-store.test.ts(89,53):
error TS2339: Property 'n_files' does not exist on type 'DicomScanResult'.
```

`DicomScanResult` was reshaped to `{ scanner, series, matching_heuristic }`, but the convert-store test and matching MSW handler still asserted on the old `n_files` field. Updated both to use `series.length`.

### 2. Container booted, then crashed with `ModuleNotFoundError: sklearn`

```
File ".../fmriflow/modules/__init__.py", line 58, in register_builtins
    import fmriflow.modules.models.himalaya
File ".../fmriflow/modules/models/himalaya.py", line 6, in <module>
    from sklearn.base import BaseEstimator, TransformerMixin
ModuleNotFoundError: No module named 'sklearn'
```

`register_builtins` eagerly imports `models/himalaya`, which has a top-level `from sklearn.base import BaseEstimator`. The slim image was originally scoped to `[frontend,bids]` only. Expanded to:

```
[frontend, bids, ml, himalaya, audio, video, cloud, viz]
```

so every builtin that participates in registration can resolve its top-level imports. Same change applied to `Dockerfile.full` for symmetry.

`nlp` (transformers + torch, ~2 GB) and `flatten` (autoflatten — likely a private package) are intentionally omitted; users derive a custom image if those modules are needed.

## Branch contents

```
d151ec7 fix(docker): install ml/himalaya/audio/video/cloud/viz extras so the server boots
d72e5ed fix(test): update DicomScanResult mock + assertion to current shape
```

(Push has been redirected to `fix/docker-runtime-deps`, which stacks both fixes. The original `fix/dicom-scan-result-test` head is preserved as the first commit.)

## Test plan

- [x] `cd frontend && npm run build` succeeds locally
- [ ] `docker compose build` finishes end-to-end on a fresh clone
- [ ] `docker compose up` boots without ImportError; UI loads on `http://localhost:8421`

🤖 Generated with [Claude Code](https://claude.com/claude-code)