### PR TITLE
chore: release v2.0.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,134 @@ Format follows [Conventional Changelog](https://www.conventionalcommits.org/).
 
 ---
 
+## v2.0.0-alpha.4 (2026-05-07)
+
+### Features
+
+**Containerization**
+- **infra:** slim + full Docker images with one-step `docker compose up` (#60). Slim delegates fmriprep to host (docker-out-of-docker or apptainer); full bakes fmriprep + FreeSurfer + ANTs (`FROM nipreps/fmriprep:24.1.1`)
+- **infra:** Docker user guide wired into mkdocs nav
+
+**Live nipype DAG monitoring**
+- **preproc:** double-click a Preproc card → live DAG modal with per-node states
+- **preproc:** live nipype-node monitoring under the Workflows graph
+- **workflows:** hierarchical, collapsible, searchable node list on the left of the DAG modal
+- **workflows:** per-node fmriprep output drawer in the DAG modal
+- **workflows:** merge cached leaves from `work_dir`, FIFO leaf matching, run-end sweep + backfill script
+- **qc:** select node → pan/zoom DAG canvas to centre it
+- **workflows:** straight edges + adaptive layout for workflow cards
+
+**Structural QC reviewer**
+- **qc:** structural-preproc reviewer sign-off (browser + freeview)
+- **qc:** cross-dataset QC Reviews view + status pill on manifest list
+- **qc:** taller niivue canvas + view + surface pickers (pial / white / inflated)
+- **qc:** fullscreen toggle + multi-surface overlay
+- **qc:** structural 3D viewer opens fullscreen directly
+- **qc:** Volume on/off toggle to hide T1 'skull' in 3D
+- **qc:** per-surface alpha sliders + meshXRay so transparency renders
+- **workflows:** Structural QC drill-in + cross-dir manifest discovery
+
+**Post-preproc workflows**
+- **post-preproc:** post-fmriprep nipype-style stage with ReactFlow builder
+- **post-preproc:** nipype-style workflows, subworkflows, MapNode
+- **post-preproc:** in-place code editor + workflow-stage node color
+- **post-preproc:** per-handle literal input paths in side panel
+- **workflows:** post_preproc as a stage in the overarching workflow
+
+**Workflow orchestrator (Phase 2)**
+- **server:** end-to-end workflow orchestrator chaining convert → preproc → autoflatten → post-preproc → analysis
+- **fe:** Workflows view + top-level Pipeline nav entry
+- **fe:** ReactFlow graph for workflow runs, auto-opens, exposes per-stage logs
+- **fe:** workflow graph decomposes analysis into its inner stages
+- **fe:** live log pane under the workflow graph
+- **server:** emit per-stage events file from the analysis subprocess
+- **workflows:** edit + duplicate workflow configs
+- **workflow:** reattach orchestrator on server restart
+
+**Detach / reattach long-running jobs (#54, #55)**
+- **server:** detach heudiconv + reattach convert runs on restart
+- **server:** detach autoflatten CLI + reattach on restart
+- **server:** detach analysis pipelines + reattach on restart
+- **fe:** Recent Runs / In-Flight panels for convert, autoflatten, analysis
+- **fe:** Configs tabs for convert + autoflatten + preproc, log viewer for in-flight runs
+
+**YAML configs (Phase 1, #56)**
+- **server:** consistent YAML configs across convert + autoflatten + preproc
+- **server:** YAML-driven autoflatten configs via `/autoflatten/configs`
+- **server:** YAML-driven preprocessing configs via `/preproc/configs` API
+- **server:** run convert YAML configs via `/convert/configs/{file}/run`
+- **fe:** preprocessing configs browser tab
+
+**Other**
+- **fe:** show full configs in run comparison
+- **fe:** replace browser dialogs with fmriflow-branded modal
+- **autoflatten:** edit + duplicate configs, unify tab bar with other managers
+- **autoflatten:** show run results (flatmaps + pycortex + patches) in log modal
+- **modules:** view + edit module source from the Module Browser
+- **triage:** automatic error capture v1
+- **fe:** delete previous runs from every In-Flight panel + Workflows
+- **preproc:** run fmriprep via apptainer with skip-bids-validation toggle
+
+### Bug Fixes
+
+**Docker / packaging**
+- **packaging:** force-include `server/static` in wheel (#64) — frontend now actually serves on `GET /` in containerized images
+- **docker:** copy frontend bundle before pip install (#64)
+- **docker:** add build-essential + opencv runtime libs to slim (#63) — pycortex + cv2 build cleanly
+- **docker:** install ml/himalaya/audio/video/cloud/viz extras so the server boots (#62)
+- **docker:** include autoflatten extra in slim and full
+- **docker:** use PUID/PGID vars consistently in compose and docs
+
+**QC**
+- **qc:** hydrate nipype_jsonl_path on registry-fallback get_run
+- **qc:** include extension in niivue volume name to avoid getFileExt crash
+- **qc:** validate fs-file suffix on requested rel, not resolved target
+- **qc:** serve fmriprep report's relative figure assets
+- **qc:** drawer Close → arrow that only hides the outputs panel
+- **qc:** replace per-surface alpha with global X-ray slider that actually works
+
+**Server**
+- **server:** capture full traceback on stage failures
+- **server:** persist full resolved config in `run_summary.config_snapshot`
+- **server:** restore env=child_env on analysis subprocess
+- **server:** surface terminal fmriprep errors immediately via log tailer
+- **server:** tail analysis events.jsonl into the WebSocket stream
+- **server:** write each analysis run to its own output subdirectory
+- **server:** rename Thread subclass `_stop` attr to `_stop_flag`
+
+**Frontend**
+- **fe:** workflow log modal handles convert batches (404 on batch_id)
+- **fe:** render log event messages in dashboard event log
+- **fe:** show KB matches + Save-to-KB in per-stage log modals
+- **fe:** use 'prepare' stage name in run dashboard
+
+**Other**
+- **convert:** accept multiple DICOM roots per heudiconv invocation
+- **autoflatten:** include subjects_dir in get_run registry-fallback path
+- **autoflatten:** replace removed `cortex.db.get_list()` call
+- **workflows:** nipype strip stays compact; add View DAG button
+- **test:** update DicomScanResult mock + assertion to current shape (#61)
+- general: close `log_fh` + WebSocket in terminal branches; batch-detection, API types, and `select()` error handling; error handling in `AutoflattenConfigBrowser.reload()`
+
+### Tests
+
+- **frontend:** Vitest + MSW + Playwright harness — 219 unit tests + 10 e2e flows (#58)
+- **frontend:** cover live-nipype + post-preproc + structural-qc features
+- **frontend:** bind vite dev to 127.0.0.1 for Playwright webServer in CI
+- **frontend:** lower coverage thresholds to current floor
+
+### Docs
+
+- **docs:** Workflows guide
+- **docs:** Docker quickstart (slim + full + apptainer-on-host)
+- **docs:** post_preproc as a workflow stage
+- **docs:** detach-reattach for convert / autoflatten / analysis runs
+- **docs:** YAML config flow for convert + autoflatten
+- **docs:** QC Reviews view + manifest status pill in the structural-qc guide
+- **docs:** niivue toolbar (view / volume / surfaces / X-ray / fullscreen) + Workflows drill-in
+
+---
+
 ## v2.0.0-alpha.3 (2026-04-16)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fMRIflow
 
-![Version](https://img.shields.io/badge/version-2.0.0--alpha.3-blue)
+![Version](https://img.shields.io/badge/version-2.0.0--alpha.4-blue)
 ![Python](https://img.shields.io/badge/python-≥3.10-green)
 ![License](https://img.shields.io/badge/license-MIT-brightgreen)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fmriflow"
-version = "2.0.0a3"
+version = "2.0.0a4"
 description = "fMRIflow — Module-based neuroscience encoding model pipeline"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
Bump version to **v2.0.0-alpha.4** and update the changelog.

Tag `v2.0.0-alpha.4` already pushed (points to the release commit on this branch).

## What changed in this PR

- `pyproject.toml`: `2.0.0a3` → `2.0.0a4`
- `README.md`: badge bumped to `2.0.0-alpha.4`
- `CHANGELOG.md`: new section for v2.0.0-alpha.4 — full grouped log of features / fixes / tests / docs since v2.0.0-alpha.3

## Highlights of the alpha.4 release

- **Containerization** (#60–#64): slim + full Docker images, one-step `docker compose up`
- **Live nipype DAG monitoring** (#59): per-node drill-in with cached-leaf merging
- **Structural QC reviewer** with niivue 3D viewer + multi-surface overlay
- **Post-preproc nipype-style stage** in the workflow graph
- **End-to-end workflow orchestrator** (Phase 2)
- **Detach / reattach** long-running jobs across all pipelines
- **Consistent YAML configs** across convert + autoflatten + preproc (#56)
- **Frontend testing harness** (#58): 219 unit tests + 10 e2e flows

See `CHANGELOG.md` for the full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)