### PR TITLE
add pial curvature, raw curv parser, threshold controls, drawing annotations

### DIFF
--- a/docs/guide/structural-qc.md
+++ b/docs/guide/structural-qc.md
@@ -39,14 +39,32 @@ Three entry points to the same panel:
       Only one surface kind is shown at a time; clicking the active
       one again hides surfaces. All surface meshes use the same
       neutral white base colour.
-    - **Curv** (on / off, default on) — shade the white + inflated
-      surfaces by FreeSurfer per-vertex curvature (`?h.curv`),
-      attached as a niivue mesh layer with `colormap=gray`,
-      `colormapInvert=true`, and `cal_min=0` / `cal_max=1` (niivue's
-      normalised CURV range). This preserves the FreeSurfer QC visual
-      convention (sulci dark, gyri light). Pial is unaffected
-      (curvature is less meaningful at the pial surface). Toggle
-      flips the layer's `opacity` live, no mesh reload.
+    - **Curv** (on / off, default on) — shade all surfaces by
+      FreeSurfer per-vertex curvature: white + inflated use `?h.curv`,
+      pial uses `?h.curv.pial`. Raw signed curvature values are
+      parsed directly from the FreeSurfer binary (bypassing niivue's
+      lossy normalisation) and injected into the mesh layer, giving
+      both hemispheres the same physical scale. The gray colormap
+      renders sulci dark and gyri light, matching FreeSurfer's
+      recon-all QC convention. Toggle flips the layer's `opacity`
+      live, no mesh reload.
+        - **Mid** slider (−0.5 to +0.5, default 0) — shifts the
+          sulcus/gyrus colour boundary. Maps to freeview's
+          `ThresholdMidPoint`.
+        - **Slope** slider (1 to 50, default 10) — controls the
+          sharpness of the transition between sulcal and gyral
+          coloring. Higher values produce a sharper, more binary
+          boundary. Maps to freeview's `ThresholdSlope`.
+    - **Draw** (on / off, default off) — enable voxel drawing on 2D
+      slices. Paint annotations directly onto the T1 volume to mark
+      regions that need surface edits. Controls:
+        - **pen** / **erase** — switch between painting and erasing
+          voxels.
+        - **undo** — undo the last stroke (up to 8 levels).
+        - **save .nii** — download the drawing as a NIfTI file
+          (`<subject>_drawing.nii`). Load it in freeview as a volume
+          overlay (`freeview -v T1.mgz <subject>_drawing.nii:colormap=lut`)
+          to guide manual surface edits.
     - **Mode** — `real` (default) draws true Freeview-style 1-px
       contours by computing the actual plane-triangle intersection
       of each surface mesh against the current slice plane and

--- a/docs/guide/structural-qc.md
+++ b/docs/guide/structural-qc.md
@@ -44,10 +44,11 @@ Three entry points to the same panel:
       pial uses `?h.curv.pial`. Raw signed curvature values are
       parsed directly from the FreeSurfer binary (bypassing niivue's
       lossy normalisation) and injected into the mesh layer, giving
-      both hemispheres the same physical scale. The gray colormap
-      renders sulci dark and gyri light, matching FreeSurfer's
-      recon-all QC convention. Toggle flips the layer's `opacity`
-      live, no mesh reload.
+      both hemispheres the same physical scale. A Freeview-style
+      green→gray→red threshold colormap is applied: sulci render
+      green, gyri render red, with a gray transition zone whose
+      center and sharpness are controlled by **Mid** and **Slope**.
+      Toggle flips the layer's `opacity` live, no mesh reload.
         - **Mid** slider (−0.5 to +0.5, default 0) — shifts the
           sulcus/gyrus colour boundary. Maps to freeview's
           `ThresholdMidPoint`.
@@ -58,13 +59,21 @@ Three entry points to the same panel:
     - **Draw** (on / off, default off) — enable voxel drawing on 2D
       slices. Paint annotations directly onto the T1 volume to mark
       regions that need surface edits. Controls:
-        - **pen** / **erase** — switch between painting and erasing
-          voxels.
+        - **pen** — freehand draw (paint voxels under cursor).
+        - **fill pen** — drag to draw an outline; releasing
+          flood-fills the enclosed region.
+        - **erase** — erase painted voxels.
+        - **color** — seven colour swatches (red, green, blue,
+          magenta, cyan, yellow, orange) to select the active pen
+          colour. Disabled while **erase** is selected.
+        - **opacity** slider (0 – 1) — controls the transparency of
+          the drawing overlay. Default 0.5.
         - **undo** — undo the last stroke (up to 8 levels).
-        - **save .nii** — download the drawing as a NIfTI file
-          (`<subject>_drawing.nii`). Load it in freeview as a volume
-          overlay (`freeview -v T1.mgz <subject>_drawing.nii:colormap=lut`)
-          to guide manual surface edits.
+        - **clear** — erase the entire drawing at once.
+        - **save + freeview cmd** — downloads the drawing as a NIfTI
+          file (`<subject>_drawing.nii`), uploads it to the backend,
+          and copies a ready-made `freeview` command (with `-c`
+          centred on the annotation centroid) to clipboard.
     - **Mode** — `real` (default) draws true Freeview-style 1-px
       contours by computing the actual plane-triangle intersection
       of each surface mesh against the current slice plane and

--- a/fmriflow/server/routes/structural_qc.py
+++ b/fmriflow/server/routes/structural_qc.py
@@ -4,6 +4,7 @@ Endpoints:
   GET  /preproc/subjects/{subject}/structural-qc
   POST /preproc/subjects/{subject}/structural-qc
   GET  /preproc/subjects/{subject}/structural-qc/freeview-command
