### PR TITLE
feat: first-class NSD + Algonauts 2023 image-viewing dataset modules

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -77,6 +77,7 @@ Use the top-level key `preparation:`. Older configs that use
 | Field | Type | Description |
 |-------|------|-------------|
 | `test_runs` | list[str] | Run names to hold out for testing |
+| `test_trials` | str | Name of a per-run boolean test mask carried on the response data (e.g. `shared1000` from the `nsd` loader). Splits rows *within* every run rather than holding out whole runs — use for held-out **image sets** scattered across runs. Mutually exclusive with `test_runs`. |
 
 ## `model`
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -17,6 +17,9 @@ Run `fmriflow list modules` for the full list with descriptions. Summary by cate
 | `bert` | 768+ | BERT contextual embeddings (configurable layer) |
 | `fasttext` | 300 | FastText subword embeddings |
 | `gpt2` | 768+ | GPT-2 hidden states (configurable layer) |
+| `luminance` | 1 | Mean frame luminance per TR (video) |
+| `motion_energy` | 1 | Frame-differencing motion energy per TR (video) |
+| `clip` | 512+ | CLIP image embeddings, one row per shown image (open_clip; consumes an image sequence) |
 
 ## Feature Sources
 
@@ -32,6 +35,9 @@ Run `fmriflow list modules` for the full list with descriptions. Summary by cate
 | Module | Description |
 |--------|-------------|
 | `textgrid` | Load from Praat TextGrid files (long, short, and chronological formats) |
+| `audio` | Load audio (.wav) stimulus files |
+| `video` | Load video stimulus files (metadata only) |
+| `nsd` | Per-trial image references for an event-related image-viewing dataset (emits one image sequence per session) |
 | `skip` | Skip stimulus loading (for pre-prepared data) |
 
 ## Response Loaders
@@ -42,6 +48,7 @@ Run `fmriflow list modules` for the full list with descriptions. Summary by cate
 | `local` | Load from local filesystem |
 | `bids` | Load from BIDS-formatted dataset |
 | `preproc` | Load from a PreprocManifest (fmriprep outputs) |
+| `nsd` | Single-trial GLM betas (one pseudo-run per session), masked to an ROI and scaled; carries the 3-D ROI mask for surface reporters |
 
 ## Preparers
 
@@ -82,6 +89,7 @@ For use with `type: pipeline`:
 |--------|-------------|
 | `metrics` | Prediction accuracy metrics (JSON) |
 | `flatmap` | Pycortex surface flatmaps |
+| `nsd_fsaverage_flatmap` | Flatmap of func-volume scores resampled onto fsaverage (no per-subject surface registration) |
 | `weights` | Model weight matrices |
 | `histogram` | Accuracy distribution plots |
 | `webgl` | Interactive 3D brain viewer |

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -20,6 +20,8 @@ Run `fmriflow list modules` for the full list with descriptions. Summary by cate
 | `luminance` | 1 | Mean frame luminance per TR (video) |
 | `motion_energy` | 1 | Frame-differencing motion energy per TR (video) |
 | `clip` | 512+ | CLIP image embeddings, one row per shown image (open_clip; consumes an image sequence) |
+| `alexnet` | layer-dependent | AlexNet layer activations, one row per image (torchvision; optional PCA reduction). Reads an image directory or HDF5 store |
+| `timm` | model-dependent | Pooled embedding from any `timm` vision backbone (ViT, DINOv2, EVA, ConvNeXt, …), one row per image; per-model preprocessing. Reads an image directory or HDF5 store |
 
 ## Feature Sources
 
@@ -38,6 +40,7 @@ Run `fmriflow list modules` for the full list with descriptions. Summary by cate
 | `audio` | Load audio (.wav) stimulus files |
 | `video` | Load video stimulus files (metadata only) |
 | `nsd` | Per-trial image references for an event-related image-viewing dataset (emits one image sequence per session) |
