### PR TITLE
fix(docker): install ml/himalaya/audio/video/cloud/viz extras so the server boots

### DIFF
--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -51,12 +51,15 @@ RUN groupadd -g ${PGID} fmriflow \
 
 WORKDIR /app
 
-# Install fmriflow on top of the fmriprep python env.
+# Install fmriflow on top of the fmriprep python env. Same extras
+# as the slim image so register_builtins succeeds (himalaya needs
+# sklearn at import time). nlp / flatten omitted on purpose; derive
+# if needed.
 COPY pyproject.toml README.md ./
 COPY fmriflow/ ./fmriflow/
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir heudiconv \
-    && pip install --no-cache-dir '.[frontend,bids]'
+    && pip install --no-cache-dir '.[frontend,bids,ml,himalaya,audio,video,cloud,viz]'
 
 COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -53,13 +53,13 @@ WORKDIR /app
 
 # Install fmriflow on top of the fmriprep python env. Same extras
 # as the slim image so register_builtins succeeds (himalaya needs
-# sklearn at import time). nlp / flatten omitted on purpose; derive
-# if needed.
+# sklearn at import time). nlp omitted on purpose (torch ~2 GB);
+# derive if needed.
 COPY pyproject.toml README.md ./
 COPY fmriflow/ ./fmriflow/
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir heudiconv \
-    && pip install --no-cache-dir '.[frontend,bids,ml,himalaya,audio,video,cloud,viz]'
+    && pip install --no-cache-dir '.[frontend,bids,ml,himalaya,audio,video,cloud,viz,flatten]'
 
 COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/
 

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -57,9 +57,17 @@ WORKDIR /app
 # pycortex/autoflatten.
 COPY pyproject.toml README.md ./
 COPY fmriflow/ ./fmriflow/
+# Extras: frontend (FastAPI/uvicorn), bids (nibabel), ml + himalaya
+# (sklearn — register_builtins eagerly imports models/himalaya), audio
+# (librosa, for audio feature extractors), video (opencv), cloud
+# (cottoncandy/boto3 for cloud response loaders), viz (pycortex +
+# matplotlib for flatmap reporters). nlp (transformers + gensim) and
+# flatten (autoflatten) are intentionally omitted: nlp pulls in torch
+# and ~2GB of weights, flatten depends on a private package. Derive
+# your own image with `pip install fmriflow[nlp,flatten]` if needed.
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir heudiconv \
-    && pip install --no-cache-dir '.[frontend,bids]'
+    && pip install --no-cache-dir '.[frontend,bids,ml,himalaya,audio,video,cloud,viz]'
 
 # Frontend bundle from stage 1.
 COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -59,15 +59,13 @@ COPY pyproject.toml README.md ./
 COPY fmriflow/ ./fmriflow/
 # Extras: frontend (FastAPI/uvicorn), bids (nibabel), ml + himalaya
 # (sklearn — register_builtins eagerly imports models/himalaya), audio
-# (librosa, for audio feature extractors), video (opencv), cloud
-# (cottoncandy/boto3 for cloud response loaders), viz (pycortex +
-# matplotlib for flatmap reporters). nlp (transformers + gensim) and
-# flatten (autoflatten) are intentionally omitted: nlp pulls in torch
-# and ~2GB of weights, flatten depends on a private package. Derive
-# your own image with `pip install fmriflow[nlp,flatten]` if needed.
+# (librosa), video (opencv), cloud (cottoncandy/boto3), viz (pycortex
+# + matplotlib for flatmap reporters), flatten (autoflatten).
+# nlp (transformers + torch ~2 GB) is intentionally omitted; derive
+# with `pip install fmriflow[nlp]` if you need Word2Vec/BERT/FastText.
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir heudiconv \
-    && pip install --no-cache-dir '.[frontend,bids,ml,himalaya,audio,video,cloud,viz]'
+    && pip install --no-cache-dir '.[frontend,bids,ml,himalaya,audio,video,cloud,viz,flatten]'
 
 # Frontend bundle from stage 1.
 COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/


### PR DESCRIPTION
## Problem

After merging #61 the docker frontend-build is green, but the server boots and immediately crashes:

\`\`\`
File ".../fmriflow/modules/__init__.py", line 58, in register_builtins
    import fmriflow.modules.models.himalaya
File ".../fmriflow/modules/models/himalaya.py", line 6, in <module>
    from sklearn.base import BaseEstimator, TransformerMixin
ModuleNotFoundError: No module named 'sklearn'
\`\`\`

\`register_builtins\` eagerly imports \`models/himalaya\`, which has a top-level \`from sklearn.base import BaseEstimator, TransformerMixin\` to subclass them. The slim image was originally scoped to \`[frontend,bids]\` only — sklearn isn't installed.

## Fix

Expand both Dockerfiles' install line to:

\`\`\`
[frontend, bids, ml, himalaya, audio, video, cloud, viz, flatten]
\`\`\`

So every builtin that participates in registration can resolve its top-level imports:

- \`ml\` + \`himalaya\` — sklearn + himalaya (this is the immediate boot blocker)
- \`audio\` — librosa, for audio feature extractors
- \`video\` — opencv, for visual feature extractors
- \`cloud\` — cottoncandy + boto3, for cloud response loaders
- \`viz\` — pycortex + matplotlib, used by flatmap reporters
- \`flatten\` — autoflatten (public on PyPI)

## Intentionally omitted

- **\`nlp\`** — transformers + gensim. Pulls in torch (~2 GB). Users who want Word2Vec / BERT / FastText extractors should derive their own image: \`pip install fmriflow[nlp]\`.

\`register_builtins\` should arguably be more defensive about optional deps (a separate code-side fix), but expanding the image covers the common case.

## Test plan

- [x] \`docker compose build --no-cache\` finishes end-to-end on a fresh clone
- [x] \`docker compose up\` boots without ImportError; UI loads on \`http://localhost:8421\`
- [x] Slim image size stays in the 2–4 GB range (sklearn + pycortex + opencv + matplotlib + autoflatten are the largest additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)