### PR TITLE
Multiple read-only result/run roots with location-aware identity

### DIFF
--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -326,6 +326,33 @@ Browser UI for the working-directory env vars: `FMRIFLOW_HOME`, `FMRIFLOW_DATA`,
 - **Create directories if they don't exist** checkbox (default on) — `mkdir -p`s `FMRIFLOW_HOME` / `FMRIFLOW_DATA` if they don't exist yet, so you don't have to drop into a terminal.
 - The **Resolved layout** table at the bottom mirrors `fmriflow paths` plus FreeSurfer-license and `subjects.json` presence.
 
+### Result locations (multiple result roots)
+
+By default the dashboard scans one location for results and runs — your primary
+`$FMRIFLOW_HOME`. The **Result locations** section of the Settings tab lets you
+register additional, **read-only** roots so the scanners also surface results
+and runs stored elsewhere (another disk, an archive, a shared lab tree).
+
+- Each extra root should be a `$FMRIFLOW_HOME`-shaped tree — i.e. it has
+  `data/results/`, `study_runs/`, `group_runs/`, and/or `runs/` beneath it.
+  Adding **one path** makes all of those visible.
+- Extra roots are **read-only**: new runs are always written to the primary
+  root, and runs discovered in an extra root cannot be deleted from the UI.
+- Changes apply on the **next refresh** — no restart needed (unlike the path
+  settings above). Each root shows a `primary` / `read-only` / `unreachable`
+  badge; an offline mount is skipped gracefully rather than breaking the scan.
+- Runs from a non-primary root carry a small `↪ <root>` badge in the run lists
+  so you can see where each one lives.
+- Headless/CI: set `$FMRIFLOW_RESULT_ROOTS` to an `os.pathsep`-separated list of
+  paths; it overrides the persisted list. API: `GET/POST/DELETE
+  /api/settings/result-roots`.
+
+> Identity note: runs are identified by **location + run id**. Each root has a
+> stable `root_id` (a hash of its path), and a run's full identity is
+> `<root_id>:<run_id>`. Bare run ids resolve against the primary root first, so
+> existing links keep working; the `?root=<root_id>` query param disambiguates
+> the rare case where the same name/run id exists in more than one root.
+
 ---
 
 ## Long-running analysis runs — detach & reattach