+  POST /preproc/subjects/{subject}/structural-qc/drawing
   GET  /preproc/subjects/{subject}/structural-qc/report
   GET  /preproc/subjects/{subject}/structural-qc/fs-file?rel=<path>
 """
@@ -14,7 +15,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, UploadFile, File, Query
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
@@ -111,7 +112,12 @@ def _fs_subject_dir(manifest: dict[str, Any]) -> Path | None:
     return None
 
 
-def _build_freeview_command(fs_subject_dir: Path) -> str:
+def _build_freeview_command(
+    fs_subject_dir: Path,
+    *,
+    drawing_path: Path | None = None,
+    ras: tuple[float, float, float] | None = None,
+) -> str:
     """Build a freeview command using the files that actually exist."""
     parts: list[str] = ["freeview"]
     mri = fs_subject_dir / "mri"
@@ -127,6 +133,9 @@ def _build_freeview_command(fs_subject_dir: Path) -> str:
         if p.is_file():
             parts.append(f"-v {p}{opts}")
 
+    if drawing_path and drawing_path.is_file():
+        parts.append(f"-v {drawing_path}:colormap=lut:opacity=0.5")
+
     surfaces = [
         ("lh.pial", ":edgecolor=red"),
         ("rh.pial", ":edgecolor=red"),
@@ -137,6 +146,9 @@ def _build_freeview_command(fs_subject_dir: Path) -> str:
         p = surf / name
         if p.is_file():
             parts.append(f"-f {p}{opts}")
+
+    if ras:
+        parts.append(f"-c {ras[0]:.1f} {ras[1]:.1f} {ras[2]:.1f}")
 
     return " \\\n  ".join(parts)
 
@@ -204,6 +216,31 @@ async def freeview_command(request: Request, subject: str):
             "Could not locate a FreeSurfer subject directory for this manifest.",
         )
     return {"command": _build_freeview_command(fs_dir), "fs_subject_dir": str(fs_dir)}
+
+
+@router.post("/preproc/subjects/{subject}/structural-qc/drawing")
+async def upload_drawing(
+    request: Request,
+    subject: str,
+    file: UploadFile = File(...),
+    ras_x: float = Query(0.0),
+    ras_y: float = Query(0.0),
+    ras_z: float = Query(0.0),
+):
+    """Save a drawing NIfTI into the FS subject's mri/ dir and return
+    a freeview command centered on the annotation centroid."""
+    manifest = _manifest_for(request, subject)
+    fs_dir = _fs_subject_dir(manifest)
+    if fs_dir is None:
+        raise HTTPException(404, "No FreeSurfer subject directory")
+    dest = fs_dir / "mri" / "qc_drawing.nii"
+    data = await file.read()
+    dest.write_bytes(data)
+    logger.info("Saved QC drawing for %s (%d bytes) → %s", subject, len(data), dest)
+
+    ras = (ras_x, ras_y, ras_z) if any(v != 0 for v in (ras_x, ras_y, ras_z)) else None
+    cmd = _build_freeview_command(fs_dir, drawing_path=dest, ras=ras)
+    return {"saved": True, "path": str(dest), "command": cmd}
 
 
 # ── file serving (fmriprep report + FS files for niivue) ────────────────

--- a/frontend/src/api/structural-qc.ts
+++ b/frontend/src/api/structural-qc.ts
@@ -45,6 +45,22 @@ export async function fetchFreeviewCommand(
   return res.json()
 }
 
+export async function uploadDrawing(
+  subject: string,
+  niftiBytes: Uint8Array,
+  ras: [number, number, number],
+): Promise<{ saved: boolean; path: string; command: string }> {
+  const form = new FormData()
+  form.append('file', new Blob([new Uint8Array(niftiBytes)], { type: 'application/octet-stream' }), 'drawing.nii')
+  const qs = `?ras_x=${ras[0].toFixed(1)}&ras_y=${ras[1].toFixed(1)}&ras_z=${ras[2].toFixed(1)}`
+  const res = await fetch(
+    `${BASE}/preproc/subjects/${subject}/structural-qc/drawing${qs}`,
+    { method: 'POST', body: form },
+  )
+  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
+  return res.json()
+}
+
 export function reportUrl(subject: string): string {
   return `${BASE}/preproc/subjects/${subject}/structural-qc/report`
 }

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -8,10 +8,12 @@ import {
   fetchReview,
   saveReview,
   fetchFreeviewCommand,
+  uploadDrawing,
   reportUrl,
   fsFileUrl,
 } from '../../api/structural-qc'
 import type { StructuralQCReview, StructuralQCStatus } from '../../api/types'
+import { parseFreeSurferCurv } from './curv_parser'
 
 interface Props {
   subject: string
@@ -100,6 +102,17 @@ export function StructuralQCPanel({ subject }: Props) {
   // nv.setMeshLayerProperty(meshId, 0, 'opacity', 0|1) without a
   // mesh reload. 2D contour overlay is unaffected (still solid).
   const [curvShaded, setCurvShaded] = useState<boolean>(true)
+  // Volume drawing mode — paint voxel annotations on slices, save as
+  // NIfTI for import into freeview as an overlay.
+  const [drawingEnabled, setDrawingEnabled] = useState(false)
+  const [penValue, setPenValue] = useState<number>(1) // 1=draw, 0=erase
+  const [isFilledPen, setIsFilledPen] = useState(false) // drag → flood-filled shape
+  const [drawOpacity, setDrawOpacity] = useState(0.5)
+  // Freeview-style curvature threshold: midpoint shifts the
+  // sulcus/gyrus boundary, slope controls transition sharpness.
+  // cal_min = midpoint - 1/slope, cal_max = midpoint + 1/slope.
+  const [curvMidpoint, setCurvMidpoint] = useState<number>(0)
+  const [curvSlope, setCurvSlope] = useState<number>(10)
   // Inflated "wings opening" animation. When toggled on, each
   // hemisphere rotates 90° around the Z axis at its medial edge
   // (smoothstep, ~800ms) so the medial cortex splays outward —
@@ -165,6 +178,18 @@ export function StructuralQCPanel({ subject }: Props) {
     nvRef.current = nv
     nv.attachToCanvas(canvasRef.current)
 
+    // Freeview-style green→gray→red curvature colormap (CM_Threshold).
+    // Green = gyri (negative curvature), gray = midpoint, red = sulci
+    // (positive curvature). Freeview uses base gray (0.4, 0.4, 0.4) =
+    // (102, 102, 102) at the transition center.
+    ;(nv as unknown as { addColormap?: (k: string, c: unknown) => void }).addColormap?.('freeview_curv', {
+      R: [0, 102, 255],
+      G: [255, 102, 0],
+      B: [0, 102, 0],
+      A: [255, 255, 255],
+      I: [0, 128, 255],
+    })
+
     // World-space slices (mm) are required for meshThicknessOn2D to
     // clip the mesh correctly. Voxel-space mode disables mesh
     // visibility entirely per the niivue API note.
@@ -179,8 +204,11 @@ export function StructuralQCPanel({ subject }: Props) {
     // which only zooms when dragMode === pan). Slice scrolling moves to
     // the scrubbers and click-to-navigate.
     try {
-      const inst = nv as unknown as { opts?: { dragMode?: number } }
-      if (inst.opts) inst.opts.dragMode = 3 /* DRAG_MODE.pan */
+      const inst = nv as unknown as { opts?: { dragMode?: number; multiplanarForceRender?: boolean } }
+      if (inst.opts) {
+        inst.opts.dragMode = 3 /* DRAG_MODE.pan */
+        inst.opts.multiplanarForceRender = true
+      }
     } catch { /* */ }
 
     // Sync the slice scrubbers when the user clicks/scrolls inside
@@ -401,8 +429,7 @@ export function StructuralQCPanel({ subject }: Props) {
   }, [inflatedOpen, surface, showViewer])
 
   // Flip the curvature layer's opacity live (no mesh reload). Hits
-  // every loaded mesh that has a layer; meshes loaded without one
-  // (e.g. pial) are skipped automatically.
+  // every loaded mesh that has a layer.
   useEffect(() => {
     const nv = nvRef.current as unknown as {
       meshes?: Array<{ id?: string | number; layers?: Array<unknown> }>
@@ -426,6 +453,53 @@ export function StructuralQCPanel({ subject }: Props) {
     }
     try { nv.drawScene?.() } catch { /* */ }
   }, [curvShaded, surface, showViewer])
+
+  // Live-update curvature threshold (cal_min / cal_max) without
+  // reloading meshes. Mirrors freeview's midpoint + slope controls.
+  useEffect(() => {
+    const nv = nvRef.current as unknown as {
+      meshes?: Array<{ id?: string | number; layers?: Array<unknown> }>
+      setMeshLayerProperty?: (
+        meshId: string | number,
+        layerIdx: number,
+        key: string,
+        val: number,
+      ) => void
+      drawScene?: () => void
+    } | null
+    if (!nv?.meshes || !nv.setMeshLayerProperty) return
+    const dSlope = curvSlope === 0 ? 1e8 : 1.0 / curvSlope
+    const calMin = curvMidpoint - dSlope
+    const calMax = curvMidpoint + dSlope
+    for (const mesh of nv.meshes) {
+      if (!mesh.layers || mesh.layers.length === 0) continue
+      if (mesh.id === undefined) continue
+      try {
+        nv.setMeshLayerProperty(mesh.id, 0, 'cal_min', calMin)
+        nv.setMeshLayerProperty(mesh.id, 0, 'cal_max', calMax)
+      } catch (e) {
+        console.warn('niivue setMeshLayerProperty cal range failed', e)
+      }
+    }
+    try { nv.drawScene?.() } catch { /* */ }
+  }, [curvMidpoint, curvSlope, surface, showViewer])
+
+  // Sync drawing mode + pen + options with niivue.
+  useEffect(() => {
+    const nv = nvRef.current as unknown as {
+      setDrawingEnabled?: (v: boolean) => void
+      setPenValue?: (v: number, filled?: boolean) => void
+      setDrawOpacity?: (v: number) => void
+      drawScene?: () => void
+    } | null
+    if (!nv) return
+    nv.setDrawingEnabled?.(drawingEnabled)
+    if (drawingEnabled) {
+      nv.setPenValue?.(penValue, isFilledPen)
+      nv.setDrawOpacity?.(drawOpacity)
+    }
+    try { nv.drawScene?.() } catch { /* */ }
+  }, [drawingEnabled, penValue, isFilledPen, drawOpacity, showViewer])
 
   // Per-mesh AABB index cache, keyed by mesh.pts identity. WeakMap so
   // unloaded meshes garbage-collect their index automatically.
@@ -605,51 +679,32 @@ export function StructuralQCPanel({ subject }: Props) {
           return
         }
         const kind = surface
-        // Attach FreeSurfer ?h.curv as a binary-grayscale layer on
-        // white + inflated (the surfaces where curvature shading
-        // is anatomically meaningful). In Niivue, CURV data is
-        // normalised per hemisphere to [0, 1], and the layer config
-        // below uses that range plus `colormapInvert: true` to keep
-        // sulci dark and gyri light, matching FreeSurfer's
-        // recon-all QC appearance. Always include the layer
-        // regardless of curvShaded so the toggle can flip opacity
-        // live without a mesh reload (controlled by a separate
-        // effect).
-        const wantCurv = kind === 'white' || kind === 'inflated'
+        // Attach FreeSurfer curvature as a binary-grayscale layer.
+        // White + inflated use ?h.curv; pial uses ?h.curv.pial
+        // (pial-surface-specific curvature from recon-all).
+        // Always include the layer regardless of curvShaded so the
+        // toggle can flip opacity live without a mesh reload.
+        const curvFile = (h: 'lh' | 'rh') =>
+          kind === 'pial' ? `surf/${h}.curv.pial` : `surf/${h}.curv`
         // `name` must carry the `.curv` extension — niivue's
         // readLayer reads the extension from `name` (preferring
-        // it over `url`), and our backend URL ends in `fs-file?
-        // rel=…` so `getFileExt(url)` returns undefined and
-        // `.toUpperCase()` throws. Same gotcha the mesh `name`
-        // works around at the loadVolumes call.
+        // it over `url`). .curv.pial is the same binary format.
+        // After loadMeshes we overwrite niivue's normalised values
+        // with raw signed curvature from our own parser. cal range
+        // is derived from the threshold controls (midpoint ± 1/slope).
+        const dSlope = curvSlope === 0 ? 1e8 : 1.0 / curvSlope
         const layerFor = (h: 'lh' | 'rh') =>
-          wantCurv
-            ? [{
-                url: fsFileUrl(subject, `surf/${h}.curv`),
+            [{
+                url: fsFileUrl(subject, curvFile(h)),
                 name: `${h}.curv`,
-                colormap: 'gray',
-                // niivue's readCURV normalises every .curv file to
-                // [0, 1] AND inverts it (`f = 1 - (f-mn)/(mx-mn)`,
-                // index.js:109541), so the actual layer values are in
-                // [0, 1] per hemisphere — NOT raw signed curvature in
-                // [-1, +1]. With cal_min=-0.5, cal_max=+0.5 (what we
-                // had before), rh's values mostly sat above cal_max
-                // and clamped to the LUT's last entry, which
-                // produced the purple-tinted rendering on one
-                // hemisphere only. cal_min=0, cal_max=1 uses the
-                // full normalised range. `colormapInvert: true`
-                // flips the gray so sulci (high normalised value
-                // after niivue's inversion = originally most-negative
-                // curvature) render DARK and gyri render LIGHT,
-                // matching FreeSurfer's recon-all QC look.
-                colormapNegative: 'gray',
+                colormap: 'freeview_curv',
+                colormapNegative: '',
                 useNegativeCmap: false,
-                colormapInvert: true,
-                cal_min: 0,
-                cal_max: 1,
+                colormapInvert: false,
+                cal_min: curvMidpoint - dSlope,
+                cal_max: curvMidpoint + dSlope,
                 opacity: curvShaded ? 1 : 0,
               }]
-            : []
         const specs = [
           { url: fsFileUrl(subject, `surf/lh.${kind}`), name: `lh.${kind}`, rgba255: SURFACE_COLOR, layers: layerFor('lh') },
           { url: fsFileUrl(subject, `surf/rh.${kind}`), name: `rh.${kind}`, rgba255: SURFACE_COLOR, layers: layerFor('rh') },
@@ -716,65 +771,39 @@ export function StructuralQCPanel({ subject }: Props) {
           contourIndexCache.current.delete(pts)
           try { m.updateMesh?.(gl) } catch { /* */ }
         }
-        // Joint normalisation of curvature layers across hemispheres.
-        // Niivue's readCURV normalises each .curv to [0, 1] per file
-        // using that file's own mn/mx, so the same numerical value
-        // means different actual curvature in lh vs rh and the two
-        // render with mismatched overall darkness. We can't recover
-        // the raw values from niivue's output (the original mn/mx
-        // are gone), but we can statistically align the two layers
-        // by matching their mean + std: target = average mean/std
-        // across all visible curv layers; per-layer values get
-        // z-scored then rescaled into (targetMean, targetStd).
-        // Same colormap + cal range now lands at the same shade for
-        // equivalent positions in each hemisphere's curvature
-        // distribution.
+        // Replace niivue's normalised [0,1] layer values with raw
+        // signed curvature parsed from the FreeSurfer binary. This
+        // gives both hemispheres the same physical scale (no per-file
+        // normalisation drift) and enables freeview-style thresholding.
         type CurvMesh = {
           name?: string
           pts?: Float32Array
           layers?: Array<{ values?: Float32Array }>
           updateMesh?: (gl: WebGL2RenderingContext) => void
         }
-        const curvMeshes: CurvMesh[] = []
+        const curvUrls: [CurvMesh, string][] = []
         for (const m of meshList as unknown as CurvMesh[]) {
-          const v = m.layers?.[0]?.values
-          if (v && v.length > 0) curvMeshes.push(m)
+          if (!m.layers?.[0]?.values || !m.name) continue
+          const h = m.name.startsWith('lh') ? 'lh' : m.name.startsWith('rh') ? 'rh' : null
+          if (!h) continue
+          curvUrls.push([m, fsFileUrl(subject, curvFile(h))])
         }
-        if (gl && curvMeshes.length > 1) {
-          const stats = curvMeshes.map((m) => {
-            const v = m.layers![0].values!
-            let sum = 0
-            for (let i = 0; i < v.length; i++) sum += v[i]
-            const mean = sum / v.length
-            let sumSq = 0
-            for (let i = 0; i < v.length; i++) sumSq += (v[i] - mean) ** 2
-            const std = Math.sqrt(sumSq / v.length)
-            return { mean, std }
-          })
-          const targetMean =
-            stats.reduce((s, x) => s + x.mean, 0) / stats.length
-          // Use the *max* std (not the average) so the tighter-
-          // distribution hemisphere gets stretched up to match the
-          // wider one — preserves the visible curvature contrast on
-          // both sides. Averaging the stds pulled the high-contrast
-          // hemisphere DOWN, killing curvature visibility.
-          const targetStd = Math.max(...stats.map((s) => s.std))
-          for (let i = 0; i < curvMeshes.length; i++) {
-            const { mean, std } = stats[i]
-            if (std < 1e-6) continue
-            const m = curvMeshes[i]
-            const v = m.layers![0].values!
-            const scale = targetStd / std
-            for (let j = 0; j < v.length; j++) {
-              // Clamp to [0, 1] post-rescale: stretching can push
-              // outliers outside the cal range, which would otherwise
-              // clamp at the LUT endpoints with a sharp transition.
-              const scaled = (v[j] - mean) * scale + targetMean
-              v[j] = scaled < 0 ? 0 : scaled > 1 ? 1 : scaled
+        if (gl && curvUrls.length > 0) {
+          const fetches = curvUrls.map(async ([m, url]) => {
+            try {
+              const resp = await fetch(url)
+              if (!resp.ok) return
+              const raw = parseFreeSurferCurv(await resp.arrayBuffer())
+              const vals = m.layers![0].values!
+              if (raw.length !== vals.length) return
+              for (let j = 0; j < vals.length; j++) vals[j] = raw[j]
+              try { m.updateMesh?.(gl) } catch { /* */ }
+              if (m.pts) contourIndexCache.current.delete(m.pts)
+            } catch (e) {
+              console.warn('raw curv injection failed for', m.name, e)
             }
-            try { m.updateMesh?.(gl) } catch { /* */ }
-            if (m.pts) contourIndexCache.current.delete(m.pts)
-          }
+          })
+          await Promise.all(fetches)
         }
 
         try { (inst as unknown as { drawScene?: () => void }).drawScene?.() } catch { /* */ }
@@ -1049,10 +1078,40 @@ export function StructuralQCPanel({ subject }: Props) {
                   borderColor: curvShaded ? 'var(--accent-cyan)' : 'var(--border)',
                 }}
                 onClick={() => setCurvShaded((v) => !v)}
-                title="Shade white + inflated by FreeSurfer per-vertex curvature (?h.curv). Binary gray (sulci dark, gyri light). Pial unaffected; 2D real-contour overlay unaffected."
+                title="Shade surfaces by FreeSurfer per-vertex curvature. Binary gray (sulci dark, gyri light)."
               >
                 {curvShaded ? 'on' : 'off'}
               </button>
+              {curvShaded && (
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                  <label style={{ color: 'var(--text-secondary)', fontSize: 10 }} title="Shift the sulcus/gyrus boundary (curvature value at the transition center)">
+                    mid
+                    <input
+                      type="range"
+                      min={-0.5}
+                      max={0.5}
+                      step={0.01}
+                      value={curvMidpoint}
+                      onChange={(e) => setCurvMidpoint(Number(e.target.value))}
+                      style={{ width: 60, verticalAlign: 'middle', marginLeft: 2 }}
+                    />
+                    <span style={{ fontSize: 10, fontFamily: 'monospace', minWidth: 36, display: 'inline-block' }}>{curvMidpoint.toFixed(2)}</span>
+                  </label>
+                  <label style={{ color: 'var(--text-secondary)', fontSize: 10 }} title="Transition sharpness (higher = sharper boundary between sulci and gyri coloring)">
+                    slope
+                    <input
+                      type="range"
+                      min={1}
+                      max={50}
+                      step={1}
+                      value={curvSlope}
+                      onChange={(e) => setCurvSlope(Number(e.target.value))}
+                      style={{ width: 60, verticalAlign: 'middle', marginLeft: 2 }}
+                    />
+                    <span style={{ fontSize: 10, fontFamily: 'monospace', minWidth: 20, display: 'inline-block' }}>{curvSlope}</span>
+                  </label>
+                </span>
+              )}
               {sliceType !== 4 && (
                 <span
                   style={{ display: 'inline-flex', alignItems: 'center', gap: 4, marginLeft: 6 }}
@@ -1166,6 +1225,173 @@ export function StructuralQCPanel({ subject }: Props) {
                   reset
                 </button>
               </span>
+              <span style={{ width: 1, alignSelf: 'stretch', background: 'var(--border)' }} />
+              <span style={{ color: 'var(--text-secondary)' }}>Draw</span>
+              <button
+                style={{
+                  ...btn,
+                  padding: '2px 8px',
+                  fontSize: 11,
+                  background: drawingEnabled ? 'var(--accent-yellow)' : btn.background,
+                  color: drawingEnabled ? '#000' : 'var(--text-primary)',
+                  borderColor: drawingEnabled ? 'var(--accent-yellow)' : 'var(--border)',
+                }}
+                onClick={() => setDrawingEnabled((v) => !v)}
+                title="Enable voxel drawing on 2D slices. Paint annotations, then save as NIfTI to open in freeview."
+              >
+                {drawingEnabled ? 'on' : 'off'}
+              </button>
+              {drawingEnabled && (
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
+                  {/* ── Tool select ── */}
+                  {([
+                    { v: 1, filled: false, label: 'pen', title: 'Freehand draw (paint voxels under cursor)' },
+                    { v: 1, filled: true, label: 'fill pen', title: 'Filled pen — drag draws an outline, release flood-fills the enclosed region' },
+                    { v: 0, filled: false, label: 'erase', title: 'Erase painted voxels' },
+                  ] as const).map((t) => (
+                    <button
+                      key={`${t.v}-${t.filled}`}
+                      style={{
+                        ...btn,
+                        padding: '2px 8px',
+                        fontSize: 11,
+                        background: penValue === t.v && isFilledPen === t.filled ? 'var(--accent-cyan)' : btn.background,
+                        color: penValue === t.v && isFilledPen === t.filled ? '#000' : 'var(--text-primary)',
+                        borderColor: penValue === t.v && isFilledPen === t.filled ? 'var(--accent-cyan)' : 'var(--border)',
+                      }}
+                      onClick={() => { setPenValue(t.v); setIsFilledPen(t.filled) }}
+                      title={t.title}
+                    >
+                      {t.label}
+                    </button>
+                  ))}
+                  {/* ── Pen color (1–7) ── */}
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+                    <span style={{ color: 'var(--text-secondary)', fontSize: 10 }}>color</span>
+                    {[
+                      { v: 1, c: '#ff0000' },
+                      { v: 2, c: '#00ff00' },
+                      { v: 3, c: '#0000ff' },
+                      { v: 4, c: '#ff00ff' },
+                      { v: 5, c: '#00ffff' },
+                      { v: 6, c: '#ffff00' },
+                      { v: 7, c: '#ff8800' },
+                    ].map((swatch) => (
+                      <button
+                        key={swatch.v}
+                        style={{
+                          width: 16,
+                          height: 16,
+                          borderRadius: 3,
+                          border: penValue === swatch.v ? '2px solid #fff' : '1px solid var(--border)',
+                          background: swatch.c,
+                          cursor: 'pointer',
+                          padding: 0,
+                          opacity: penValue === 0 ? 0.4 : 1,
+                        }}
+                        onClick={() => { if (penValue !== 0) setPenValue(swatch.v) }}
+                        title={`Color ${swatch.v}`}
+                        disabled={penValue === 0}
+                      />
+                    ))}
+                  </span>
+                  {/* ── Opacity ── */}
+                  <label style={{ color: 'var(--text-secondary)', fontSize: 10 }} title="Drawing overlay opacity (0 = transparent, 1 = opaque)">
+                    opacity
+                    <input
+                      type="range"
+                      min={0} max={1} step={0.05}
+                      value={drawOpacity}
+                      onChange={(e) => setDrawOpacity(Number(e.target.value))}
+                      style={{ width: 50, verticalAlign: 'middle', marginLeft: 2 }}
+                    />
+                    <span style={{ fontSize: 10, fontFamily: 'monospace', minWidth: 24, display: 'inline-block' }}>{drawOpacity.toFixed(2)}</span>
+                  </label>
+                  {/* ── Undo ── */}
+                  <button
+                    style={{ ...btn, padding: '2px 8px', fontSize: 11 }}
+                    onClick={() => {
+                      const nv = nvRef.current as unknown as { drawUndo?: () => void }
+                      nv?.drawUndo?.()
+                    }}
+                    title="Undo last drawing action (max 8 levels)"
+                  >
+                    undo
+                  </button>
+                  {/* ── Clear ── */}
+                  <button
+                    style={{ ...btn, padding: '2px 8px', fontSize: 11 }}
+                    onClick={() => {
+                      const nv = nvRef.current as unknown as {
+                        drawBitmap?: Uint8Array | null
+                        refreshDrawing?: (force?: boolean) => void
+                      }
+                      if (nv?.drawBitmap) {
+                        nv.drawBitmap.fill(0)
+                        nv.refreshDrawing?.(true)
+                      }
+                    }}
+                    title="Clear the entire drawing"
+                  >
+                    clear
+                  </button>
+                  {/* ── Save ── */}
+                  <button
+                    style={{ ...btn, padding: '2px 8px', fontSize: 11, background: 'var(--accent-green)', color: '#000', border: 'none' }}
+                    onClick={async () => {
+                      const nv = nvRef.current as unknown as {
+                        saveImage?: (opts: { isSaveDrawing: boolean }) => Uint8Array | boolean
+                        drawBitmap?: Uint8Array | null
+                        volumes?: Array<{ dims?: number[] }>
+                        frac2mm?: (f: Float32Array) => number[]
+                      }
+                      if (!nv) return
+                      const bmp = nv.drawBitmap
+                      const dims = nv.volumes?.[0]?.dims
+                      if (!bmp || !dims || dims.length < 4) return
+
+                      // Compute centroid of drawn voxels in voxel space
+                      const nx = dims[1], ny = dims[2], nz = dims[3]
+                      let sx = 0, sy = 0, sz = 0, count = 0
+                      for (let idx = 0; idx < bmp.length; idx++) {
+                        if (bmp[idx] === 0) continue
+                        const z = Math.floor(idx / (nx * ny))
+                        const rem = idx - z * nx * ny
+                        const y = Math.floor(rem / nx)
+                        const x = rem - y * nx
+                        sx += x; sy += y; sz += z; count++
+                      }
+                      if (count === 0) return
+
+                      // Centroid in fractional [0,1] → RAS mm
+                      const cx = (sx / count) / (nx - 1)
+                      const cy = (sy / count) / (ny - 1)
+                      const cz = (sz / count) / (nz - 1)
+                      let ras: [number, number, number] = [0, 0, 0]
+                      if (nv.frac2mm) {
+                        const mm = nv.frac2mm(new Float32Array([cx, cy, cz]))
+                        ras = [mm[0], mm[1], mm[2]]
+                      }
+
+                      // Get NIfTI bytes of drawing
+                      const bytes = nv.saveImage?.({ isSaveDrawing: true })
+                      if (!bytes || typeof bytes === 'boolean') return
+
+                      try {
+                        const result = await uploadDrawing(subject, bytes, ras)
+                        setFreeviewCmd(result.command)
+                        await navigator.clipboard.writeText(result.command)
+                      } catch (e) {
+                        console.warn('drawing upload failed, falling back to download', e)
+                        nv.saveImage?.({ isSaveDrawing: true } as never)
+                      }
+                    }}
+                    title="Save the drawing to the FS subject dir and copy a freeview command (with -c centered on the annotation) to clipboard."
+                  >
+                    save + freeview cmd
+                  </button>
+                </span>
+              )}
               <span style={{ flex: 1 }} />
               <button
                 style={{ ...btn, padding: '2px 8px', fontSize: 11 }}
@@ -1175,11 +1401,32 @@ export function StructuralQCPanel({ subject }: Props) {
                 ✕ Close
               </button>
             </div>
+            {freeviewCmd && (
+              <div
+                style={{
+                  padding: '4px 8px',
+                  fontSize: 10,
+                  fontFamily: 'monospace',
+                  background: 'var(--bg-secondary)',
+                  borderLeft: '1px solid var(--border)',
+                  borderRight: '1px solid var(--border)',
+                  color: 'var(--text-primary)',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-all',
+                  cursor: 'pointer',
+                }}
+                onClick={() => navigator.clipboard.writeText(freeviewCmd)}
+                title="Click to copy freeview command"
+              >
+                <span style={{ color: 'var(--accent-green)', marginRight: 6 }}>freeview cmd (click to copy):</span>
+                {freeviewCmd}
+              </div>
+            )}
             <div
               style={{
                 position: 'relative',
                 border: '1px solid var(--border)',
-                borderTop: 'none',
+                borderTop: freeviewCmd ? 'none' : undefined,
                 borderBottomLeftRadius: sliceType === 4 ? 4 : 0,
                 borderBottomRightRadius: sliceType === 4 ? 4 : 0,
                 background: '#000',

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -1377,13 +1377,21 @@ export function StructuralQCPanel({ subject }: Props) {
                       const bytes = nv.saveImage?.({ isSaveDrawing: true })
                       if (!bytes || typeof bytes === 'boolean') return
 
+                      // Browser download
+                      const blob = new Blob([new Uint8Array(bytes)], { type: 'application/octet-stream' })
+                      const a = document.createElement('a')
+                      a.href = URL.createObjectURL(blob)
+                      a.download = `${subject}_drawing.nii`
+                      a.click()
+                      URL.revokeObjectURL(a.href)
+
+                      // Upload to backend + get freeview command
                       try {
                         const result = await uploadDrawing(subject, bytes, ras)
                         setFreeviewCmd(result.command)
                         await navigator.clipboard.writeText(result.command)
                       } catch (e) {
-                        console.warn('drawing upload failed, falling back to download', e)
-                        nv.saveImage?.({ isSaveDrawing: true } as never)
+                        console.warn('drawing upload failed', e)
                       }
                     }}
                     title="Save the drawing to the FS subject dir and copy a freeview command (with -c centered on the annotation) to clipboard."

--- a/frontend/src/components/preproc/StructuralQCPanel.tsx
+++ b/frontend/src/components/preproc/StructuralQCPanel.tsx
@@ -1078,7 +1078,7 @@ export function StructuralQCPanel({ subject }: Props) {
                   borderColor: curvShaded ? 'var(--accent-cyan)' : 'var(--border)',
                 }}
                 onClick={() => setCurvShaded((v) => !v)}
-                title="Shade surfaces by FreeSurfer per-vertex curvature. Binary gray (sulci dark, gyri light)."
+                title="Shade surfaces by FreeSurfer per-vertex curvature using a green→gray→red threshold colormap. Adjust midpoint (sulcus/gyrus boundary) and slope (transition sharpness) below."
               >
                 {curvShaded ? 'on' : 'off'}
               </button>

--- a/frontend/src/components/preproc/__tests__/curv_parser.test.ts
+++ b/frontend/src/components/preproc/__tests__/curv_parser.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { parseFreeSurferCurv } from '../curv_parser'
+
+function buildCurvBuffer(values: number[]): ArrayBuffer {
+  const headerSize = 3 + 4 + 4 + 4 // magic + nVert + nFace + valsPerVert
+  const buf = new ArrayBuffer(headerSize + values.length * 4)
+  const view = new DataView(buf)
+  // Magic bytes
+  view.setUint8(0, 0xff)
+  view.setUint8(1, 0xff)
+  view.setUint8(2, 0xff)
+  // nVertices (big-endian)
+  view.setInt32(3, values.length, false)
+  // nFaces (unused, set to 0)
+  view.setInt32(7, 0, false)
+  // valsPerVertex (always 1)
+  view.setInt32(11, 1, false)
+  // Per-vertex float32 values (big-endian)
+  for (let i = 0; i < values.length; i++) {
+    view.setFloat32(headerSize + i * 4, values[i], false)
+  }
+  return buf
+}
+
+describe('parseFreeSurferCurv', () => {
+  it('parses a minimal .curv buffer with known values', () => {
+    const expected = [0.25, -0.5, 0.0, 1.0, -1.0]
+    const buf = buildCurvBuffer(expected)
+    const result = parseFreeSurferCurv(buf)
+    expect(result).toBeInstanceOf(Float32Array)
+    expect(result.length).toBe(expected.length)
+    for (let i = 0; i < expected.length; i++) {
+      expect(result[i]).toBeCloseTo(expected[i], 5)
+    }
+  })
+
+  it('preserves signed values (no normalisation or inversion)', () => {
+    const vals = [-0.3, 0.7, -0.001, 0.999]
+    const result = parseFreeSurferCurv(buildCurvBuffer(vals))
+    expect(result[0]).toBeCloseTo(-0.3, 5)
+    expect(result[1]).toBeCloseTo(0.7, 5)
+    expect(result[2]).toBeCloseTo(-0.001, 5)
+    expect(result[3]).toBeCloseTo(0.999, 5)
+  })
+
+  it('handles an empty vertex array', () => {
+    const result = parseFreeSurferCurv(buildCurvBuffer([]))
+    expect(result.length).toBe(0)
+  })
+
+  it('rejects buffers without the magic bytes', () => {
+    const buf = new ArrayBuffer(15)
+    const view = new DataView(buf)
+    view.setUint8(0, 0x00)
+    view.setUint8(1, 0x00)
+    view.setUint8(2, 0x00)
+    expect(() => parseFreeSurferCurv(buf)).toThrow('Not a FreeSurfer')
+  })
+})

--- a/frontend/src/components/preproc/curv_parser.ts
+++ b/frontend/src/components/preproc/curv_parser.ts
@@ -1,0 +1,28 @@
+/**
+ * Parse a FreeSurfer "new" curvature binary file (.curv / .curv.pial)
+ * into a raw signed Float32Array — no normalisation, no inversion.
+ *
+ * Format:
+ *   3 bytes   magic  0xFF 0xFF 0xFF
+ *   int32 BE  nVertices
+ *   int32 BE  nFaces
+ *   int32 BE  valsPerVertex  (always 1 for .curv)
+ *   nVertices × float32 BE   raw signed curvature
+ */
+export function parseFreeSurferCurv(buf: ArrayBuffer): Float32Array {
+  const view = new DataView(buf)
+  const b0 = view.getUint8(0)
+  const b1 = view.getUint8(1)
+  const b2 = view.getUint8(2)
+  if (b0 !== 0xff || b1 !== 0xff || b2 !== 0xff) {
+    throw new Error('Not a FreeSurfer new-format curvature file')
+  }
+  const nVertices = view.getInt32(3, false)
+  // bytes 7–10: nFaces (unused), 11–14: valsPerVertex (unused)
+  const headerBytes = 3 + 4 + 4 + 4 // 15
+  const out = new Float32Array(nVertices)
+  for (let i = 0; i < nVertices; i++) {
+    out[i] = view.getFloat32(headerBytes + i * 4, false)
+  }
+  return out
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ audio = ["librosa>=0.10", "soundfile>=0.12"]
 video = ["opencv-python>=4.7"]
 bids = ["nibabel>=5.0"]
 flatten = ["autoflatten>=0.1.0"]
-frontend = ["fastapi>=0.109", "uvicorn>=0.27", "websockets>=12.0"]
+frontend = ["fastapi>=0.109", "uvicorn>=0.27", "websockets>=12.0", "python-multipart>=0.0.7"]
 all = ["fmriflow[cloud,viz,ml,nlp,himalaya,audio,video,bids,frontend,flatten]"]
 dev = ["fmriflow[all]", "pytest>=7.3", "pytest-cov>=4.1", "h5py>=3.8"]
 


### PR DESCRIPTION
## Summary

- **Pial curvature shading**: all three surfaces (pial/white/inflated) now get curvature layers. Pial uses `?h.curv.pial`, others use `?h.curv`.
- **Raw `.curv` parser** (`curv_parser.ts`): parses the FreeSurfer binary ourselves, bypasses niivue's lossy `[0,1]` normalisation, injects raw signed values into mesh layers. Both hemispheres share the same physical scale — removes the statistical harmonisation hack.
- **Freeview-style curvature threshold**: custom green→gray→red colormap (`freeview_curv`) matching freeview's `CM_Threshold` mode. Midpoint slider (−0.5 to +0.5) and slope slider (1–50) for live threshold control.
- **Voxel drawing annotations**: pen/fill-pen/erase tools, 7 color swatches, opacity slider, undo, clear. Save uploads the drawing NIfTI to `<fs_subject_dir>/mri/qc_drawing.nii`, computes annotation centroid in RAS, and generates a freeview command with `-c X Y Z` + drawing overlay. Also triggers a browser download. Command displayed in viewer and copied to clipboard.
- **Multiplanar + 3D**: `multiplanarForceRender = true` so the Multi view shows all 3 slices + 3D render.
- **Backend**: new `POST .../structural-qc/drawing` route for drawing upload; `_build_freeview_command` extended with `drawing_path` and `ras` kwargs; `python-multipart` added to deps.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/components/preproc` — 14/14 pass (includes 4 new `curv_parser` tests)
- [x] `mkdocs build --strict` — clean
- [x] Manual: open QC viewer, verify curvature on pial/white/inflated, adjust mid+slope sliders, toggle Curv on/off
- [x] Manual: enable Draw, paint on slices, save → verify browser download + freeview command with `-c` coordinates
- [x] Manual: paste freeview command → verify it opens with drawing overlay centered on annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)