### PR TITLE
fix(docker): serve built frontend on GET /

### DIFF
--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -57,11 +57,13 @@ WORKDIR /app
 # derive if needed.
 COPY pyproject.toml README.md ./
 COPY fmriflow/ ./fmriflow/
+# Frontend bundle from stage 1 — must land BEFORE pip install so
+# hatch packages it into the wheel; otherwise the installed package
+# has no static/ dir and GET / returns 404.
+COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir heudiconv \
     && pip install --no-cache-dir '.[frontend,bids,ml,himalaya,audio,video,cloud,viz,flatten]'
-
-COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/
 
 RUN mkdir -p /workspace/experiments /workspace/results /workspace/derivatives \
              /data/.fmriflow /data/heuristics /data/modules \

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -64,6 +64,11 @@ WORKDIR /app
 # pycortex/autoflatten.
 COPY pyproject.toml README.md ./
 COPY fmriflow/ ./fmriflow/
+# Frontend bundle from stage 1 — must land BEFORE pip install so
+# hatch packages it into the wheel (otherwise the installed package
+# has no static/ dir and FastAPI's StaticFiles mount is skipped,
+# causing GET / to return 404).
+COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/
 # Extras: frontend (FastAPI/uvicorn), bids (nibabel), ml + himalaya
 # (sklearn — register_builtins eagerly imports models/himalaya), audio
 # (librosa), video (opencv), cloud (cottoncandy/boto3), viz (pycortex
@@ -73,9 +78,6 @@ COPY fmriflow/ ./fmriflow/
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir heudiconv \
     && pip install --no-cache-dir '.[frontend,bids,ml,himalaya,audio,video,cloud,viz,flatten]'
-
-# Frontend bundle from stage 1.
-COPY --from=frontend-build /build/fmriflow/server/static/ ./fmriflow/server/static/
 
 # Default workspace + persistent state dirs. Heuristics are provided
 # via the runtime data directory rather than copied from the repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,10 @@ webgl = "fmriflow.modules.reporters.webgl:WebGLReporter"
 
 [tool.hatch.build.targets.wheel]
 packages = ["fmriflow"]
+
+# Force-include the built frontend bundle. Hatch's default file
+# selection skips it in some sandboxes (e.g. docker build context
+# without a .gitignore present), even though it lives under the
+# packaged tree. force-include is unconditional.
+[tool.hatch.build.targets.wheel.force-include]
+"fmriflow/server/static" = "fmriflow/server/static"


### PR DESCRIPTION
## Summary

The slim and full images booted but `GET /` returned `{"detail":"Not Found"}` — the React app was unreachable. Two layered bugs:

1. **Dockerfile ordering** — `pip install '.[…]'` ran *before* the frontend bundle was copied from the build stage, so hatch built the wheel with no `server/static/` content.
2. **hatch packaging** — even after reordering the COPY, hatch silently dropped `fmriflow/server/static/` from the wheel in the docker build context (no `.gitignore` is copied in via `.dockerignore`, which apparently disables hatch's default file selection for that subtree). `force-include` is unconditional and guarantees the bundle ships.

After the fix, the installed package at `/usr/local/lib/python3.11/site-packages/fmriflow/server/` contains `static/`, FastAPI's `StaticFiles` mount activates, and `GET /` serves the React app.

## Test plan

- [x] `docker compose build --no-cache` succeeds on a remote host
- [x] `docker compose up` → `curl localhost:8421/` returns the React `index.html` (not the JSON 404)
- [x] Inside the container: `python -c "import fmriflow.server as s, os; print(sorted(os.listdir(os.path.dirname(s.__file__))))"` includes `'static'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)