--- a/fmriflow/core/paths.py
+++ b/fmriflow/core/paths.py
@@ -504,7 +504,12 @@ def add_result_root(path: str) -> list[str]:
     is the primary root.
     """
     p = Path(path).expanduser()
-    if not p.is_dir():
+    try:
+        reachable = p.is_dir()
+    except OSError as e:
+        # Stale/offline mount (e.g. NFS "stale file handle").
+        raise FileNotFoundError(f"{p} is not reachable: {e}") from e
+    if not reachable:
         raise FileNotFoundError(f"{p} does not exist or is not a directory")
     abspath = _realkey(p)
     if abspath == _realkey(home()):

--- a/fmriflow/core/paths.py
+++ b/fmriflow/core/paths.py
@@ -472,6 +472,24 @@ def root_for_id(rid: str) -> Path | None:
     return None
 
 
+def root_id_for_path(p: Path | str) -> str:
+    """``root_id`` of the search root that contains *p*.
+
+    Uses the longest matching root prefix (so a nested root wins over a
+    parent). Falls back to the primary root id when *p* is under none of
+    the known roots (e.g. a run whose output_dir is fully custom).
+    """
+    pk = _realkey(Path(p))
+    best: Path | None = None
+    best_len = -1
+    for r in result_search_roots():
+        rk = _realkey(r)
+        if (pk == rk or pk.startswith(rk + os.sep)) and len(rk) > best_len:
+            best = r
+            best_len = len(rk)
+    return root_id(best) if best is not None else primary_root_id()
+
+
 # ── Extra-root config mutators (used by the Settings API / CLI) ───────
 
 def result_roots_config() -> list[str]:

--- a/fmriflow/core/paths.py
+++ b/fmriflow/core/paths.py
@@ -24,6 +24,7 @@ to ease migration.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -300,6 +301,211 @@ def work_dir(run_id: str) -> Path:
     p = work_root() / run_id
     p.mkdir(parents=True, exist_ok=True)
     return p
+
+
+# ── Multi-root search (results + runs) ───────────────────────────────
+#
+# The primary root is ``$FMRIFLOW_HOME`` — the only place new runs are
+# *written*. Additional, **read-only** roots can be registered so the
+# dashboard's scanners also surface results/runs stored elsewhere
+# (other disks, archived runs, a shared lab tree). Each extra root is a
+# ``$FMRIFLOW_HOME``-shaped tree: its ``data/results/``, ``study_runs/``,
+# ``group_runs/`` and ``runs/`` subtrees are discovered.
+#
+# Resolution of the extra-root list: ``$FMRIFLOW_RESULT_ROOTS`` (an
+# ``os.pathsep``-separated env var) overrides the persisted list in
+# settings.json (key ``FMRIFLOW_RESULT_ROOTS``, a JSON array). The
+# primary root is always implicit and never duplicated into the list.
+
+ENV_RESULT_ROOTS = "FMRIFLOW_RESULT_ROOTS"
+SETTINGS_KEY_RESULT_ROOTS = "FMRIFLOW_RESULT_ROOTS"
+
+
+def _realkey(p: Path) -> str:
+    """Canonical string key for dedupe (best-effort realpath)."""
+    try:
+        return str(Path(p).resolve(strict=False))
+    except OSError:
+        return str(p)
+
+
+def _dedupe_existing(candidates: list[Path]) -> list[Path]:
+    """Keep order; drop non-existent / unreachable dirs and realpath dups.
+
+    Robust to an offline mount: a candidate whose ``is_dir()`` raises
+    (e.g. a stale NFS handle) is skipped rather than crashing the scan.
+    """
+    out: list[Path] = []
+    seen: set[str] = set()
+    for p in candidates:
+        try:
+            if not p.is_dir():
+                continue
+        except OSError:
+            continue
+        key = _realkey(p)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(p)
+    return out
+
+
+def _load_result_roots_setting() -> list[str]:
+    """Read the persisted extra-root list from settings.json (or [])."""
+    p = RUNTIME_CONFIG_PATH
+    if not p.is_file():
+        return []
+    try:
+        data = json.loads(p.read_text())
+    except Exception:
+        return []
+    if not isinstance(data, dict):
+        return []
+    val = data.get(SETTINGS_KEY_RESULT_ROOTS, [])
+    if isinstance(val, str):
+        val = [val]
+    if not isinstance(val, list):
+        return []
+    return [str(x) for x in val if str(x).strip()]
+
+
+def _save_result_roots_setting(roots: list[str]) -> None:
+    p = RUNTIME_CONFIG_PATH
+    data: dict = {}
+    if p.is_file():
+        try:
+            loaded = json.loads(p.read_text())
+            if isinstance(loaded, dict):
+                data = loaded
+        except Exception:
+            data = {}
+    if roots:
+        data[SETTINGS_KEY_RESULT_ROOTS] = roots
+    else:
+        data.pop(SETTINGS_KEY_RESULT_ROOTS, None)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def extra_result_roots() -> list[Path]:
+    """Configured **read-only** extra roots (env > settings.json).
+
+    Never includes the primary ``home()``. Not existence-filtered here —
+    callers that scan use the store accessors below (which are).
+    """
+    env = os.environ.get(ENV_RESULT_ROOTS)
+    if env:
+        raw = [s for s in env.split(os.pathsep) if s.strip()]
+    else:
+        raw = _load_result_roots_setting()
+    primary = _realkey(home())
+    out: list[Path] = []
+    seen: set[str] = set()
+    for r in raw:
+        p = Path(r).expanduser()
+        key = _realkey(p)
+        if key == primary or key in seen:
+            continue
+        seen.add(key)
+        out.append(p)
+    return out
+
+
+def result_search_roots() -> list[Path]:
+    """All home-shaped roots, primary first: ``[home(), *extra]``.
+
+    Used for reverse lookup (``root_for_id``) and status listing; not
+    existence-filtered (the primary always exists; extras may be offline
+    and we still want to report them).
+    """
+    return [home(), *extra_result_roots()]
+
+
+def result_roots() -> list[Path]:
+    """Every ``…/data/results`` dir to scan (primary + extras)."""
+    return _dedupe_existing(
+        [results_root(), *[r / "data" / "results" for r in extra_result_roots()]]
+    )
+
+
+def study_run_roots() -> list[Path]:
+    """Every ``…/study_runs`` dir to scan (primary + extras)."""
+    return _dedupe_existing(
+        [study_runs_root(), *[r / "study_runs" for r in extra_result_roots()]]
+    )
+
+
+def group_run_roots() -> list[Path]:
+    """Every ``…/group_runs`` dir to scan (primary + extras)."""
+    return _dedupe_existing(
+        [group_runs_root(), *[r / "group_runs" for r in extra_result_roots()]]
+    )
+
+
+def runs_roots() -> list[Path]:
+    """Every preproc-``runs/`` dir to scan (primary + extras + legacy)."""
+    return _dedupe_existing(
+        [runs_dir(), *[r / "runs" for r in extra_result_roots()], legacy_runs_root()]
+    )
+
+
+def root_id(path: Path | str) -> str:
+    """Stable, reorder-safe id for a root: first 8 hex of sha1(realpath).
+
+    Used to make run identity location-aware (``<root_id>:<run_id>``)
+    without leaking absolute paths into URLs. Stable across restarts and
+    list reordering.
+    """
+    return hashlib.sha1(_realkey(Path(path)).encode()).hexdigest()[:8]
+
+
+def primary_root_id() -> str:
+    return root_id(home())
+
+
+def root_for_id(rid: str) -> Path | None:
+    """Reverse ``root_id`` → the home-shaped root path (or None)."""
+    for r in result_search_roots():
+        if root_id(r) == rid:
+            return r
+    return None
+
+
+# ── Extra-root config mutators (used by the Settings API / CLI) ───────
+
+def result_roots_config() -> list[str]:
+    """The persisted extra-root list, as stored (absolute strings)."""
+    return _load_result_roots_setting()
+
+
+def add_result_root(path: str) -> list[str]:
+    """Register a read-only extra root. Validates + dedupes; persists.
+
+    Raises FileNotFoundError if the path doesn't exist, ValueError if it
+    is the primary root.
+    """
+    p = Path(path).expanduser()
+    if not p.is_dir():
+        raise FileNotFoundError(f"{p} does not exist or is not a directory")
+    abspath = _realkey(p)
+    if abspath == _realkey(home()):
+        raise ValueError("that path is already the primary $FMRIFLOW_HOME root")
+    cur = _load_result_roots_setting()
+    if abspath not in [_realkey(Path(x).expanduser()) for x in cur]:
+        cur.append(abspath)
+        _save_result_roots_setting(cur)
+    return cur
+
+
+def remove_result_root(path: str) -> list[str]:
+    """Unregister an extra root (matched by realpath). Persists."""
+    target = _realkey(Path(path).expanduser())
+    cur = _load_result_roots_setting()
+    new = [x for x in cur if _realkey(Path(x).expanduser()) != target]
+    if new != cur:
+        _save_result_roots_setting(new)
+    return new
 
 
 # ── Two-tier resolution ──────────────────────────────────────────────

--- a/fmriflow/server/routes/group.py
+++ b/fmriflow/server/routes/group.py
@@ -63,11 +63,16 @@ async def list_group_runs(request: Request, name: str | None = None):
 
 
 @router.get("/group-runs/{name}/{run_id}")
-async def get_group_run_by_run_id(request: Request, name: str, run_id: str):
-    """Return the full ``GroupRunSummary`` for one timestamped run."""
+async def get_group_run_by_run_id(request: Request, name: str, run_id: str, root: str | None = None):
+    """Return the full ``GroupRunSummary`` for one timestamped run.
+
+    Optional ``?root=<root_id>`` disambiguates the same name/run_id across
+    result roots.
+    """
     _check_path_segment(name, "group name")
     _check_path_segment(run_id, "run_id")
-    run_dir = resolve_group_run_dir(request.app.state.run_manager.registry, name, run_id)
+    run_dir = resolve_group_run_dir(
+        request.app.state.run_manager.registry, name, run_id, root_id=root)
     if run_dir is None:
         raise HTTPException(
             status_code=404,
@@ -78,18 +83,20 @@ async def get_group_run_by_run_id(request: Request, name: str, run_id: str):
 
 @router.get("/group-runs/{name}/{run_id}/file/{file_path:path}")
 async def get_group_run_file(
-    request: Request, name: str, run_id: str, file_path: str,
+    request: Request, name: str, run_id: str, file_path: str, root: str | None = None,
 ):
     """Serve a single file from inside a timestamped group run directory.
 
     The frontend uses this to pull flatmaps, logs, and the HTML report
     over HTTP (browsers refuse ``file://`` from an http origin). The
     handler resolves the requested path under the run dir and rejects
-    anything that resolves outside it.
+    anything that resolves outside it. ``?root=<root_id>`` disambiguates
+    across result roots.
     """
     _check_path_segment(name, "group name")
     _check_path_segment(run_id, "run_id")
-    run_dir = resolve_group_run_dir(request.app.state.run_manager.registry, name, run_id)
+    run_dir = resolve_group_run_dir(
+        request.app.state.run_manager.registry, name, run_id, root_id=root)
     if run_dir is None:
         raise HTTPException(
             status_code=404,
@@ -249,10 +256,15 @@ def _summarize(run_dir: Path, *, run_id: str, data: dict) -> dict:
         "group_stages": data.get("group_stages") or [],
         "subject_summaries": data.get("subject_summaries") or [],
     })
+    from fmriflow.core import paths
+    root_id = paths.root_id_for_path(run_dir)
     return {
         "group_name": data.get("group_name", run_dir.name),
         "run_id": run_id,
         "run_dir": str(run_dir),
+        "root_id": root_id,
+        "root_path": str(paths.root_for_id(root_id) or ""),
+        "is_primary_root": root_id == paths.primary_root_id(),
         "subjects": data.get("subjects", []),
         "n_subjects": len(data.get("subjects", [])),
         "status_counts": status_counts,

--- a/fmriflow/server/routes/qa.py
+++ b/fmriflow/server/routes/qa.py
@@ -194,7 +194,8 @@ def _resolve_group_subject_dir(
     # 404'd for those.
     from fmriflow.server.services.run_manager import resolve_group_run_dir
     registry = request.app.state.run_manager.registry
-    run_dir = resolve_group_run_dir(registry, name, run_id)
+    run_dir = resolve_group_run_dir(
+        registry, name, run_id, root_id=request.query_params.get('root'))
     if run_dir is None:
         raise HTTPException(
             status_code=404,

--- a/fmriflow/server/routes/run_graph.py
+++ b/fmriflow/server/routes/run_graph.py
@@ -83,7 +83,8 @@ def _resolve_group_run_dir(
         raise HTTPException(status_code=400, detail="invalid run_id")
     from fmriflow.server.services.run_manager import resolve_group_run_dir
     registry = request.app.state.run_manager.registry
-    run_dir = resolve_group_run_dir(registry, group_name, run_id)
+    root = request.query_params.get('root')
+    run_dir = resolve_group_run_dir(registry, group_name, run_id, root_id=root)
     if run_dir is None:
         raise HTTPException(
             status_code=404,
@@ -105,7 +106,8 @@ def _resolve_study_run_dir(
         raise HTTPException(status_code=400, detail="invalid run_id")
     from fmriflow.server.services.run_manager import resolve_study_run_dir
     registry = request.app.state.run_manager.registry
-    run_dir = resolve_study_run_dir(registry, study_name, run_id)
+    root = request.query_params.get('root')
+    run_dir = resolve_study_run_dir(registry, study_name, run_id, root_id=root)
     if run_dir is None:
         raise HTTPException(
             status_code=404,

--- a/fmriflow/server/routes/settings.py
+++ b/fmriflow/server/routes/settings.py
@@ -13,6 +13,7 @@ successful POST.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
@@ -104,7 +105,14 @@ def _result_roots_snapshot() -> dict:
             "read_only": rid != primary_id,
             "reachable": reachable,
         })
-    return {"roots": roots, "configured": paths.result_roots_config()}
+    # When $FMRIFLOW_RESULT_ROOTS is exported it overrides the persisted
+    # list (same precedence as the scalar path settings), so add/remove
+    # here would be ineffective — the UI locks the controls in that case.
+    return {
+        "roots": roots,
+        "configured": paths.result_roots_config(),
+        "env_override": bool(os.environ.get(paths.ENV_RESULT_ROOTS)),
+    }
 
 
 @router.get("/result-roots")

--- a/fmriflow/server/routes/settings.py
+++ b/fmriflow/server/routes/settings.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from fmriflow.core import paths
@@ -77,3 +77,57 @@ def post_settings(update: SettingsUpdate) -> dict:
     snap["restart_required"] = True
     snap["created"] = created
     return snap
+
+
+# ── Result roots (read-only extra scan locations) ────────────────────
+#
+# Unlike the scalar path overrides above, these apply **live** — the run
+# scanners re-resolve the root list on each rescan, so no restart needed.
+
+class ResultRootBody(BaseModel):
+    path: str
+
+
+def _result_roots_snapshot() -> dict:
+    primary_id = paths.primary_root_id()
+    roots = []
+    for r in paths.result_search_roots():
+        rid = paths.root_id(r)
+        try:
+            reachable = r.is_dir()
+        except OSError:
+            reachable = False
+        roots.append({
+            "root_id": rid,
+            "path": str(r),
+            "is_primary": rid == primary_id,
+            "read_only": rid != primary_id,
+            "reachable": reachable,
+        })
+    return {"roots": roots, "configured": paths.result_roots_config()}
+
+
+@router.get("/result-roots")
+def get_result_roots() -> dict:
+    """List every result root the scanners see (primary + read-only extras),
+    each with its stable ``root_id`` and reachability."""
+    return _result_roots_snapshot()
+
+
+@router.post("/result-roots")
+def add_result_root(body: ResultRootBody) -> dict:
+    """Register a read-only extra root. Applies on the next rescan."""
+    try:
+        paths.add_result_root(body.path)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return _result_roots_snapshot()
+
+
+@router.delete("/result-roots")
+def remove_result_root(body: ResultRootBody) -> dict:
+    """Unregister an extra root (matched by realpath). Applies on next rescan."""
+    paths.remove_result_root(body.path)
+    return _result_roots_snapshot()

--- a/fmriflow/server/routes/study.py
+++ b/fmriflow/server/routes/study.py
@@ -58,11 +58,16 @@ async def list_study_runs(request: Request, name: str | None = None):
 
 
 @router.get("/study-runs/{name}/{run_id}")
-async def get_study_run(request: Request, name: str, run_id: str):
-    """Return the full ``StudyRunSummary`` for one timestamped run."""
+async def get_study_run(request: Request, name: str, run_id: str, root: str | None = None):
+    """Return the full ``StudyRunSummary`` for one timestamped run.
+
+    Optional ``?root=<root_id>`` disambiguates when the same study/run_id
+    exists in more than one result root.
+    """
     _check_path_segment(name, "study name")
     _check_path_segment(run_id, "run_id")
-    run_dir = resolve_study_run_dir(request.app.state.run_manager.registry, name, run_id)
+    run_dir = resolve_study_run_dir(
+        request.app.state.run_manager.registry, name, run_id, root_id=root)
     if run_dir is None:
         raise HTTPException(
             status_code=404,
@@ -73,12 +78,13 @@ async def get_study_run(request: Request, name: str, run_id: str):
 
 @router.get("/study-runs/{name}/{run_id}/file/{file_path:path}")
 async def get_study_run_file(
-    request: Request, name: str, run_id: str, file_path: str,
+    request: Request, name: str, run_id: str, file_path: str, root: str | None = None,
 ):
     """Serve a single file from inside a timestamped study run directory."""
     _check_path_segment(name, "study name")
     _check_path_segment(run_id, "run_id")
-    run_dir = resolve_study_run_dir(request.app.state.run_manager.registry, name, run_id)
+    run_dir = resolve_study_run_dir(
+        request.app.state.run_manager.registry, name, run_id, root_id=root)
     if run_dir is None:
         raise HTTPException(
             status_code=404,
@@ -207,6 +213,7 @@ def _serve_file(base: Path, file_path: str) -> FileResponse:
 
 def _summarize(run_dir: Path, *, run_id: str, data: dict) -> dict:
     """Project a ``StudyRunSummary`` JSON down to a row for the list view."""
+    from fmriflow.core import paths
     from fmriflow.core.run_summary import derive_group_status
     groups = data.get("group_summaries", []) or []
     labels = data.get("group_labels", []) or []
@@ -241,10 +248,15 @@ def _summarize(run_dir: Path, *, run_id: str, data: dict) -> dict:
         overall_status = "warning"
     else:
         overall_status = "ok"
+    root_id = paths.root_id_for_path(run_dir)
     return {
         "study_name": data.get("study_name", run_dir.parent.name),
         "run_id": run_id,
         "run_dir": str(run_dir),
+        # Location-aware identity: which result root this run lives in.
+        "root_id": root_id,
+        "root_path": str(paths.root_for_id(root_id) or ""),
+        "is_primary_root": root_id == paths.primary_root_id(),
         "group_labels": labels,
         "n_groups": n_groups_total,
         "status_counts": status_counts,

--- a/fmriflow/server/services/run_manager.py
+++ b/fmriflow/server/services/run_manager.py
@@ -117,11 +117,14 @@ def discover_subject_run_summaries(
         seen.add(real)
         out.append(summary_path)
 
-    # Source 1 — filesystem default tree.
-    root = paths.results_root()
-    if root.is_dir():
-        for summary_path in root.rglob('run_summary.json'):
-            add(summary_path)
+    # Source 1 — filesystem default tree(s): primary + read-only extras.
+    for root in paths.result_roots():
+        try:
+            for summary_path in root.rglob('run_summary.json'):
+                add(summary_path)
+        except OSError:
+            # An extra root on an offline mount shouldn't break discovery.
+            logger.warning("Skipping unreadable results root: %s", root)
 
     # Source 2 — registry entries whose output_dir we know.
     for state in registry.list_all():
@@ -164,7 +167,7 @@ def discover_group_run_dirs(
     """
     return _discover_run_dirs(
         registry,
-        default_root=paths.group_runs_root(),
+        default_roots=paths.group_run_roots(),
         summary_name='group_summary.json',
         kind='group',
         name=name,
@@ -177,7 +180,7 @@ def discover_study_run_dirs(
     """Study analogue of :func:`discover_group_run_dirs`."""
     return _discover_run_dirs(
         registry,
-        default_root=paths.study_runs_root(),
+        default_roots=paths.study_run_roots(),
         summary_name='study_summary.json',
         kind='study',
         name=name,
@@ -187,7 +190,7 @@ def discover_study_run_dirs(
 def _discover_run_dirs(
     registry: "RunRegistry",
     *,
-    default_root: Path,
+    default_roots: list[Path],
     summary_name: str,
     kind: str,
     name: str | None,
@@ -205,9 +208,18 @@ def _discover_run_dirs(
         seen.add(real)
         out.append((group_or_study, run_id, run_dir))
 
-    # Source 1 — default root (legacy + symlinked layouts).
-    if default_root.exists():
-        for top in sorted(default_root.iterdir()):
+    # Source 1 — default root(s): primary + read-only extras. Earlier
+    # roots win on collisions (dedupe-by-realpath), so the primary's copy
+    # of a same-named run takes precedence.
+    for default_root in default_roots:
+        try:
+            if not default_root.is_dir():
+                continue
+            tops = sorted(default_root.iterdir())
+        except OSError:
+            logger.warning("Skipping unreadable run root: %s", default_root)
+            continue
+        for top in tops:
             if not top.is_dir():
                 continue
             if name is not None and top.name != name:
@@ -256,20 +268,31 @@ def _discover_run_dirs(
 
 def resolve_group_run_dir(
     registry: "RunRegistry", name: str, run_id: str,
+    root_id: str | None = None,
 ) -> Path | None:
-    """Return the on-disk dir for a ``(name, run_id)`` pair or ``None``."""
+    """Return the on-disk dir for a ``(name, run_id)`` pair or ``None``.
+
+    Discovery is in precedence order (primary root first), so without a
+    ``root_id`` the primary's copy wins on a cross-root collision. Pass
+    ``root_id`` to disambiguate to a specific root.
+    """
     for gname, rid, run_dir in discover_group_run_dirs(registry, name=name):
         if gname == name and rid == run_id:
+            if root_id is not None and paths.root_id_for_path(run_dir) != root_id:
+                continue
             return run_dir
     return None
 
 
 def resolve_study_run_dir(
     registry: "RunRegistry", name: str, run_id: str,
+    root_id: str | None = None,
 ) -> Path | None:
     """Study analogue of :func:`resolve_group_run_dir`."""
     for sname, rid, run_dir in discover_study_run_dirs(registry, name=name):
         if sname == name and rid == run_id:
+            if root_id is not None and paths.root_id_for_path(run_dir) != root_id:
+                continue
             return run_dir
     return None
 

--- a/fmriflow/server/services/run_registry.py
+++ b/fmriflow/server/services/run_registry.py
@@ -74,26 +74,40 @@ class RunRegistry:
     """Directory-backed registry for preprocessing runs."""
 
     def __init__(self, root: Path | None = None):
-        # Explicit root disables the legacy fallback (so tests are
-        # isolated from the developer's real ~/.fmriflow/runs/).
+        # Explicit root disables the multi-root + legacy fallback (so
+        # tests are isolated from the developer's real ~/.fmriflow/runs/
+        # and any configured extra roots).
+        self._explicit = root is not None
         if root is not None:
             self.root = Path(root)
-            self._legacy_root = None
         else:
             self.root = paths.runs_dir()
-            self._legacy_root = paths.legacy_runs_root()
         self.root.mkdir(parents=True, exist_ok=True)
 
+    def _read_roots(self) -> list[Path]:
+        """Roots to *read* from: primary + read-only extras + legacy.
+
+        Writes always go to ``self.root`` (the primary); only discovery
+        and resolution span the extra roots.
+        """
+        if self._explicit:
+            return [self.root]
+        return paths.runs_roots()
+
     def _resolve(self, run_id: str) -> Path:
-        """Return the run directory, falling back to the legacy
-        location for runs created before $FMRIFLOW_HOME existed."""
-        new = self.root / run_id
-        if new.is_dir() or self._legacy_root is None:
-            return new
-        legacy = self._legacy_root / run_id
-        if legacy.is_dir():
-            return legacy
-        return new
+        """Return a run's directory, searching every read root in order.
+
+        New/primary first; an extra (read-only) or legacy root is used
+        only if the run isn't under the primary. Falls back to the
+        primary path (for new runs about to be created)."""
+        for root in self._read_roots():
+            cand = root / run_id
+            try:
+                if cand.is_dir():
+                    return cand
+            except OSError:
+                continue
+        return self.root / run_id
 
     # ── Paths ────────────────────────────────────────────────────────
 
@@ -146,13 +160,15 @@ class RunRegistry:
         """
         out: list[RunStateFile] = []
         seen: set[str] = set()
-        roots = [self.root]
-        if self._legacy_root is not None:
-            roots.append(self._legacy_root)
-        for root in roots:
-            if not root.is_dir():
+        for root in self._read_roots():
+            try:
+                if not root.is_dir():
+                    continue
+                children = list(root.iterdir())
+            except OSError:
+                logger.warning("Skipping unreadable runs root: %s", root)
                 continue
-            for child in root.iterdir():
+            for child in children:
                 if not child.is_dir() or child.name in seen:
                     continue
                 state = self.load(child.name)

--- a/fmriflow/server/services/run_store.py
+++ b/fmriflow/server/services/run_store.py
@@ -49,20 +49,31 @@ class RunStore:
                 discover_subject_run_summaries,
             )
             summary_paths = discover_subject_run_summaries(self.registry)
-        elif self.results_dir.is_dir():
-            summary_paths = list(self.results_dir.rglob('run_summary.json'))
         else:
+            # No registry (rare): scan every results root directly.
+            from fmriflow.core import paths as _p
+            roots = [self.results_dir] if self.results_dir else _p.result_roots()
             summary_paths = []
+            for root in roots:
+                try:
+                    if root.is_dir():
+                        summary_paths.extend(root.rglob('run_summary.json'))
+                except OSError:
+                    continue
 
+        from fmriflow.core import paths as _paths
         for summary_path in summary_paths:
             try:
                 summary = RunSummary.from_json(summary_path)
                 run_id = hashlib.md5(
                     str(summary_path.parent).encode()
                 ).hexdigest()[:12]
+                rid = _paths.root_id_for_path(summary_path.parent)
                 self._index.append({
                     'run_id': run_id,
                     'output_dir': str(summary_path.parent),
+                    'root_id': rid,
+                    'root_path': str(_paths.root_for_id(rid) or ''),
                     'summary': summary,
                 })
             except Exception as e:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -892,6 +892,28 @@ export async function saveSettings(
   })
 }
 
+// ── Result roots (read-only extra scan locations) ──
+
+export async function fetchResultRoots(): Promise<import('./types').ResultRootsSnapshot> {
+  return json(`${BASE}/settings/result-roots`)
+}
+
+export async function addResultRoot(path: string): Promise<import('./types').ResultRootsSnapshot> {
+  return json(`${BASE}/settings/result-roots`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path }),
+  })
+}
+
+export async function removeResultRoot(path: string): Promise<import('./types').ResultRootsSnapshot> {
+  return json(`${BASE}/settings/result-roots`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path }),
+  })
+}
+
 // ── Preproc stack ────────────────────────────────────────────────────
 
 export async function fetchStackWorkflows(): Promise<{ workflows: import('./types').WorkflowInfo[] }> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -923,6 +923,21 @@ export type SettingsUpdate = Partial<Record<SettingsKey, string>> & {
   create_missing?: boolean
 }
 
+// ── Result roots (read-only extra scan locations) ──
+
+export interface ResultRoot {
+  root_id: string
+  path: string
+  is_primary: boolean
+  read_only: boolean
+  reachable: boolean
+}
+
+export interface ResultRootsSnapshot {
+  roots: ResultRoot[]
+  configured: string[]
+}
+
 // ── Preproc stack ────────────────────────────────────────────────────
 
 export type BootstrapKind = 'fmriprep' | 'nipype' | 'custom' | 'bids_app' | 'passthrough'

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1094,6 +1094,9 @@ export interface GroupRunListing {
   group_name: string
   run_id: string                  // empty string for legacy (pre-run-id) layout
   run_dir: string
+  root_id?: string                // which result root this run lives in
+  root_path?: string
+  is_primary_root?: boolean
   subjects: string[]
   n_subjects: number
   status_counts: GroupStatusCounts
@@ -1154,6 +1157,9 @@ export interface StudyRunListing {
   study_name: string
   run_id: string
   run_dir: string
+  root_id?: string                // which result root this run lives in
+  root_path?: string
+  is_primary_root?: boolean
   group_labels: string[]
   n_groups: number
   status_counts: StudyStatusCounts

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -936,6 +936,9 @@ export interface ResultRoot {
 export interface ResultRootsSnapshot {
   roots: ResultRoot[]
   configured: string[]
+  // True when $FMRIFLOW_RESULT_ROOTS is set in the environment, which
+  // overrides the persisted list — the UI locks add/remove in that case.
+  env_override?: boolean
 }
 
 // ── Preproc stack ────────────────────────────────────────────────────

--- a/frontend/src/views/GroupRunsView.tsx
+++ b/frontend/src/views/GroupRunsView.tsx
@@ -153,7 +153,22 @@ function RunListItem({
   return (
     <tr style={rowStyle(selected)} onClick={onClick}>
       <td style={tdStyle}>
-        <div style={{ fontWeight: 600 }}>{run.group_name}</div>
+        <div style={{ fontWeight: 600 }}>
+          {run.group_name}
+          {run.is_primary_root === false && run.root_path && (
+            <span
+              title={`Read-only result location: ${run.root_path}`}
+              style={{
+                marginLeft: 6, fontSize: 10, fontWeight: 500,
+                padding: '1px 6px', borderRadius: 4,
+                background: 'var(--bg-card)', border: '1px solid var(--border)',
+                color: 'var(--text-secondary)',
+              }}
+            >
+              ↪ {run.root_path.split('/').filter(Boolean).pop()}
+            </span>
+          )}
+        </div>
         <div style={monoSmall}>
           {run.run_id ? <code>{run.run_id}</code> : <em>legacy</em>}
           {' · '}{run.n_subjects} subjects

--- a/frontend/src/views/Settings.tsx
+++ b/frontend/src/views/Settings.tsx
@@ -415,10 +415,11 @@ function ResultRootsSection() {
   const [path, setPath] = useState('')
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  const [envOverride, setEnvOverride] = useState(false)
 
   const load = () => {
     fetchResultRoots()
-      .then((s) => setRoots(s.roots))
+      .then((s) => { setRoots(s.roots); setEnvOverride(!!s.env_override) })
       .catch((e) => setErr(String(e)))
   }
   useEffect(load, [])
@@ -452,6 +453,13 @@ function ResultRootsSection() {
 
       {err && <div style={bannerStyle('warning')}>{err}</div>}
 
+      {envOverride && (
+        <div style={bannerStyle('info')}>
+          <code>$FMRIFLOW_RESULT_ROOTS</code> is set in the environment and
+          overrides this list — unset it in your shell to manage roots here.
+        </div>
+      )}
+
       <table style={resolvedTable}>
         <tbody>
           {roots.map((r) => (
@@ -471,7 +479,7 @@ function ResultRootsSection() {
                 {!r.is_primary && (
                   <button
                     style={{ fontSize: 11, padding: '2px 8px', cursor: 'pointer' }}
-                    disabled={busy}
+                    disabled={busy || envOverride}
                     onClick={() => remove(r.path)}
                   >
                     Remove
@@ -489,12 +497,13 @@ function ResultRootsSection() {
           style={{ ...inputStyle, flex: 1 }}
           placeholder="/path/to/another/fmriflow"
           value={path}
+          disabled={envOverride}
           onChange={(e) => setPath(e.target.value)}
           onKeyDown={(e) => { if (e.key === 'Enter') add() }}
         />
         <button
           style={{ padding: '6px 14px', cursor: 'pointer' }}
-          disabled={busy || !path.trim()}
+          disabled={busy || envOverride || !path.trim()}
           onClick={add}
         >
           Add location

--- a/frontend/src/views/Settings.tsx
+++ b/frontend/src/views/Settings.tsx
@@ -11,8 +11,13 @@
 
 import { useEffect, useState } from 'react'
 import type { CSSProperties } from 'react'
-import { fetchSettings, saveSettings } from '../api/client'
-import type { SettingsKey, SettingsSnapshot, SettingsUpdate } from '../api/types'
+import {
+  fetchSettings, saveSettings,
+  fetchResultRoots, addResultRoot, removeResultRoot,
+} from '../api/client'
+import type {
+  SettingsKey, SettingsSnapshot, SettingsUpdate, ResultRoot,
+} from '../api/types'
 
 const SETTINGS_FIELDS: Array<{
   key: SettingsKey
@@ -398,6 +403,103 @@ export function Settings() {
           </tr>
         </tbody>
       </table>
+
+      <ResultRootsSection />
     </div>
+  )
+}
+
+
+function ResultRootsSection() {
+  const [roots, setRoots] = useState<ResultRoot[]>([])
+  const [path, setPath] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = () => {
+    fetchResultRoots()
+      .then((s) => setRoots(s.roots))
+      .catch((e) => setErr(String(e)))
+  }
+  useEffect(load, [])
+
+  const add = () => {
+    if (!path.trim()) return
+    setBusy(true); setErr(null)
+    addResultRoot(path.trim())
+      .then((s) => { setRoots(s.roots); setPath('') })
+      .catch((e) => setErr(String(e)))
+      .finally(() => setBusy(false))
+  }
+  const remove = (p: string) => {
+    setBusy(true); setErr(null)
+    removeResultRoot(p)
+      .then((s) => setRoots(s.roots))
+      .catch((e) => setErr(String(e)))
+      .finally(() => setBusy(false))
+  }
+
+  return (
+    <>
+      <div style={sectionHeader}>Result locations</div>
+      <div style={descStyle}>
+        Extra <strong>read-only</strong> directories the dashboard also scans for
+        results and runs. Each should be an <code>$FMRIFLOW_HOME</code>-shaped tree
+        (with <code>data/results/</code>, <code>study_runs/</code>,{' '}
+        <code>group_runs/</code>, <code>runs/</code>). New runs are never written
+        here. Applies on the next refresh — no restart needed.
+      </div>
+
+      {err && <div style={bannerStyle('warning')}>{err}</div>}
+
+      <table style={resolvedTable}>
+        <tbody>
+          {roots.map((r) => (
+            <tr key={r.root_id}>
+              <td style={resolvedTd}>
+                <code>{r.path}</code>{' '}
+                {r.is_primary
+                  ? <span style={sourceBadge('env')}>primary</span>
+                  : <span style={sourceBadge('default')}>read-only</span>}
+                {!r.reachable && (
+                  <span style={{ ...sourceBadge('default'), color: 'var(--accent-red, #cc6677)' }}>
+                    unreachable
+                  </span>
+                )}
+              </td>
+              <td style={{ ...resolvedTd, textAlign: 'right', width: 90 }}>
+                {!r.is_primary && (
+                  <button
+                    style={{ fontSize: 11, padding: '2px 8px', cursor: 'pointer' }}
+                    disabled={busy}
+                    onClick={() => remove(r.path)}
+                  >
+                    Remove
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
+        <input
+          type="text"
+          style={{ ...inputStyle, flex: 1 }}
+          placeholder="/path/to/another/fmriflow"
+          value={path}
+          onChange={(e) => setPath(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') add() }}
+        />
+        <button
+          style={{ padding: '6px 14px', cursor: 'pointer' }}
+          disabled={busy || !path.trim()}
+          onClick={add}
+        >
+          Add location
+        </button>
+      </div>
+    </>
   )
 }

--- a/frontend/src/views/StudyRunsView.tsx
+++ b/frontend/src/views/StudyRunsView.tsx
@@ -197,7 +197,22 @@ function RunListItem({
   return (
     <tr style={rowStyle(selected)} onClick={onClick}>
       <td style={tdStyle}>
-        <div style={{ fontWeight: 600 }}>{run.study_name}</div>
+        <div style={{ fontWeight: 600 }}>
+          {run.study_name}
+          {run.is_primary_root === false && run.root_path && (
+            <span
+              title={`Read-only result location: ${run.root_path}`}
+              style={{
+                marginLeft: 6, fontSize: 10, fontWeight: 500,
+                padding: '1px 6px', borderRadius: 4,
+                background: 'var(--bg-card)', border: '1px solid var(--border)',
+                color: 'var(--text-secondary)',
+              }}
+            >
+              ↪ {run.root_path.split('/').filter(Boolean).pop()}
+            </span>
+          )}
+        </div>
         <div style={monoSmall}>
           <code>{run.run_id}</code> · {formatTimestamp(run.started_at)}
         </div>

--- a/tests/test_infrastructure/test_registry.py
+++ b/tests/test_infrastructure/test_registry.py
@@ -18,6 +18,11 @@ EXPECTED_CATEGORIES = {
     "analyzers",
     "models",
     "reporters",
+    "nipype_nodes",
+    "group_analyzers",
+    "group_reporters",
+    "study_analyzers",
+    "study_reporters",
 }
 
 


### PR DESCRIPTION
## Summary

Lets the dashboard scan **multiple locations** for results and runs, not just the
primary `$FMRIFLOW_HOME`. You register additional **read-only** roots (another
disk, an archive, a shared tree) and their results/runs show up alongside your
own.

**Principle: write-to-one, read-from-many.** New runs are always written to the
primary root; extra roots are an ordered, read-only search path. Runs are
**identified by location** — each root has a stable `root_id` (`sha1(realpath)[:8]`,
reorder-safe), and a run's identity is `<root_id>:<run_id>`. Bare run ids resolve
primary-first, so existing links keep working; `?root=<root_id>` disambiguates the
rare same-name/run-id collision.

## What's included
- **paths** — `result_search_roots()` + plural accessors (`result_roots`,
  `study_run_roots`, `group_run_roots`, `runs_roots`), env (`$FMRIFLOW_RESULT_ROOTS`,
  os.pathsep) > settings.json list. `root_id` / `root_for_id` / `root_id_for_path`,
  and `add/remove_result_root`. Dedupe-by-realpath; offline mounts skipped, never crash.
- **discovery** — subject/study/group discovery + `RunRegistry` + `RunStore` scan
  every root; reads span all roots, **writes stay on the primary**. `delete()`
  already refuses anything outside the primary, so extra-root runs are read-only.
- **api** — listings expose `root_id`/`root_path`/`is_primary_root`; detail/file/
  graph/qa endpoints accept `?root=`. `GET/POST/DELETE /api/settings/result-roots`.
- **ui** — Settings "Result locations" editor (add/remove, primary/read-only/
  unreachable badges); `↪ <root>` badge on runs from a non-primary root.
- **docs** — web-ui guide section.

Default behaviour is unchanged when no extra roots are configured.

## Notes
- Applies on next refresh — **no restart** needed (unlike the scalar path settings).
- Known follow-up: the frontend doesn't yet send `?root=` on every per-file URL;
  only matters for the rare collision case (unique run ids resolve fine).
- Also fixes a pre-existing stale assertion in `test_registry.py` (its expected
  category set predated the group/study/nipype plugin categories).

## Verification
paths/discovery/settings smokes pass (extra roots discovered, offline skipped,
root_id stable+reversible, read-only deletes refused); `tsc --noEmit` clean; app
imports; `pytest` green (incl. the corrected registry test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)