### PR TITLE
fix(docker): add build-essential + opencv runtime libs to slim

### DIFF
--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -24,17 +24,24 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# System deps: dcm2niix (heudiconv backend), git, tini (PID 1),
-# curl/ca-certs, gosu (drop privs in entrypoint), nodejs+npm
-# (bids-validator), docker-cli (docker-out-of-docker for fmriprep).
+# System deps:
+#  - dcm2niix (heudiconv backend), tini (PID 1), curl/ca-certs,
+#    gosu (drop privs in entrypoint), nodejs+npm (bids-validator),
+#    docker-cli (docker-out-of-docker for fmriprep).
+#  - build-essential — pycortex builds the OpenCTM C extension from
+#    source on install; python:3.11-slim has no compiler by default.
+#  - libgl1 + libglib2.0-0 — opencv-python (cv2) runtime deps.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        build-essential \
         ca-certificates \
         curl \
         dcm2niix \
         docker.io \
         git \
         gosu \
+        libgl1 \
+        libglib2.0-0 \
         nodejs \
         npm \
         tini \


### PR DESCRIPTION
## Problem

After #62 (which added \`viz\` and \`video\` extras), the slim build now fails:

\`\`\`
gcc -Wsign-compare ... -c OpenCTM-1.0.3/lib/compressMG1.c ...
error: command 'gcc' failed: No such file or directory
ERROR: Failed building wheel for pycortex
\`\`\`

\`pycortex\` (from \`viz\`) builds an OpenCTM C extension from source on install. \`python:3.11-slim\` ships without a compiler. \`opencv-python\` (from \`video\`) also dlopens \`libgl1\` / \`libglib2.0-0\` at import time, which the slim base doesn't have either.

## Fix

Add three packages to the slim image's apt install:

- \`build-essential\` — gcc + headers, so \`pip install pycortex\` can compile OpenCTM.
- \`libgl1\` + \`libglib2.0-0\` — opencv runtime deps; pre-empts a later \`ImportError: libGL.so.1\` when anything imports cv2.

\`Dockerfile.full\` is untouched — the \`nipreps/fmriprep\` base already has a build toolchain.

## Test plan

- [ ] \`docker compose build --no-cache\` finishes end-to-end on a fresh clone
- [ ] \`docker compose up\` boots; UI loads on \`http://localhost:8421\`
- [ ] First request to a flatmap reporter doesn't blow up with libGL errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)