+| `algonauts2023` | Training images for the Algonauts 2023 challenge (emits one image sequence over the subject's training-image directory) |
 | `skip` | Skip stimulus loading (for pre-prepared data) |
 
 ## Response Loaders
@@ -49,6 +52,7 @@ Run `fmriflow list modules` for the full list with descriptions. Summary by cate
 | `bids` | Load from BIDS-formatted dataset |
 | `preproc` | Load from a PreprocManifest (fmriprep outputs) |
 | `nsd` | Single-trial GLM betas (one pseudo-run per session), masked to an ROI and scaled; carries the 3-D ROI mask for surface reporters |
+| `algonauts2023` | Algonauts 2023 fsaverage-surface fMRI (LH+RH `.npy` concatenated to a 2-D matrix); carries a seeded validation split (`split.test_trials: val`) and fsaverage vertex masks for surface reporters |
 
 ## Preparers
 
@@ -90,6 +94,7 @@ For use with `type: pipeline`:
 | `metrics` | Prediction accuracy metrics (JSON) |
 | `flatmap` | Pycortex surface flatmaps |
 | `nsd_fsaverage_flatmap` | Flatmap of func-volume scores resampled onto fsaverage (no per-subject surface registration) |
+| `algonauts_fsaverage_flatmap` | Flatmap of Algonauts 2023 challenge-space vertex scores expanded onto the full fsaverage surface |
 | `weights` | Model weight matrices |
 | `histogram` | Accuracy distribution plots |
 | `webgl` | Interactive 3D brain viewer |

--- a/fmriflow/config/schema.py
+++ b/fmriflow/config/schema.py
@@ -93,10 +93,11 @@ def validate_config(config: dict) -> list[str]:
             if source == "grouped_hdf" and "paths" not in feat:
                 errors.append(f"features[{i}] grouped_hdf source requires 'paths'")
 
-    # Split validation
+    # Split validation — either whole-run holdout (test_runs) or a trial-level
+    # holdout named by test_trials (a per-run mask the response loader supplies).
     split = config.get("split", {})
-    if "test_runs" not in split:
-        errors.append("'split.test_runs' is required")
+    if "test_runs" not in split and "test_trials" not in split:
+        errors.append("'split' requires either 'test_runs' or 'test_trials'")
 
     # Preparation validation
     prep = config.get("preparation", {})

--- a/fmriflow/config/schema.py
+++ b/fmriflow/config/schema.py
@@ -98,6 +98,9 @@ def validate_config(config: dict) -> list[str]:
     split = config.get("split", {})
     if "test_runs" not in split and "test_trials" not in split:
         errors.append("'split' requires either 'test_runs' or 'test_trials'")
+    elif "test_runs" in split and "test_trials" in split:
+        errors.append("'split' accepts either 'test_runs' or 'test_trials', not both "
+                      "(the preparer would silently ignore 'test_runs')")
 
     # Preparation validation
     prep = config.get("preparation", {})

--- a/fmriflow/core/types.py
+++ b/fmriflow/core/types.py
@@ -95,13 +95,28 @@ class VisualStim:
     tr_times: np.ndarray    # TR onset times in seconds
 
 
+@dataclass(frozen=True)
+class ImageSeqStim:
+    """A sequence of still images, one per row/trial (event-related viewing).
+
+    Unlike :class:`VisualStim` (a continuous video resampled onto a TR grid),
+    each image corresponds to exactly one response row, so no temporal
+    alignment is needed.  Images are referenced — not decoded — here; the
+    feature extractor reads them on demand from ``source``.
+    """
+    source: str             # path or URL to the image store (e.g. an HDF5 file)
+    image_ids: np.ndarray   # (n_trials,) 0-based indices into the store, in trial order
+    source_kind: str = "hdf5"   # how to read `source`: "hdf5" | "image_dir"
+    dataset: str = ""       # dataset name within an HDF5 source (e.g. "imgBrick")
+
+
 # ─── Stimulus Data ────────────────────────────────────────────
 
 @dataclass(frozen=True)
 class StimRun:
     """Stimulus data for a single run/story."""
     name: str
-    stimulus: LanguageStim | AudioStim | VisualStim
+    stimulus: LanguageStim | AudioStim | VisualStim | ImageSeqStim
     language: str = "en"
     modality: str = "reading"  # "reading" | "listening" | "visual"
 

--- a/fmriflow/modules/__init__.py
+++ b/fmriflow/modules/__init__.py
@@ -15,10 +15,12 @@ def register_builtins(registry):
     import fmriflow.modules.stimulus_loaders.skip  # noqa: F401
     import fmriflow.modules.stimulus_loaders.audio  # noqa: F401
     import fmriflow.modules.stimulus_loaders.video  # noqa: F401
+    import fmriflow.modules.stimulus_loaders.nsd  # noqa: F401
 
     import fmriflow.modules.response_loaders.bids  # noqa: F401
     import fmriflow.modules.response_loaders.cloud  # noqa: F401
     import fmriflow.modules.response_loaders.local  # noqa: F401
+    import fmriflow.modules.response_loaders.nsd  # noqa: F401
     import fmriflow.modules.response_loaders.readers  # noqa: F401
     import fmriflow.modules.response_loaders.multiphase_hdf  # noqa: F401
     try:
@@ -74,6 +76,7 @@ def register_builtins(registry):
     import fmriflow.modules.reporters.r_flatmap  # noqa: F401
     import fmriflow.modules.reporters.r2_flatmap  # noqa: F401
     import fmriflow.modules.reporters.native_flatmap  # noqa: F401
+    import fmriflow.modules.reporters.nsd_fsaverage_flatmap  # noqa: F401
 
     # Post-fmriprep nipype-style nodes
     import fmriflow.modules.nipype_nodes.source  # noqa: F401

--- a/fmriflow/modules/__init__.py
+++ b/fmriflow/modules/__init__.py
@@ -16,11 +16,13 @@ def register_builtins(registry):
     import fmriflow.modules.stimulus_loaders.audio  # noqa: F401
     import fmriflow.modules.stimulus_loaders.video  # noqa: F401
     import fmriflow.modules.stimulus_loaders.nsd  # noqa: F401
+    import fmriflow.modules.stimulus_loaders.algonauts2023  # noqa: F401
 
     import fmriflow.modules.response_loaders.bids  # noqa: F401
     import fmriflow.modules.response_loaders.cloud  # noqa: F401
     import fmriflow.modules.response_loaders.local  # noqa: F401
     import fmriflow.modules.response_loaders.nsd  # noqa: F401
+    import fmriflow.modules.response_loaders.algonauts2023  # noqa: F401
     import fmriflow.modules.response_loaders.readers  # noqa: F401
     import fmriflow.modules.response_loaders.multiphase_hdf  # noqa: F401
     try:
@@ -59,6 +61,7 @@ def register_builtins(registry):
     import fmriflow.modules.analyzers.project_to_subspace  # noqa: F401
     import fmriflow.modules.analyzers.project_to_fsaverage  # noqa: F401
     import fmriflow.modules.analyzers.block_permutation_significance  # noqa: F401
+    import fmriflow.modules.analyzers.algonauts_to_fsaverage  # noqa: F401
 
     import fmriflow.modules.models.ridge  # noqa: F401
     import fmriflow.modules.models.himalaya  # noqa: F401
@@ -77,6 +80,7 @@ def register_builtins(registry):
     import fmriflow.modules.reporters.r2_flatmap  # noqa: F401
     import fmriflow.modules.reporters.native_flatmap  # noqa: F401
     import fmriflow.modules.reporters.nsd_fsaverage_flatmap  # noqa: F401
+    import fmriflow.modules.reporters.algonauts_fsaverage_flatmap  # noqa: F401
 
     # Post-fmriprep nipype-style nodes
     import fmriflow.modules.nipype_nodes.source  # noqa: F401

--- a/fmriflow/modules/analyzers/algonauts_to_fsaverage.py
+++ b/fmriflow/modules/analyzers/algonauts_to_fsaverage.py
@@ -1,0 +1,100 @@
+"""Expand Algonauts 2023 challenge-space vertex scores onto the full fsaverage surface.
+
+The Algonauts response loader delivers scores over each subject's *challenge
+space* (the per-subject subset of fsaverage vertices with valid data), which
+differs between subjects.  To average or compare across subjects, each subject's
+scores must live on a common grid.  This analyzer expands ``result.scores`` back
+onto the full fsaverage surface (LH then RH concatenated), zero-filling vertices
+outside the subject's challenge space, and stores the result at
+``analysis.<output_key>``.
+
+Group-scope ``voxelwise_mean`` (a plain mean) can then average the shape-
+consistent per-subject arrays, and ``group_fsaverage_flatmap`` can render the
+group-average prediction-accuracy map.  Zeros are used (not NaN) so the plain
+group mean stays defined over the *union* of subjects' challenge spaces;
+non-visual cortex reads ~0 anyway.
+
+Fails gracefully (logs + stores nothing) when the ``algonauts2023`` response
+loader's ``fsaverage_masks`` / ``hemi_dims`` metadata is absent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from fmriflow.core.types import ResponseData
+from fmriflow.modules._decorators import analyzer
+
+logger = logging.getLogger(__name__)
+
+
+@analyzer("algonauts_to_fsaverage")
+class AlgonautsToFsaverageAnalyzer:
+    """Map Algonauts challenge-space ``result.scores`` onto full fsaverage vertices."""
+
+    name = "algonauts_to_fsaverage"
+    PARAM_SCHEMA = {
+        "input_key": {"type": "str", "default": "result.scores", "description": "Dotted context path to the per-vertex scores"},
+        "output_key": {"type": "str", "default": "analysis.fsaverage_scores", "description": "Where to store the (n_fsavg_verts,) array"},
+    }
+
+    def analyze(self, context, config: dict) -> None:
+        acfg = _my_cfg(config, self.name)
+        input_key = acfg.get("input_key", "result.scores")
+        output_key = acfg.get("output_key", "analysis.fsaverage_scores")
+
+        scores = _resolve_subject_key(context, input_key)
+        if scores is None:
+            logger.warning("algonauts_to_fsaverage: '%s' not in context — skipping", input_key)
+            return
+        if not context.has("responses"):
+            logger.warning("algonauts_to_fsaverage: no responses in context — skipping")
+            return
+        resp = context.get("responses", ResponseData)
+        masks = resp.metadata.get("fsaverage_masks", {})
+        hemi_dims = resp.metadata.get("hemi_dims", {})
+        hemis = resp.metadata.get("hemispheres", ["lh", "rh"])
+        if not masks or not hemi_dims:
+            logger.warning("algonauts_to_fsaverage: response carries no fsaverage_masks/"
+                           "hemi_dims (need the algonauts2023 loader) — skipping")
+            return
+
+        scores = np.asarray(scores, dtype=np.float32)
+        parts, offset = [], 0
+        for h in hemis:
+            d = hemi_dims[h]
+            full = np.zeros(masks[h].shape[0], dtype=np.float32)
+            full[masks[h]] = scores[offset:offset + d]
+            offset += d
+            parts.append(full)
+        fsaverage = np.concatenate(parts)   # lh then rh
+        context.put(output_key, fsaverage)
+        logger.info("algonauts_to_fsaverage: stored %s %s", output_key, fsaverage.shape)
+
+    def validate_config(self, config: dict) -> list[str]:
+        return []
+
+
+# ─── helpers (mirrors project_to_fsaverage) ───────────────────────
+
+def _my_cfg(config: dict, name: str) -> dict:
+    for entry in config.get("analysis", []) or []:
+        if entry.get("name") == name:
+            return entry.get("params", {}) or {}
+    return {}
+
+
+def _resolve_subject_key(ctx, key: str):
+    if ctx.has(key):
+        return ctx.get(key)
+    parts = key.split(".")
+    if not ctx.has(parts[0]):
+        return None
+    obj = ctx.get(parts[0])
+    for part in parts[1:]:
+        if obj is None:
+            return None
+        obj = obj.get(part) if isinstance(obj, dict) else getattr(obj, part, None)
+    return obj

--- a/fmriflow/modules/analyzers/algonauts_to_fsaverage.py
+++ b/fmriflow/modules/analyzers/algonauts_to_fsaverage.py
@@ -61,7 +61,21 @@ class AlgonautsToFsaverageAnalyzer:
                            "hemi_dims (need the algonauts2023 loader) — skipping")
             return
 
+        # The loader only carries masks for hemispheres whose mask file exists;
+        # skip clearly on any missing hemisphere or score-length mismatch rather
+        # than KeyError-ing or producing an incorrectly offset expansion.
+        missing = [h for h in hemis if h not in masks or h not in hemi_dims]
+        if missing:
+            logger.warning("algonauts_to_fsaverage: missing fsaverage_masks/hemi_dims "
+                           "for %s — skipping", missing)
+            return
+
         scores = np.asarray(scores, dtype=np.float32)
+        total = sum(hemi_dims[h] for h in hemis)
+        if scores.shape[0] != total:
+            logger.warning("algonauts_to_fsaverage: scores length %d != sum(hemi_dims) "
+                           "%d — skipping", scores.shape[0], total)
+            return
         parts, offset = [], 0
         for h in hemis:
             d = hemi_dims[h]

--- a/fmriflow/modules/feature_extractors/visual.py
+++ b/fmriflow/modules/feature_extractors/visual.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import numpy as np
 
@@ -176,6 +177,240 @@ class CLIPExtractor:
                 return _run(h[dataset])
         with h5py.File(source, "r") as h:
             return _run(h[dataset])
+
+    def validate_config(self, config: dict) -> list[str]:
+        return []
+
+
+@feature_extractor("alexnet")
+class AlexNetExtractor:
+    """AlexNet layer activations, one row per shown image.
+
+    Reproduces the Algonauts 2023 dev-kit visual-encoding features: a pretrained
+    torchvision AlexNet, activations read from a chosen layer (via
+    ``create_feature_extractor``), flattened per image, and optionally reduced
+    with PCA — the classic ``AlexNet layer -> PCA -> linear/ridge`` recipe.
+
+    Consumes :class:`ImageSeqStim`.  Images are read on demand from a directory
+    of image files (``source_kind='image_dir'``, e.g. Algonauts PNGs) or an HDF5
+    store (``'hdf5'``, e.g. NSD).  Identical images shared across runs are
+    encoded once and reused.
+
+    Note on PCA: when ``n_pca_components`` is set the basis is fit on **all**
+    encoded images (train + held-out), matching common Algonauts reproductions.
+    For a leakage-free fit, leave PCA off and let a ridge model regularise the
+    full-dimensional features (himalaya handles this natively via the kernel).
+    """
+
+    name = "alexnet"
+    n_dims = None  # set at extract time from the (flattened / PCA) width
+    PARAM_SCHEMA = {
+        "layer": {"type": "string", "default": "features.7", "description": "torchvision node to read (e.g. features.2, features.7, classifier.2)"},
+        "pretrained": {"type": "bool", "default": True, "description": "Use ImageNet-pretrained weights"},
+        "n_pca_components": {"type": "int", "description": "If set, PCA-reduce the flattened features to this many dims (fit on all images)"},
+        "batch_size": {"type": "int", "default": 64, "min": 1, "description": "Images per forward pass"},
+        "image_size": {"type": "int", "default": 224, "description": "Resize images to this square size before the network"},
+    }
+
+    def extract(self, stimuli: StimulusData, run_names: list[str],
+                config: dict) -> FeatureSet:
+        import torch
+        from torchvision.models import alexnet, AlexNet_Weights
+        from torchvision.models.feature_extraction import create_feature_extractor
+        from torchvision import transforms
+
+        layer = config.get("layer", "features.7")
+        pretrained = config.get("pretrained", True)
+        n_pca = config.get("n_pca_components")
+        batch_size = int(config.get("batch_size", 64))
+        image_size = int(config.get("image_size", 224))
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        weights = AlexNet_Weights.DEFAULT if pretrained else None
+        model = alexnet(weights=weights).eval().to(device)
+        fx = create_feature_extractor(model, return_nodes=[layer])
+        preprocess = transforms.Compose([
+            transforms.Resize((image_size, image_size)),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                                 std=[0.229, 0.224, 0.225]),
+        ])
+
+        stims = {r: _require_image_seq(stimuli.runs[r], self.name) for r in run_names}
+        sources = {s.source for s in stims.values()}
+        kinds = {s.source_kind for s in stims.values()}
+        if len(sources) != 1 or len(kinds) != 1:
+            raise ValueError("alexnet extractor expects one image store across runs; "
+                             f"got sources={sources} kinds={kinds}")
+        source, kind = sources.pop(), kinds.pop()
+        dataset = next(iter(stims.values())).dataset
+
+        unique_ids = np.unique(np.concatenate([s.image_ids for s in stims.values()]))
+        logger.info("alexnet: encoding %d unique images (layer=%s) on %s",
+                    len(unique_ids), layer, device)
+        feats = self._encode(source, kind, dataset, unique_ids, fx, layer,
+                             preprocess, device, batch_size)
+        if n_pca:
+            feats = self._pca(feats, int(n_pca))
+        self.n_dims = int(next(iter(feats.values())).shape[0])
+
+        data = {r: np.stack([feats[int(i)] for i in s.image_ids])
+                for r, s in stims.items()}
+        return FeatureSet(name=self.name, data=data, n_dims=self.n_dims)
+
+    @staticmethod
+    def _encode(source, kind, dataset, ids, fx, layer, preprocess, device, batch_size):
+        import torch
+        from PIL import Image
+
+        ids_sorted = np.sort(ids)
+
+        def _batches(load):
+            out: dict[int, np.ndarray] = {}
+            for start in range(0, len(ids_sorted), batch_size):
+                chunk = ids_sorted[start:start + batch_size]
+                batch = torch.stack([preprocess(load(int(i))) for i in chunk]).to(device)
+                with torch.no_grad():
+                    act = fx(batch)[layer]
+                act = act.reshape(act.shape[0], -1).cpu().numpy().astype(np.float32)
+                for i, vec in zip(chunk, act):
+                    out[int(i)] = vec
+            return out
+
+        if kind == "image_dir":
+            files = sorted(Path(source).glob("*.png")) or sorted(Path(source).glob("*.jpg"))
+            if not files:
+                raise FileNotFoundError(f"no .png/.jpg images under {source}")
+            return _batches(lambda i: Image.open(files[i]).convert("RGB"))
+
+        if kind == "hdf5":
+            import h5py
+            def _from_h5(h):
+                brick = h[dataset]
+                return _batches(lambda i: Image.fromarray(brick[i]).convert("RGB"))
+            if str(source).startswith("s3://"):
+                import s3fs
+                fs = s3fs.S3FileSystem(anon=True)
+                with fs.open(str(source)[len("s3://"):], "rb") as fobj, h5py.File(fobj, "r") as h:
+                    return _from_h5(h)
+            with h5py.File(source, "r") as h:
+                return _from_h5(h)
+
+        raise ValueError(f"alexnet extractor: unsupported source_kind '{kind}'")
+
+    @staticmethod
+    def _pca(feats: dict, n_components: int) -> dict:
+        from sklearn.decomposition import PCA
+        from sklearn.preprocessing import StandardScaler
+
+        ids = sorted(feats)
+        X = StandardScaler().fit_transform(np.stack([feats[i] for i in ids]))
+        n = min(n_components, X.shape[0], X.shape[1])
+        Xr = PCA(n_components=n, random_state=0).fit_transform(X).astype(np.float32)
+        return {i: Xr[k] for k, i in enumerate(ids)}
+
+    def validate_config(self, config: dict) -> list[str]:
+        return []
+
+
+@feature_extractor("timm")
+class TimmBackboneExtractor:
+    """Pooled features from any `timm` vision backbone, one row per image.
+
+    A generic image-encoder extractor: names a `timm` model (ViT, DINOv2, EVA,
+    ConvNeXt, …), runs each image through it, and returns the model's pooled
+    embedding (``num_classes=0``).  Covers the feature *backbones* used by the
+    top Algonauts 2023 solutions (ViT CLS-token / DINOv2 / EVA) so they can be
+    fit with a ridge encoder — it does **not** reproduce those systems' trained
+    readouts, memory, or ensembling.
+
+    Consumes :class:`ImageSeqStim`; reads images from an image directory
+    (``source_kind='image_dir'``) or an HDF5 store (``'hdf5'``).  Preprocessing
+    uses each model's own `timm` data config (correct resize + normalisation).
+    """
+
+    name = "timm"
+    n_dims = None  # set at extract time from the model's embedding width
+    PARAM_SCHEMA = {
+        "model": {"type": "string", "default": "vit_base_patch16_224.augreg2_in21k_ft_in1k", "description": "timm model name (e.g. vit_base_patch14_dinov2.lvd142m, eva02_base_patch14_224.mim_in22k_ft_in1k)"},
+        "pretrained": {"type": "bool", "default": True, "description": "Load pretrained weights"},
+        "batch_size": {"type": "int", "default": 64, "min": 1, "description": "Images per forward pass"},
+    }
+
+    def extract(self, stimuli: StimulusData, run_names: list[str],
+                config: dict) -> FeatureSet:
+        import torch
+        import timm
+
+        model_name = config.get("model", "vit_base_patch16_224.augreg2_in21k_ft_in1k")
+        pretrained = config.get("pretrained", True)
+        batch_size = int(config.get("batch_size", 64))
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model = timm.create_model(model_name, pretrained=pretrained, num_classes=0)
+        model = model.eval().to(device)
+        data_cfg = timm.data.resolve_model_data_config(model)
+        preprocess = timm.data.create_transform(**data_cfg, is_training=False)
+
+        stims = {r: _require_image_seq(stimuli.runs[r], self.name) for r in run_names}
+        sources = {s.source for s in stims.values()}
+        kinds = {s.source_kind for s in stims.values()}
+        if len(sources) != 1 or len(kinds) != 1:
+            raise ValueError("timm extractor expects one image store across runs; "
+                             f"got sources={sources} kinds={kinds}")
+        source, kind = sources.pop(), kinds.pop()
+        dataset = next(iter(stims.values())).dataset
+
+        unique_ids = np.unique(np.concatenate([s.image_ids for s in stims.values()]))
+        logger.info("timm: encoding %d unique images (%s) on %s",
+                    len(unique_ids), model_name, device)
+        feats = self._encode(source, kind, dataset, unique_ids, model,
+                             preprocess, device, batch_size)
+        self.n_dims = int(next(iter(feats.values())).shape[0])
+
+        data = {r: np.stack([feats[int(i)] for i in s.image_ids])
+                for r, s in stims.items()}
+        return FeatureSet(name=self.name, data=data, n_dims=self.n_dims)
+
+    @staticmethod
+    def _encode(source, kind, dataset, ids, model, preprocess, device, batch_size):
+        import torch
+        from PIL import Image
+
+        ids_sorted = np.sort(ids)
+
+        def _batches(load):
+            out: dict[int, np.ndarray] = {}
+            for start in range(0, len(ids_sorted), batch_size):
+                chunk = ids_sorted[start:start + batch_size]
+                batch = torch.stack([preprocess(load(int(i))) for i in chunk]).to(device)
+                with torch.no_grad():
+                    emb = model(batch)                     # (B, D) pooled
+                emb = emb.cpu().numpy().astype(np.float32)
+                for i, vec in zip(chunk, emb):
+                    out[int(i)] = vec
+            return out
+
+        if kind == "image_dir":
+            files = sorted(Path(source).glob("*.png")) or sorted(Path(source).glob("*.jpg"))
+            if not files:
+                raise FileNotFoundError(f"no .png/.jpg images under {source}")
+            return _batches(lambda i: Image.open(files[i]).convert("RGB"))
+
+        if kind == "hdf5":
+            import h5py
+            def _from_h5(h):
+                brick = h[dataset]
+                return _batches(lambda i: Image.fromarray(brick[i]).convert("RGB"))
+            if str(source).startswith("s3://"):
+                import s3fs
+                fs = s3fs.S3FileSystem(anon=True)
+                with fs.open(str(source)[len("s3://"):], "rb") as fobj, h5py.File(fobj, "r") as h:
+                    return _from_h5(h)
+            with h5py.File(source, "r") as h:
+                return _from_h5(h)
+
+        raise ValueError(f"timm extractor: unsupported source_kind '{kind}'")
 
     def validate_config(self, config: dict) -> list[str]:
         return []

--- a/fmriflow/modules/feature_extractors/visual.py
+++ b/fmriflow/modules/feature_extractors/visual.py
@@ -129,6 +129,12 @@ class CLIPExtractor:
 
         # Resolve the (single) image store and collect every image needed.
         stims = {r: _require_image_seq(stimuli.runs[r], self.name) for r in run_names}
+        kinds = {s.source_kind for s in stims.values()}
+        if kinds != {"hdf5"}:
+            raise ValueError("clip extractor requires an HDF5 image store "
+                             f"(source_kind='hdf5'); got {kinds}. For an image "
+                             "directory (e.g. Algonauts PNGs) use the alexnet or "
+                             "timm extractor instead.")
         sources = {s.source for s in stims.values()}
         datasets = {s.dataset for s in stims.values()}
         if len(sources) != 1 or len(datasets) != 1:
@@ -281,7 +287,12 @@ class AlexNetExtractor:
             files = sorted(Path(source).glob("*.png")) or sorted(Path(source).glob("*.jpg"))
             if not files:
                 raise FileNotFoundError(f"no .png/.jpg images under {source}")
-            return _batches(lambda i: Image.open(files[i]).convert("RGB"))
+
+            def _load(i):
+                # context-manage the handle so large image dirs don't leak fds
+                with Image.open(files[i]) as im:
+                    return im.convert("RGB")
+            return _batches(_load)
 
         if kind == "hdf5":
             import h5py
@@ -395,7 +406,12 @@ class TimmBackboneExtractor:
             files = sorted(Path(source).glob("*.png")) or sorted(Path(source).glob("*.jpg"))
             if not files:
                 raise FileNotFoundError(f"no .png/.jpg images under {source}")
-            return _batches(lambda i: Image.open(files[i]).convert("RGB"))
+
+            def _load(i):
+                # context-manage the handle so large image dirs don't leak fds
+                with Image.open(files[i]) as im:
+                    return im.convert("RGB")
+            return _batches(_load)
 
         if kind == "hdf5":
             import h5py

--- a/fmriflow/modules/feature_extractors/visual.py
+++ b/fmriflow/modules/feature_extractors/visual.py
@@ -1,12 +1,18 @@
-"""Visual feature extractors: luminance, motion_energy."""
+"""Visual feature extractors: luminance, motion_energy, clip."""
 
 from __future__ import annotations
+
+import logging
 
 import numpy as np
 
 from fmriflow.core.alignment import align_to_trs
-from fmriflow.core.types import FeatureSet, StimulusData, VisualStim
+from fmriflow.core.types import (
+    FeatureSet, ImageSeqStim, StimulusData, VisualStim,
+)
 from fmriflow.modules._decorators import feature_extractor
+
+logger = logging.getLogger(__name__)
 
 
 def _require_visual(stim_run, extractor_name: str) -> VisualStim:
@@ -72,6 +78,104 @@ class LuminanceExtractor:
             )
 
         return FeatureSet(name=self.name, data=data, n_dims=self.n_dims)
+
+    def validate_config(self, config: dict) -> list[str]:
+        return []
+
+
+def _require_image_seq(stim_run, extractor_name: str) -> ImageSeqStim:
+    """Return the ImageSeqStim or raise TypeError."""
+    if not isinstance(stim_run.stimulus, ImageSeqStim):
+        raise TypeError(
+            f"{extractor_name} requires ImageSeqStim, "
+            f"got {type(stim_run.stimulus).__name__}"
+        )
+    return stim_run.stimulus
+
+
+@feature_extractor("clip")
+class CLIPExtractor:
+    """CLIP image embeddings, one row per shown image (L2-normalized).
+
+    Consumes :class:`ImageSeqStim` (one still image per response row).  Images
+    are read on demand from the run's image store (a local or ``s3://`` HDF5),
+    encoded with an open_clip vision model, and L2-normalized.  Identical
+    images shared across runs are encoded once and reused.
+    """
+
+    name = "clip"
+    n_dims = None  # set from the model's embedding width at extract time
+    PARAM_SCHEMA = {
+        "model": {"type": "string", "default": "ViT-B-32", "description": "open_clip model architecture"},
+        "pretrained": {"type": "string", "default": "laion2b_s34b_b79k", "description": "open_clip pretrained tag"},
+        "batch_size": {"type": "int", "default": 64, "min": 1, "description": "Images encoded per forward pass"},
+    }
+
+    def extract(self, stimuli: StimulusData, run_names: list[str],
+                config: dict) -> FeatureSet:
+        import torch
+        import open_clip
+
+        model_name = config.get("model", "ViT-B-32")
+        pretrained = config.get("pretrained", "laion2b_s34b_b79k")
+        batch_size = int(config.get("batch_size", 64))
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model, _, preprocess = open_clip.create_model_and_transforms(
+            model_name, pretrained=pretrained
+        )
+        model = model.eval().to(device)
+
+        # Resolve the (single) image store and collect every image needed.
+        stims = {r: _require_image_seq(stimuli.runs[r], self.name) for r in run_names}
+        sources = {s.source for s in stims.values()}
+        datasets = {s.dataset for s in stims.values()}
+        if len(sources) != 1 or len(datasets) != 1:
+            raise ValueError("clip extractor expects one image store across runs; "
+                             f"got sources={sources} datasets={datasets}")
+        source = sources.pop()
+        dataset = datasets.pop()
+
+        unique_ids = np.unique(np.concatenate([s.image_ids for s in stims.values()]))
+        logger.info("clip: encoding %d unique images (%s/%s) on %s",
+                    len(unique_ids), model_name, pretrained, device)
+        emb = self._encode_ids(source, dataset, unique_ids, model, preprocess,
+                               device, batch_size)
+        self.n_dims = next(iter(emb.values())).shape[0]
+
+        data = {r: np.stack([emb[int(i)] for i in s.image_ids])
+                for r, s in stims.items()}
+        return FeatureSet(name=self.name, data=data, n_dims=self.n_dims)
+
+    @staticmethod
+    def _encode_ids(source, dataset, ids, model, preprocess, device, batch_size):
+        import torch
+        import h5py
+        from PIL import Image
+
+        def _run(brick):
+            ids_sorted = np.sort(ids)   # sequential reads minimise S3 range fetches
+            out: dict[int, np.ndarray] = {}
+            for start in range(0, len(ids_sorted), batch_size):
+                chunk = ids_sorted[start:start + batch_size]
+                tensors = [preprocess(Image.fromarray(brick[int(i)])) for i in chunk]
+                batch = torch.stack(tensors).to(device)
+                with torch.no_grad():
+                    feats = model.encode_image(batch)
+                    feats = feats / feats.norm(dim=-1, keepdim=True)
+                feats = feats.cpu().numpy().astype(np.float32)
+                for i, vec in zip(chunk, feats):
+                    out[int(i)] = vec
+            return out
+
+        if str(source).startswith("s3://"):
+            import s3fs
+            fs = s3fs.S3FileSystem(anon=True)
+            with fs.open(str(source)[len("s3://"):], "rb") as fobj, \
+                    h5py.File(fobj, "r") as h:
+                return _run(h[dataset])
+        with h5py.File(source, "r") as h:
+            return _run(h[dataset])
 
     def validate_config(self, config: dict) -> list[str]:
         return []

--- a/fmriflow/modules/group_reporters/group_fsaverage_flatmap.py
+++ b/fmriflow/modules/group_reporters/group_fsaverage_flatmap.py
@@ -78,15 +78,21 @@ class GroupFsaverageFlatmapReporter:
                 "group_fsaverage_flatmap: cortex.Vertex failed: %s", exc)
             return {}
 
+        kwargs = dict(with_curvature=cfg.get("with_curvature", True), dpi=cfg.get("dpi", 100))
         try:
-            cortex.quickflat.make_png(
-                str(path), vert,
-                with_curvature=cfg.get("with_curvature", True),
-                dpi=cfg.get("dpi", 100),
-            )
+            cortex.quickflat.make_png(str(path), vert, **kwargs)
+        except RuntimeError as exc:
+            if 'inkscape' not in str(exc).lower():
+                logger.warning("group_fsaverage_flatmap: quickflat.make_png failed: %s", exc)
+                return {}
+            logger.warning("inkscape not available — rendering group flatmap without ROI overlays")
+            try:
+                cortex.quickflat.make_png(str(path), vert, with_rois=False, with_labels=False, **kwargs)
+            except Exception as exc2:
+                logger.warning("group_fsaverage_flatmap: fallback render failed: %s", exc2)
+                return {}
         except Exception as exc:
-            logger.warning(
-                "group_fsaverage_flatmap: quickflat.make_png failed: %s", exc)
+            logger.warning("group_fsaverage_flatmap: quickflat.make_png failed: %s", exc)
             return {}
         return {"group_fsaverage_flatmap": str(path)}
 

--- a/fmriflow/modules/preparers/default.py
+++ b/fmriflow/modules/preparers/default.py
@@ -46,12 +46,25 @@ class DefaultPreparer:
         trim_responses = prep_cfg.get('trim_responses', True)
         apply_delays = prep_cfg.get('apply_delays', True)
 
-        test_runs = split_cfg['test_runs']
         all_runs = sorted(
             set(responses.responses.keys())
             & set(self._get_feature_runs(features))
         )
-        train_runs = sorted(set(all_runs) - set(test_runs))
+
+        # Two split modes:
+        #  - run-level (default): whole runs are held out (split.test_runs)
+        #  - trial-level: rows within every run are split by a per-run boolean
+        #    mask named in split.test_trials and carried on
+        #    responses.metadata['trial_split'][name] (e.g. NSD shared1000).
+        test_trials = split_cfg.get('test_trials')
+        if test_trials:
+            test_mask = self._resolve_trial_mask(responses, test_trials, all_runs)
+            test_runs = all_runs
+            train_runs = all_runs
+        else:
+            test_mask = None
+            test_runs = split_cfg['test_runs']
+            train_runs = sorted(set(all_runs) - set(test_runs))
 
         # Trim and z-score responses
         trimmed_resp = {}
@@ -92,10 +105,22 @@ class DefaultPreparer:
             logger.info("Run '%s': %d TRs", run, nr)
 
         # Concatenate runs, split train/test
-        Y_train = np.vstack([trimmed_resp[r] for r in train_runs])
-        Y_test = np.vstack([trimmed_resp[r] for r in test_runs])
-        X_train = np.vstack([trimmed_feat[r] for r in train_runs])
-        X_test = np.vstack([trimmed_feat[r] for r in test_runs])
+        if test_mask is not None:
+            # Trial-level: every run contributes its test rows to the test set
+            # and its remaining rows to the train set.
+            trim_mask = test_mask
+            if trim_responses:
+                trim_mask = {r: self._trim(m, trim_start, trim_end)
+                             for r, m in test_mask.items()}
+            Y_train = np.vstack([trimmed_resp[r][~trim_mask[r]] for r in all_runs])
+            Y_test = np.vstack([trimmed_resp[r][trim_mask[r]] for r in all_runs])
+            X_train = np.vstack([trimmed_feat[r][~trim_mask[r]] for r in all_runs])
+            X_test = np.vstack([trimmed_feat[r][trim_mask[r]] for r in all_runs])
+        else:
+            Y_train = np.vstack([trimmed_resp[r] for r in train_runs])
+            Y_test = np.vstack([trimmed_resp[r] for r in test_runs])
+            X_train = np.vstack([trimmed_feat[r] for r in train_runs])
+            X_test = np.vstack([trimmed_feat[r] for r in test_runs])
 
         logger.info("X_train=%s Y_train=%s X_test=%s Y_test=%s",
                      X_train.shape, Y_train.shape, X_test.shape, Y_test.shape)
@@ -118,9 +143,32 @@ class DefaultPreparer:
 
     def validate_config(self, config: dict) -> list[str]:
         errors = []
-        if 'split' not in config or 'test_runs' not in config.get('split', {}):
-            errors.append("split.test_runs is required")
+        split_cfg = config.get('split', {})
+        if 'test_runs' not in split_cfg and 'test_trials' not in split_cfg:
+            errors.append("split requires either test_runs or test_trials")
         return errors
+
+    @staticmethod
+    def _resolve_trial_mask(responses, name, all_runs):
+        """Per-run boolean test mask named by split.test_trials.
+
+        Looked up on ``responses.metadata['trial_split'][name]``; the response
+        loader is responsible for populating it (e.g. NSD shared1000).
+        """
+        trial_split = responses.metadata.get('trial_split', {})
+        if name not in trial_split:
+            available = ", ".join(sorted(trial_split)) or "<none>"
+            raise ValueError(
+                f"split.test_trials='{name}' but responses carry no such trial "
+                f"mask. Available: {available}. The response loader must populate "
+                f"responses.metadata['trial_split'].")
+        masks = trial_split[name]
+        out = {}
+        for run in all_runs:
+            if run not in masks:
+                raise ValueError(f"trial mask '{name}' missing run '{run}'")
+            out[run] = np.asarray(masks[run], dtype=bool)
+        return out
 
     def _trim(self, arr, start, end):
         if end == 0:

--- a/fmriflow/modules/preparers/default.py
+++ b/fmriflow/modules/preparers/default.py
@@ -146,6 +146,9 @@ class DefaultPreparer:
         split_cfg = config.get('split', {})
         if 'test_runs' not in split_cfg and 'test_trials' not in split_cfg:
             errors.append("split requires either test_runs or test_trials")
+        elif 'test_runs' in split_cfg and 'test_trials' in split_cfg:
+            errors.append("split accepts either test_runs or test_trials, not both "
+                          "(trial-level splitting would silently take precedence)")
         return errors
 
     @staticmethod

--- a/fmriflow/modules/reporters/algonauts_fsaverage_flatmap.py
+++ b/fmriflow/modules/reporters/algonauts_fsaverage_flatmap.py
@@ -82,11 +82,16 @@ class AlgonautsFsaverageFlatmapReporter:
             cmap=opts.get('cmap', 'inferno'),
         )
         path = output_dir / opts.get('filename', 'prediction_accuracy_fsaverage_flatmap.png')
-        cortex.quickflat.make_png(
-            str(path), vx,
-            with_curvature=opts.get('with_curvature', True),
-            dpi=opts.get('dpi', 100),
-        )
+        kwargs = dict(with_curvature=opts.get('with_curvature', True), dpi=opts.get('dpi', 100))
+        try:
+            cortex.quickflat.make_png(str(path), vx, **kwargs)
+        except RuntimeError as e:
+            # pycortex's ROI/label overlays need inkscape; if it's absent, render
+            # the curvature + data layers without overlays rather than failing.
+            if 'inkscape' not in str(e).lower():
+                raise
+            logger.warning("inkscape not available — rendering flatmap without ROI overlays")
+            cortex.quickflat.make_png(str(path), vx, with_rois=False, with_labels=False, **kwargs)
         return {self.name: str(path)}
 
     def validate_config(self, config: dict) -> list[str]:

--- a/fmriflow/modules/reporters/algonauts_fsaverage_flatmap.py
+++ b/fmriflow/modules/reporters/algonauts_fsaverage_flatmap.py
@@ -1,0 +1,93 @@
+"""AlgonautsFsaverageFlatmapReporter — flatmap of Algonauts 2023 vertex scores.
+
+Algonauts 2023 responses already live on the fsaverage surface (in "challenge
+space" — the subset of vertices with valid data), so no volume→surface sampling
+is needed.  This reporter:
+
+1. splits the per-vertex scores back into left/right hemispheres,
+2. expands each hemisphere's challenge-space scores onto the full fsaverage
+   surface using the ``{hemi}.all-vertices_fsaverage_space`` masks carried on
+   ``ResponseData.metadata['fsaverage_masks']``,
+3. renders a ``cortex.Vertex`` quickflat on fsaverage.
+
+Requires the ``algonauts2023`` response loader (which supplies the masks and the
+per-hemisphere vertex counts).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from fmriflow.core.types import ModelResult, ResponseData
+from fmriflow.modules._decorators import reporter
+
+logger = logging.getLogger(__name__)
+
+
+@reporter("algonauts_fsaverage_flatmap")
+class AlgonautsFsaverageFlatmapReporter:
+    """Render Algonauts 2023 challenge-space vertex scores as an fsaverage flatmap."""
+
+    name = "algonauts_fsaverage_flatmap"
+    PARAM_SCHEMA = {
+        "cmap": {"type": "string", "default": "inferno", "description": "Matplotlib colormap"},
+        "vmin": {"type": "float", "default": 0.0, "description": "Color scale minimum"},
+        "vmax": {"type": "float", "default": 0.5, "description": "Color scale maximum"},
+        "with_curvature": {"type": "bool", "default": True, "description": "Overlay cortical curvature"},
+        "threshold": {"type": "float", "description": "Mask scores below this value"},
+        "dpi": {"type": "int", "default": 100, "min": 50, "description": "PNG resolution"},
+        "fsaverage_subject": {"type": "string", "default": "fsaverage", "description": "pycortex subject for the fsaverage surface"},
+        "filename": {"type": "string", "default": "prediction_accuracy_fsaverage_flatmap.png", "description": "Output PNG filename"},
+    }
+
+    def report(self, result: ModelResult, context, config: dict) -> dict[str, str]:
+        import cortex
+
+        resp_data = context.get('responses', ResponseData)
+        meta = resp_data.metadata
+        masks = meta.get('fsaverage_masks', {})
+        hemi_dims = meta.get('hemi_dims', {})
+        hemis = meta.get('hemispheres', ['lh', 'rh'])
+        if not masks or not hemi_dims:
+            logger.warning("algonauts_fsaverage_flatmap needs the algonauts2023 "
+                           "response loader (fsaverage_masks + hemi_dims); skipping.")
+            return {}
+
+        opts = config.get('reporting', {}).get(self.name, {})
+        output_dir = Path(config.get('reporting', {}).get('output_dir', './results'))
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        scores = np.asarray(result.scores, dtype=float)
+        threshold = opts.get('threshold', None)
+
+        # Split concatenated scores by hemisphere, expand each to full fsaverage.
+        verts, offset = [], 0
+        for h in hemis:
+            d = hemi_dims[h]
+            hemi_scores = scores[offset:offset + d]
+            offset += d
+            full = np.full(masks[h].shape[0], np.nan, dtype=float)
+            full[masks[h]] = hemi_scores
+            verts.append(full)
+        all_verts = np.concatenate(verts)   # lh then rh -> fsaverage
+        if threshold is not None:
+            all_verts[all_verts < threshold] = np.nan
+
+        vx = cortex.Vertex(
+            all_verts, opts.get('fsaverage_subject', 'fsaverage'),
+            vmin=opts.get('vmin', 0.0), vmax=opts.get('vmax', 0.5),
+            cmap=opts.get('cmap', 'inferno'),
+        )
+        path = output_dir / opts.get('filename', 'prediction_accuracy_fsaverage_flatmap.png')
+        cortex.quickflat.make_png(
+            str(path), vx,
+            with_curvature=opts.get('with_curvature', True),
+            dpi=opts.get('dpi', 100),
+        )
+        return {self.name: str(path)}
+
+    def validate_config(self, config: dict) -> list[str]:
+        return []

--- a/fmriflow/modules/reporters/algonauts_fsaverage_flatmap.py
+++ b/fmriflow/modules/reporters/algonauts_fsaverage_flatmap.py
@@ -63,6 +63,20 @@ class AlgonautsFsaverageFlatmapReporter:
         scores = np.asarray(result.scores, dtype=float)
         threshold = opts.get('threshold', None)
 
+        # The loader only carries masks for hemispheres whose mask file exists;
+        # bail clearly if any hemisphere or the score length is inconsistent
+        # rather than KeyError-ing or misrendering a truncated slice.
+        missing = [h for h in hemis if h not in masks or h not in hemi_dims]
+        if missing:
+            logger.warning("algonauts_fsaverage_flatmap: missing fsaverage_masks/"
+                           "hemi_dims for %s; skipping.", missing)
+            return {}
+        total = sum(hemi_dims[h] for h in hemis)
+        if scores.shape[0] != total:
+            logger.warning("algonauts_fsaverage_flatmap: scores length %d != "
+                           "sum(hemi_dims) %d; skipping.", scores.shape[0], total)
+            return {}
+
         # Split concatenated scores by hemisphere, expand each to full fsaverage.
         verts, offset = [], 0
         for h in hemis:

--- a/fmriflow/modules/reporters/nsd_fsaverage_flatmap.py
+++ b/fmriflow/modules/reporters/nsd_fsaverage_flatmap.py
@@ -80,11 +80,16 @@ class NsdFsaverageFlatmapReporter:
             cmap=opts.get('cmap', 'inferno'),
         )
         path = output_dir / opts.get('filename', 'prediction_accuracy_fsaverage_flatmap.png')
-        cortex.quickflat.make_png(
-            str(path), vx,
-            with_curvature=opts.get('with_curvature', True),
-            dpi=opts.get('dpi', 100),
-        )
+        kwargs = dict(with_curvature=opts.get('with_curvature', True), dpi=opts.get('dpi', 100))
+        try:
+            cortex.quickflat.make_png(str(path), vx, **kwargs)
+        except RuntimeError as e:
+            # pycortex's ROI/label overlays need inkscape; if it's absent, render
+            # the curvature + data layers without overlays rather than failing.
+            if 'inkscape' not in str(e).lower():
+                raise
+            logger.warning("inkscape not available — rendering flatmap without ROI overlays")
+            cortex.quickflat.make_png(str(path), vx, with_rois=False, with_labels=False, **kwargs)
         return {self.name: str(path)}
 
     @staticmethod

--- a/fmriflow/modules/reporters/nsd_fsaverage_flatmap.py
+++ b/fmriflow/modules/reporters/nsd_fsaverage_flatmap.py
@@ -1,0 +1,110 @@
+"""NsdFsaverageFlatmapReporter — flatmap of func-volume scores on fsaverage.
+
+NSD analyses run in the subject's 1.8 mm functional volume, but pycortex ships a
+flattened ``fsaverage`` surface, so no per-subject surface registration or
+flattening is needed to visualise results.  This reporter:
+
+1. expands the masked voxel scores back into the full func1pt8mm volume,
+2. samples them onto the subject's native white surface using NSD's
+   ``{hemi}.func1pt8-to-white.mgz`` voxel-coordinate maps,
+3. resamples native -> fsaverage with ``{hemi}.white-to-fsaverage.mgz``,
+4. renders a ``cortex.Vertex`` quickflat on fsaverage.
+
+The volume->surface convention (direct (i,j,k) axis order, 1-based coordinates)
+is validated in ``testing/nsd/verify_surface_mapping.py`` against NSD's official
+fsaverage nsdgeneral label (Dice ~0.85).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from fmriflow.core.mask_utils import has_real_mask, unmask_scores
+from fmriflow.core.types import ModelResult, ResponseData
+from fmriflow.modules._decorators import reporter
+
+logger = logging.getLogger(__name__)
+
+
+@reporter("nsd_fsaverage_flatmap")
+class NsdFsaverageFlatmapReporter:
+    """Render func1pt8mm voxel scores as an fsaverage flatmap."""
+
+    name = "nsd_fsaverage_flatmap"
+    PARAM_SCHEMA = {
+        "cmap": {"type": "string", "default": "inferno", "description": "Matplotlib colormap"},
+        "vmin": {"type": "float", "default": 0.0, "description": "Color scale minimum"},
+        "vmax": {"type": "float", "default": 0.5, "description": "Color scale maximum"},
+        "with_curvature": {"type": "bool", "default": True, "description": "Overlay cortical curvature"},
+        "threshold": {"type": "float", "description": "Mask scores below this value"},
+        "dpi": {"type": "int", "default": 100, "min": 50, "description": "PNG resolution"},
+        "fsaverage_subject": {"type": "string", "default": "fsaverage", "description": "pycortex subject for the fsaverage surface"},
+        "filename": {"type": "string", "default": "prediction_accuracy_fsaverage_flatmap.png", "description": "Output PNG filename"},
+    }
+
+    def report(self, result: ModelResult, context, config: dict) -> dict[str, str]:
+        import cortex
+
+        resp_data = context.get('responses', ResponseData)
+        if not has_real_mask(resp_data.mask):
+            logger.warning("nsd_fsaverage_flatmap needs the 3-D ROI mask on "
+                           "ResponseData (use the nsd response loader); skipping.")
+            return {}
+
+        resp_cfg = config.get('response', {})
+        raw_dir = Path(resp_cfg.get('raw_dir', '.'))
+        subject = resp_cfg.get('subject') or config.get('subject')
+        tf_dir = raw_dir / "nsddata" / "ppdata" / subject / "transforms"
+
+        opts = config.get('reporting', {}).get(self.name, {})
+        output_dir = Path(config.get('reporting', {}).get('output_dir', './results'))
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Expand masked scores to the full func1pt8mm volume.
+        full_vol = unmask_scores(result.scores.astype(float), resp_data.mask)
+        threshold = opts.get('threshold', None)
+
+        verts = np.concatenate([
+            self._volume_to_fsaverage(full_vol, resp_data.mask, tf_dir, h)
+            for h in ("lh", "rh")
+        ])
+        if threshold is not None:
+            verts[verts < threshold] = np.nan
+
+        vx = cortex.Vertex(
+            verts, opts.get('fsaverage_subject', 'fsaverage'),
+            vmin=opts.get('vmin', 0.0), vmax=opts.get('vmax', 0.5),
+            cmap=opts.get('cmap', 'inferno'),
+        )
+        path = output_dir / opts.get('filename', 'prediction_accuracy_fsaverage_flatmap.png')
+        cortex.quickflat.make_png(
+            str(path), vx,
+            with_curvature=opts.get('with_curvature', True),
+            dpi=opts.get('dpi', 100),
+        )
+        return {self.name: str(path)}
+
+    @staticmethod
+    def _volume_to_fsaverage(full_vol, mask_3d, tf_dir, hemi):
+        """Sample a func1pt8mm volume onto fsaverage vertices for one hemisphere."""
+        import nibabel as nib
+        from scipy.ndimage import map_coordinates
+
+        f2w = np.asarray(nib.load(tf_dir / f"{hemi}.func1pt8-to-white.mgz").dataobj)
+        w2f = np.asarray(nib.load(tf_dir / f"{hemi}.white-to-fsaverage.mgz").dataobj)
+        coords = f2w.reshape(-1, 3).T - 1.0   # (3, n_white), 1-based -> 0-based
+        idx = w2f.reshape(-1).astype(int) - 1  # 1-based native-white index
+
+        # Trilinear within the ROI; NaN outside so curvature shows through.
+        filled = np.nan_to_num(full_vol, nan=0.0)
+        vals = map_coordinates(filled, coords, order=1, mode="nearest")
+        inmask = map_coordinates(mask_3d.astype(float), coords, order=1,
+                                 mode="nearest") > 0.5
+        vals = np.where(inmask, vals, np.nan)
+        return vals[idx]
+
+    def validate_config(self, config: dict) -> list[str]:
+        return []

--- a/fmriflow/modules/response_loaders/algonauts2023.py
+++ b/fmriflow/modules/response_loaders/algonauts2023.py
@@ -71,12 +71,17 @@ class Algonauts2023ResponseLoader:
             arrays.append(arr)
             hemi_dims[h] = int(arr.shape[1])
             logger.info("  %s: %s vertices %d", subject, h, arr.shape[1])
-        resp = np.concatenate(arrays, axis=1)   # (n_images, sum n_vertices)
-        n_img = resp.shape[0]
+        # Check row (image) agreement *before* concatenating — np.concatenate on
+        # axis=1 would otherwise raise a less clear error first.
+        n_img = arrays[0].shape[0]
         if any(a.shape[0] != n_img for a in arrays):
-            raise ValueError("hemisphere fMRI arrays disagree on image count")
+            raise ValueError("hemisphere fMRI arrays disagree on image count: "
+                             f"{[a.shape[0] for a in arrays]}")
+        resp = np.concatenate(arrays, axis=1)   # (n_images, sum n_vertices)
 
         # Seeded validation holdout, carried for split.test_trials: val.
+        if not 0.0 <= val_fraction <= 1.0:
+            raise ValueError(f"val_fraction must be in [0, 1], got {val_fraction}")
         n_val = int(round(n_img * val_fraction))
         val_mask = np.zeros(n_img, dtype=bool)
         val_idx = np.random.default_rng(val_seed).permutation(n_img)[:n_val]

--- a/fmriflow/modules/response_loaders/algonauts2023.py
+++ b/fmriflow/modules/response_loaders/algonauts2023.py
@@ -1,0 +1,117 @@
+"""Algonauts2023ResponseLoader — fsaverage-surface fMRI for the Algonauts 2023 challenge.
+
+Loads the per-subject training fMRI (left/right hemisphere ``.npy`` arrays in
+fsaverage "challenge space"), concatenates the hemispheres into one 2-D
+``(n_images, n_vertices)`` matrix, and returns it as a single ``"train"``
+pseudo-run.  Because the array is 2-D, the prepare/model stages need no surface
+geometry; the fsaverage vertex masks are carried in ``metadata`` so a flatmap
+reporter can expand scores back onto the full fsaverage surface.
+
+Row order matches the sorted training-image order emitted by
+:mod:`fmriflow.modules.stimulus_loaders.algonauts2023`, so response row *i*
+aligns with feature row *i*.
+
+A held-out validation set is carried as a per-run boolean mask under
+``metadata['trial_split']['val']`` (a seeded random ``val_fraction`` of images),
+so a config can hold it out with ``split.test_trials: val`` — the challenge has
+no separate labelled test fMRI, so we validate on a slice of the training set.
+
+Expected on-disk layout (the challenge dev-kit tree under ``data_dir``)::
+
+    {data_dir}/{subject}/training_split/training_fmri/{lh,rh}_training_fmri.npy
+    {data_dir}/{subject}/roi_masks/{lh,rh}.all-vertices_fsaverage_space.npy
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from fmriflow.core.types import ResponseData
+from fmriflow.modules._decorators import response_loader
+
+logger = logging.getLogger(__name__)
+
+# Sentinel triggering the 2-D ingest path (no pycortex masking); the real
+# fsaverage vertex masks ride in metadata for the flatmap reporter.
+_NO_MASK = np.array([True])
+
+
+@response_loader("algonauts2023")
+class Algonauts2023ResponseLoader:
+    """Load Algonauts 2023 fsaverage-surface fMRI as a 2-D response matrix."""
+
+    name = "algonauts2023"
+
+    PARAM_SCHEMA = {
+        "data_dir": {"type": "path", "required": True, "description": "Root of the Algonauts 2023 dev-kit tree"},
+        "subject": {"type": "string", "description": "Subject id, e.g. subj01 (defaults to config.subject)"},
+        "hemispheres": {"type": "list[str]", "default": ["lh", "rh"], "description": "Hemispheres to load and concatenate"},
+        "val_fraction": {"type": "float", "default": 0.1, "description": "Fraction of training images held out as validation (split.test_trials: val)"},
+        "val_seed": {"type": "int", "default": 0, "description": "RNG seed for the validation split"},
+    }
+
+    def load(self, config: dict) -> ResponseData:
+        resp_cfg = config.get("response", {})
+        data_dir = Path(resp_cfg["data_dir"])
+        subject = resp_cfg.get("subject") or config.get("subject")
+        hemis = list(resp_cfg.get("hemispheres", ["lh", "rh"]))
+        val_fraction = float(resp_cfg.get("val_fraction", 0.1))
+        val_seed = int(resp_cfg.get("val_seed", 0))
+
+        subj_dir = data_dir / subject
+        fmri_dir = subj_dir / "training_split" / "training_fmri"
+        roi_dir = subj_dir / "roi_masks"
+
+        arrays, hemi_dims = [], {}
+        for h in hemis:
+            arr = np.load(fmri_dir / f"{h}_training_fmri.npy").astype(np.float32)
+            arrays.append(arr)
+            hemi_dims[h] = int(arr.shape[1])
+            logger.info("  %s: %s vertices %d", subject, h, arr.shape[1])
+        resp = np.concatenate(arrays, axis=1)   # (n_images, sum n_vertices)
+        n_img = resp.shape[0]
+        if any(a.shape[0] != n_img for a in arrays):
+            raise ValueError("hemisphere fMRI arrays disagree on image count")
+
+        # Seeded validation holdout, carried for split.test_trials: val.
+        n_val = int(round(n_img * val_fraction))
+        val_mask = np.zeros(n_img, dtype=bool)
+        val_idx = np.random.default_rng(val_seed).permutation(n_img)[:n_val]
+        val_mask[val_idx] = True
+
+        # fsaverage all-vertices masks (challenge-space -> full fsaverage) for flatmaps.
+        fsavg_masks = {}
+        for h in hemis:
+            p = roi_dir / f"{h}.all-vertices_fsaverage_space.npy"
+            if p.exists():
+                fsavg_masks[h] = np.load(p).astype(bool)
+
+        run = "train"
+        metadata = {
+            "dataset": "algonauts2023",
+            "subject": subject,
+            "hemispheres": hemis,
+            "hemi_dims": hemi_dims,
+            "fsaverage_masks": fsavg_masks,
+            "trial_split": {"val": {run: val_mask}},
+        }
+        logger.info("  %s: responses %s (val %d/%d)", subject, resp.shape, n_val, n_img)
+        return ResponseData(
+            responses={run: resp},
+            mask=_NO_MASK,
+            surface="fsaverage",
+            transform="",
+            metadata=metadata,
+        )
+
+    def validate_config(self, config: dict) -> list[str]:
+        errors = []
+        resp_cfg = config.get("response", {})
+        if "data_dir" not in resp_cfg:
+            errors.append("algonauts2023 loader requires response.data_dir")
+        elif not Path(resp_cfg["data_dir"]).is_dir():
+            errors.append(f"response.data_dir not found: {resp_cfg['data_dir']}")
+        return errors

--- a/fmriflow/modules/response_loaders/nsd.py
+++ b/fmriflow/modules/response_loaders/nsd.py
@@ -1,0 +1,169 @@
+"""NsdResponseLoader — single-trial betas for an image-viewing dataset.
+
+Loads per-session GLM betas (one pseudo-run per scan session), masks them to a
+cortical ROI, and scales the int16 betas to percent-signal-change.  Returns 2-D
+``(n_trials, n_voxels)`` arrays so the prepare/model stages need no surface
+geometry, while still carrying the **real 3-D ROI mask** plus the pycortex
+``surface``/``transform`` so flatmap reporters can rebuild the full volume.
+
+Trial order within a session follows ``responses.tsv`` sorted by ``(RUN, TRIAL)``,
+which matches the betas 4th axis, so row *t* of the returned array is trial *t*.
+
+Expected on-disk layout (mirrors the public dataset tree under ``raw_dir``)::
+
+    {raw_dir}/nsddata_betas/ppdata/{subject}/{space}/{betas_version}/betas_session{NN}.nii.gz
+    {raw_dir}/nsddata/ppdata/{subject}/{space}/roi/{roi}.nii.gz
+    {raw_dir}/nsddata/ppdata/{subject}/behav/responses.tsv
+    {raw_dir}/nsddata/experiments/nsd/nsd_stim_info_merged.csv   (optional; shared1000 split)
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from fmriflow.core.types import ResponseData
+from fmriflow.modules._decorators import response_loader
+
+logger = logging.getLogger(__name__)
+
+
+@response_loader("nsd")
+class NsdResponseLoader:
+    """Load NSD-style single-trial betas as pre-masked per-session responses."""
+
+    name = "nsd"
+
+    PARAM_SCHEMA = {
+        "raw_dir": {"type": "path", "required": True, "description": "Root of the downloaded dataset tree"},
+        "subject": {"type": "string", "description": "Subject id, e.g. subj01 (defaults to config.subject)"},
+        "space": {"type": "string", "default": "func1pt8mm", "description": "Functional space directory"},
+        "betas_version": {"type": "string", "default": "betas_fithrf_GLMdenoise_RR", "description": "Betas GLM version directory"},
+        "roi": {"type": "string", "default": "nsdgeneral", "description": "ROI mask name (under roi/), > 0 selects voxels"},
+        "sessions": {"type": "list[int]", "required": True, "description": "Session numbers to load (one pseudo-run each)"},
+        "scale": {"type": "float", "default": 300.0, "description": "Divisor turning int16 betas into percent signal change"},
+    }
+
+    def load(self, config: dict) -> ResponseData:
+        resp_cfg = config.get("response", {})
+        sub_cfg = config.get("subject_config", {})
+
+        raw_dir = Path(resp_cfg["raw_dir"])
+        subject = resp_cfg.get("subject") or config.get("subject")
+        space = resp_cfg.get("space", "func1pt8mm")
+        betas_version = resp_cfg.get("betas_version", "betas_fithrf_GLMdenoise_RR")
+        roi = resp_cfg.get("roi", "nsdgeneral")
+        sessions = list(resp_cfg["sessions"])
+        scale = float(resp_cfg.get("scale", 300.0))
+
+        # pycortex names are carried through for flatmap reporters; the loader
+        # itself does not need them (it masks with the on-disk ROI).
+        surface = sub_cfg.get("surface", "unknown")
+        transform = sub_cfg.get("transform", "unknown")
+
+        betas_dir = raw_dir / "nsddata_betas" / "ppdata" / subject / space / betas_version
+        mask_path = raw_dir / "nsddata" / "ppdata" / subject / space / "roi" / f"{roi}.nii.gz"
+        behav_path = raw_dir / "nsddata" / "ppdata" / subject / "behav" / "responses.tsv"
+
+        mask_3d, flat_mask = self._load_mask(mask_path)
+        logger.info("NSD %s mask '%s': %d voxels", subject, roi, int(flat_mask.sum()))
+
+        ses_ids = self._trial_image_ids(behav_path, sessions)
+        shared = self._shared1000_map(raw_dir, ses_ids)
+
+        responses: dict[str, np.ndarray] = {}
+        trial_image_ids: dict[str, np.ndarray] = {}
+        shared_mask: dict[str, np.ndarray] = {}
+        for ses in sessions:
+            run = f"ses{ses:02d}"
+            resp = self._load_betas_masked(betas_dir / f"betas_session{ses:02d}.nii.gz",
+                                           flat_mask, scale)
+            ids = ses_ids[ses]
+            if resp.shape[0] != ids.shape[0]:
+                raise ValueError(
+                    f"{run}: betas have {resp.shape[0]} trials but responses.tsv "
+                    f"lists {ids.shape[0]} — trial/beta ordering mismatch.")
+            responses[run] = resp
+            trial_image_ids[run] = ids
+            if shared is not None:
+                shared_mask[run] = shared[ses]
+            logger.info("  %s: responses %s", run, resp.shape)
+
+        metadata: dict = {
+            "dataset": "nsd",
+            "subject": subject,
+            "space": space,
+            "trial_image_ids": trial_image_ids,
+        }
+        if shared_mask:
+            # Per-run boolean test masks consumed by the trial-level split.
+            metadata["trial_split"] = {"shared1000": shared_mask}
+
+        return ResponseData(
+            responses=responses,
+            mask=mask_3d,
+            surface=surface,
+            transform=transform,
+            metadata=metadata,
+        )
+
+    # ── private helpers ─────────────────────────────────────────────────
+
+    @staticmethod
+    def _load_mask(mask_path: Path) -> tuple[np.ndarray, np.ndarray]:
+        import nibabel as nib
+
+        mask_3d = nib.load(mask_path).get_fdata() > 0
+        return mask_3d, mask_3d.reshape(-1)
+
+    @staticmethod
+    def _load_betas_masked(betas_path: Path, flat_mask: np.ndarray,
+                           scale: float) -> np.ndarray:
+        """(n_trials, n_voxels) float32 percent-signal-change."""
+        import nibabel as nib
+
+        img = nib.load(betas_path)
+        data = np.asarray(img.dataobj)              # (X, Y, Z, T) int16
+        data = data.reshape(-1, data.shape[-1])     # (n_vox_all, T)
+        return (data[flat_mask, :].T.astype(np.float32)) / scale
+
+    @staticmethod
+    def _trial_image_ids(behav_path: Path, sessions: list[int]) -> dict[int, np.ndarray]:
+        """Per session: ordered 73KID (1-indexed) in (RUN, TRIAL) order."""
+        import pandas as pd
+
+        df = pd.read_csv(behav_path, sep="\t")
+        out = {}
+        for ses in sessions:
+            sub = df[df["SESSION"] == ses].sort_values(["RUN", "TRIAL"])
+            out[ses] = sub["73KID"].to_numpy().astype(int)
+        return out
+
+    @staticmethod
+    def _shared1000_map(raw_dir: Path,
+                        ses_ids: dict[int, np.ndarray]) -> dict[int, np.ndarray] | None:
+        """Per session: boolean array marking shared1000 trials, or None if absent."""
+        import pandas as pd
+
+        info_path = raw_dir / "nsddata" / "experiments" / "nsd" / "nsd_stim_info_merged.csv"
+        if not info_path.exists():
+            logger.info("nsd_stim_info_merged.csv not found — shared1000 split unavailable")
+            return None
+
+        info = pd.read_csv(info_path, usecols=["nsdId", "shared1000"])
+        # nsdId is the 0-based 73k index; 73KID is 1-based -> shared[73KID - 1].
+        shared_by_nsdid = info.sort_values("nsdId")["shared1000"].to_numpy().astype(bool)
+        return {ses: shared_by_nsdid[ids - 1] for ses, ids in ses_ids.items()}
+
+    def validate_config(self, config: dict) -> list[str]:
+        errors = []
+        resp_cfg = config.get("response", {})
+        if "raw_dir" not in resp_cfg:
+            errors.append("nsd loader requires response.raw_dir")
+        elif not Path(resp_cfg["raw_dir"]).is_dir():
+            errors.append(f"response.raw_dir not found: {resp_cfg['raw_dir']}")
+        if "sessions" not in resp_cfg:
+            errors.append("nsd loader requires response.sessions")
+        return errors

--- a/fmriflow/modules/stimulus_loaders/algonauts2023.py
+++ b/fmriflow/modules/stimulus_loaders/algonauts2023.py
@@ -1,0 +1,73 @@
+"""Algonauts2023StimulusLoader — training images for the Algonauts 2023 challenge.
+
+Emits one :class:`ImageSeqStim` (the ``"train"`` pseudo-run) pointing at the
+subject's training-image directory.  Images are *not* decoded here — the
+``alexnet`` (or ``clip``) feature extractor reads them on demand.
+
+Image order is the **sorted filename order**, which matches the row order of the
+fMRI arrays read by :mod:`fmriflow.modules.response_loaders.algonauts2023`
+(Algonauts names images ``train-0001_nsd-XXXXX.png`` … so they sort into
+presentation order).  Feature row *i* therefore aligns with response row *i*.
+
+Expected on-disk layout (the challenge dev-kit tree under ``data_dir``)::
+
+    {data_dir}/{subject}/training_split/training_images/*.png
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from fmriflow.core.types import ImageSeqStim, StimRun, StimulusData
+from fmriflow.modules._decorators import stimulus_loader
+
+logger = logging.getLogger(__name__)
+
+
+@stimulus_loader("algonauts2023")
+class Algonauts2023StimulusLoader:
+    """Emit one ImageSeqStim over the subject's training images."""
+
+    name = "algonauts2023"
+
+    PARAM_SCHEMA = {
+        "data_dir": {"type": "path", "required": True, "description": "Root of the Algonauts 2023 dev-kit tree"},
+        "subject": {"type": "string", "description": "Subject id, e.g. subj01 (defaults to config.subject)"},
+    }
+
+    def load(self, config: dict) -> StimulusData:
+        stim_cfg = config.get("stimulus", {})
+        data_dir = Path(stim_cfg["data_dir"])
+        subject = stim_cfg.get("subject") or config.get("subject")
+
+        img_dir = data_dir / subject / "training_split" / "training_images"
+        files = sorted(img_dir.glob("*.png")) or sorted(img_dir.glob("*.jpg"))
+        if not files:
+            raise FileNotFoundError(f"no training images under {img_dir}")
+
+        run = "train"
+        runs = {
+            run: StimRun(
+                name=run,
+                stimulus=ImageSeqStim(
+                    source=str(img_dir),
+                    image_ids=np.arange(len(files)),   # sorted-file order
+                    source_kind="image_dir",
+                ),
+                modality="visual",
+            )
+        }
+        logger.info("algonauts2023 %s: %d training images", subject, len(files))
+        return StimulusData(runs=runs, metadata={"dataset": "algonauts2023", "subject": subject})
+
+    def validate_config(self, config: dict) -> list[str]:
+        errors = []
+        stim_cfg = config.get("stimulus", {})
+        if "data_dir" not in stim_cfg:
+            errors.append("algonauts2023 stimulus loader requires stimulus.data_dir")
+        elif not Path(stim_cfg["data_dir"]).is_dir():
+            errors.append(f"stimulus.data_dir not found: {stim_cfg['data_dir']}")
+        return errors

--- a/fmriflow/modules/stimulus_loaders/nsd.py
+++ b/fmriflow/modules/stimulus_loaders/nsd.py
@@ -1,0 +1,94 @@
+"""NsdStimulusLoader — per-trial image references for an image-viewing dataset.
+
+Reads the behavioural ``responses.tsv`` to recover, for each scan session, the
+ordered sequence of images shown (one per trial), and emits an
+:class:`ImageSeqStim` per session pointing at the shared image store.  Images
+are *not* decoded here — the ``clip`` feature extractor reads them on demand.
+
+Trial order matches :mod:`fmriflow.modules.response_loaders.nsd` (sorted by
+``(RUN, TRIAL)`` within a session), so feature row *t* aligns with response
+row *t*.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from fmriflow.core.types import ImageSeqStim, StimRun, StimulusData
+from fmriflow.modules._decorators import stimulus_loader
+
+logger = logging.getLogger(__name__)
+
+# Public dataset stimuli file (read remotely if no local copy is given).
+_DEFAULT_IMAGES = (
+    "s3://natural-scenes-dataset/nsddata_stimuli/stimuli/nsd/nsd_stimuli.hdf5"
+)
+
+
+@stimulus_loader("nsd")
+class NsdStimulusLoader:
+    """Emit one ImageSeqStim per session from the behavioural design."""
+
+    name = "nsd"
+
+    PARAM_SCHEMA = {
+        "raw_dir": {"type": "path", "required": True, "description": "Root of the downloaded dataset tree"},
+        "subject": {"type": "string", "description": "Subject id, e.g. subj01 (defaults to config.subject)"},
+        "sessions": {"type": "list[int]", "required": True, "description": "Session numbers (one run each)"},
+        "images": {"type": "string", "default": _DEFAULT_IMAGES, "description": "HDF5 image store (local path or s3:// URL)"},
+        "dataset": {"type": "string", "default": "imgBrick", "description": "Dataset name inside the HDF5 image store"},
+    }
+
+    def load(self, config: dict) -> StimulusData:
+        stim_cfg = config.get("stimulus", {})
+        raw_dir = Path(stim_cfg["raw_dir"])
+        subject = stim_cfg.get("subject") or config.get("subject")
+        sessions = list(stim_cfg["sessions"])
+        images = stim_cfg.get("images", _DEFAULT_IMAGES)
+        dataset = stim_cfg.get("dataset", "imgBrick")
+
+        behav_path = raw_dir / "nsddata" / "ppdata" / subject / "behav" / "responses.tsv"
+        ses_ids = self._trial_image_ids(behav_path, sessions)
+
+        runs: dict[str, StimRun] = {}
+        for ses in sessions:
+            run = f"ses{ses:02d}"
+            ids_1based = ses_ids[ses]
+            runs[run] = StimRun(
+                name=run,
+                stimulus=ImageSeqStim(
+                    source=images,
+                    image_ids=ids_1based - 1,   # 73KID is 1-based; store 0-based
+                    source_kind="hdf5",
+                    dataset=dataset,
+                ),
+                modality="visual",
+            )
+            logger.info("  %s: %d images", run, ids_1based.shape[0])
+
+        return StimulusData(runs=runs, metadata={"dataset": "nsd", "subject": subject})
+
+    @staticmethod
+    def _trial_image_ids(behav_path: Path, sessions: list[int]) -> dict[int, np.ndarray]:
+        import pandas as pd
+
+        df = pd.read_csv(behav_path, sep="\t")
+        out = {}
+        for ses in sessions:
+            sub = df[df["SESSION"] == ses].sort_values(["RUN", "TRIAL"])
+            out[ses] = sub["73KID"].to_numpy().astype(int)
+        return out
+
+    def validate_config(self, config: dict) -> list[str]:
+        errors = []
+        stim_cfg = config.get("stimulus", {})
+        if "raw_dir" not in stim_cfg:
+            errors.append("nsd stimulus loader requires stimulus.raw_dir")
+        elif not Path(stim_cfg["raw_dir"]).is_dir():
+            errors.append(f"stimulus.raw_dir not found: {stim_cfg['raw_dir']}")
+        if "sessions" not in stim_cfg:
+            errors.append("nsd stimulus loader requires stimulus.sessions")
+        return errors

--- a/tests/test_modules/test_preparers.py
+++ b/tests/test_modules/test_preparers.py
@@ -135,3 +135,41 @@ class TestDefaultPreparer:
         prep = DefaultPreparer()
         with pytest.raises(ValueError, match="Row mismatch in run 'story1'"):
             prep.prepare(responses, features, prep_config)
+
+    def test_trial_level_split(self, prep_features):
+        """split.test_trials holds out rows *within* every run via a per-run mask."""
+        n_held = 4
+        rng = np.random.RandomState(0)
+        masks = {name: np.zeros(N_TRS, dtype=bool) for name in RUN_NAMES}
+        for m in masks.values():
+            m[:n_held] = True  # first n_held TRs of each run are the test set
+        responses = ResponseData(
+            responses={
+                name: rng.randn(N_TRS, N_VOXELS).astype(np.float32)
+                for name in RUN_NAMES
+            },
+            mask=np.ones(N_VOXELS, dtype=bool),
+            surface="s",
+            transform="t",
+            metadata={"trial_split": {"heldout": masks}},
+        )
+        cfg = {
+            "split": {"test_trials": "heldout"},
+            "preparation": {"trim_start": 0, "trim_end": 0, "delays": [1], "zscore": False},
+        }
+        result = DefaultPreparer().prepare(responses, prep_features, cfg)
+        n_runs = len(RUN_NAMES)
+        # every run contributes its masked rows to test, the rest to train
+        assert result.Y_test.shape[0] == n_runs * n_held
+        assert result.Y_train.shape[0] == n_runs * (N_TRS - n_held)
+        assert result.Y_test.shape[1] == N_VOXELS
+        # trial-level: all runs appear in both train and test run lists
+        assert set(result.train_runs) == set(RUN_NAMES)
+        assert set(result.test_runs) == set(RUN_NAMES)
+
+    def test_validate_config_rejects_both_split_modes(self):
+        """test_runs and test_trials are mutually exclusive."""
+        prep = DefaultPreparer()
+        errors = prep.validate_config(
+            {"split": {"test_runs": ["story3"], "test_trials": "heldout"}})
+        assert any("not both" in e for e in errors)


### PR DESCRIPTION
## Summary
First-class fMRIflow modules for two public image-viewing encoding datasets — NSD and the Algonauts 2023 challenge — following the existing plugin patterns (stimulus/response loaders, feature extractors, reporters, analyzer).

## What's included
**NSD image-viewing dataset modules** (`6b53b48`)
- Stimulus + response loaders for the NSD single-trial image-viewing paradigm.

**Algonauts 2023 encoding modules** (`88624dd`)
- `stimulus_loaders/algonauts2023` — per-image stimulus sequences from an image directory.
- `response_loaders/algonauts2023` — LH/RH fsaverage challenge-space vertex responses with a seeded validation split.
- `feature_extractors/visual` — `alexnet` (torchvision, layer + optional PCA) and generic `timm` backbone pooled-embedding extractors.
- `reporters/algonauts_fsaverage_flatmap` — challenge-space vertex scores rendered on an fsaverage flatmap.
- `analyzers/algonauts_to_fsaverage` — group-mean accuracy + group-average fsaverage map across subjects.

**Robustness fix** (`1e54add`)
- fsaverage flatmap reporters fall back to no-ROI/no-label rendering when inkscape is unavailable, instead of failing.

## Docs
`docs/reference/modules.md` updated; `mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP6Tp5aFJxp4ZCvwUPnwHy
